### PR TITLE
Improvements in Kubernetes and Maya setup process for slow networks. Fix for issue #76.

### DIFF
--- a/k8s/demo/Vagrantfile
+++ b/k8s/demo/Vagrantfile
@@ -52,22 +52,14 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.9.1"
 
 #Local Variables
-machine_ip_address = %Q(ifconfig | grep -oP "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | sort | tail -n 1 | head -n 1)
+machine_ip_address = %Q(ifconfig | grep -oP \
+            "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+            | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+            | sort | tail -n 1 | head -n 1)
 master_ip_address = ""
 host_ip_address = ""
 get_token = ""
 token = ""
-
-
-# Generic installer script common for server(s) & client(s)
-$installerscripts = <<SCRIPT
-#!/bin/bash
-#Copy setup files - Needed for vagrant-triggers plugin.
-mkdir -p /home/ubuntu/demo/installer/scripts
-cd /vagrant/
-cp -u scripts/setup*.sh /home/ubuntu/demo/installer/scripts 2>/dev/null || :
-
-SCRIPT
 
 required_plugins = %w(vagrant-cachier vagrant-triggers)
 
@@ -82,15 +74,20 @@ end
 
 
 def configureVM(vmCfg, hostname, cpus, mem)
-
-  vmCfg.vm.box = "ubuntu/xenial64"
-  
-  #Default timeout is 300 sec for boot. 
-  #Uncomment the following line and set the desired timeout value. 
-  #vmCfg.vm.boot_timeout = 300
+ 
+  # Default timeout is 300 sec for boot. 
+  # Uncomment the following line and set the desired timeout value. 
+  # vmCfg.vm.boot_timeout = 300
 	
   vmCfg.vm.hostname = hostname
   vmCfg.vm.network "private_network", type: "dhcp"
+
+  # Needed for ubuntu/xenial64 packaged boxes
+  # The default user is ubuntu for those boxes
+  vmCfg.ssh.username = "ubuntu"
+  vmCfg.vm.provision "shell", inline: <<-SHELL
+      echo "ubuntu:ubuntu" | sudo chpasswd
+  SHELL
 
   
   #Adding Vagrant-cachier
@@ -108,6 +105,7 @@ def configureVM(vmCfg, hostname, cpus, mem)
     vb.memory = mem
     vb.cpus = cpus
     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "ubuntu-xenial-16.04-cloudimg-console.log")]
   end  
   
   return vmCfg
@@ -122,12 +120,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
 
     #Check for invalid deployment modes and default to DEDICATED MODE.  
-    if ((deploy_Mode.to_i < DEPLOY_MODE_NONE.to_i) || (deploy_Mode.to_i > DEPLOY_MODE_HC.to_i))
+    if ((deploy_Mode.to_i < DEPLOY_MODE_NONE.to_i) || \
+      (deploy_Mode.to_i > DEPLOY_MODE_HC.to_i))
         puts "Invalid value set for OPENEBS_DEPLOY_MODE"
         puts "Usage: OPENEBS_DEPLOY_MODE=0 for NONE"
         puts "Usage: OPENEBS_DEPLOY_MODE=1 for DEDICATED"
         puts "Usage: OPENEBS_DEPLOY_MODE=2 for HYPERCONVERGED"
-        puts "Defaulting to DEDICATED MODE. Do you want to continue?(y/n):"
+        puts "Defaulting to DEDICATED MODE..."
+        puts "Do you want to continue?(y/n):"
         input = STDIN.gets.chomp
         while 1 do
            if(input == "n")
@@ -148,15 +148,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cpus = KM_CPUS
       mem = KM_MEM            
       config.vm.define hostname do |vmCfg|
+        vmCfg.vm.box = "openebs/k8s-1.5.5"
         vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
         # Run in dedicated deployment mode or hyperconverged mode
-        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
+        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+          (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
           
-          # Copy scripts to the demo folder.
-          vmCfg.vm.provision :shell, inline: $installerscripts, privileged: false
           # Install Kubernetes Master.
-          vmCfg.vm.provision :shell, path: "scripts/setup_k8s_master.sh", privileged: true          
+          vmCfg.vm.provision :shell, 
+          inline: "/bin/bash /home/ubuntu/demo/k8s/scripts/configure_k8s_master.sh", 
+          privileged: true          
         end
       end           
     end
@@ -167,31 +169,59 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cpus = KH_CPUS
       mem = KH_MEM            
       config.vm.define hostname do |vmCfg|
+        vmCfg.vm.box = "openebs/k8s-1.5.5"
         vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
         # Run in dedicated deployment mode or hyperconverged mode
-        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
+        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+          (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
 
-          # Copy scripts to the demo folder.
-          vmCfg.vm.provision :shell, inline: $installerscripts, privileged: false
-          
-          # We want to run this only when the VM is first provisioned and get the Master IP to join the cluster
-          vmCfg.vm.provision :trigger, :force => true, :stdout => true, :stderr => true do |trigger|
+          # This runs only when the VM is first provisioned.
+          # Get the Master IP to join the cluster.
+          vmCfg.vm.provision :trigger, 
+          :force => true, 
+          :stdout => true, 
+          :stderr => true do |trigger|
             trigger.fire do
               info"Getting the Master IP to join the cluster..."
               master_hostname = "kubemaster-01"
-              get_ip_address = %Q(vagrant ssh #{master_hostname}  -c 'ifconfig | grep -oP "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | sort | tail -n 1 | head -n 1')            
+              
+              get_ip_address = %Q(vagrant ssh \
+              #{master_hostname} \
+              -c 'ifconfig | grep -oP \
+              "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+              | grep -oP \"\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+              | sort | tail -n 1 | head -n 1')
+              
               master_ip_address = `#{get_ip_address}`            
               if master_ip_address == ""            
-                  info"The Kubernetes Master is down, bring it up and manually run: setup_k8s_host.sh script on Kubernetes Minion."
+                  info"The Kubernetes Master is down, \
+                  bring it up and manually run: \
+                  configure_k8s_host.sh script on Kubernetes Minion."
               else                           
-                  get_token = %Q(vagrant ssh #{master_hostname} -c 'kubectl -n kube-system get secret clusterinfo -o yaml | grep token-map | cut -d ":" -f2 | cut -d " " -f2 | base64 -d | sed "s|{||g;s|}||g" | sed "s|:|.|g" | xargs echo')
+                  get_token = %Q(vagrant ssh \
+                  #{master_hostname} -c \
+                  'kubectl -n kube-system get secret clusterinfo \
+                  -o yaml | grep token-map | cut -d ":" -f2 \
+                  | cut -d " " -f2 | base64 -d \
+                  | sed "s|{||g;s|}||g" \
+                  | sed "s|:|.|g" | xargs echo')
+                  
                   token = `#{get_token}`                  
                   
                   if token != ""
-                    get_cluster_ip = %Q(vagrant ssh #{master_hostname} -c 'kubectl get svc -o yaml | grep clusterIP | cut -d ":" -f2 | cut -d " " -f2')
-                    cluster_ip = `#{get_cluster_ip}`                    
-                    @machine.communicate.sudo("bash /home/ubuntu/demo/installer/scripts/setup_k8s_host.sh --masterip=#{master_ip_address.strip} --token=#{token.strip} --clusterip=#{cluster_ip.strip}")
+                    get_cluster_ip = %Q(vagrant ssh \
+                    #{master_hostname} \
+                    -c 'kubectl get svc -o yaml | grep clusterIP \
+                    | cut -d ":" -f2 | cut -d " " -f2')
+
+                    cluster_ip = `#{get_cluster_ip}`
+
+                    @machine.communicate.sudo("bash \
+                    /home/ubuntu/demo/k8s/scripts/configure_k8s_host.sh \
+                    --masterip=#{master_ip_address.strip} \
+                    --token=#{token.strip} \
+                    --clusterip=#{cluster_ip.strip}")
                   else
                     info"Invalid Token. Check your Kubernetes setup."
                   end
@@ -208,24 +238,47 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cpus = MM_CPUS
       mem = MM_MEM
 
-      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))     
+      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+        (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))     
         config.vm.define hostname do |vmCfg|
+          vmCfg.vm.box = "openebs/openebs-0.2"
           vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
           # Run in dedicated deployment mode
           if deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i
 
-            # Copy scripts to the demo folder.
-            vmCfg.vm.provision :shell, inline: $installerscripts, privileged: false
             # Install OpenEBS Maya Master
-            vmCfg.vm.provision :shell, path: "scripts/setup_omm.sh", :args => "--releasetag=#{MAYA_RELEASE_TAG}", privileged: true
+            if MAYA_RELEASE_TAG == ""
+              vmCfg.vm.provision :shell, 
+              inline: "/bin/bash /home/ubuntu/demo/maya/scripts/configure_omm.sh",                
+              privileged: true              
+            else
+              vmCfg.vm.provision :shell, 
+              inline: "/bin/bash /home/ubuntu/demo/maya/scripts/configure_omm.sh", 
+              :args => "--releasetag=#{MAYA_RELEASE_TAG}", 
+              privileged: true              
+            end
             
-            vmCfg.vm.provision :trigger, :force => true, :stdout => true, :stderr => true do |trigger|
+            vmCfg.vm.provision :trigger, 
+            :force => true, 
+            :stdout => true, 
+            :stderr => true do |trigger|
               trigger.fire do
-                get_ip_address = %Q(vagrant ssh #{hostname}  -c 'ifconfig | grep -oP "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | sort | tail -n 1 | head -n 1')      
-                host_ip_address = `#{get_ip_address}`                
-                @machine.communicate.sudo("echo 'export NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> /home/ubuntu/.profile") 
-		@machine.communicate.sudo("echo 'export MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> /home/ubuntu/.profile")
+
+                get_ip_address = %Q(vagrant ssh \
+                #{hostname}  -c 'ifconfig | grep -oP \
+                "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                | sort | tail -n 1 | head -n 1')
+
+                host_ip_address = `#{get_ip_address}`
+
+                @machine.communicate.sudo("echo 'export \
+                NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
+                /home/ubuntu/.profile") 
+		            @machine.communicate.sudo("echo 'export \
+                MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
+                /home/ubuntu/.profile")
               end
             end            
           end      
@@ -239,31 +292,62 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       cpus = MH_CPUS
       mem = MH_MEM
 
-      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))      
+      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+        (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))
         config.vm.define hostname do |vmCfg|
+          vmCfg.vm.box = "openebs/openebs-0.2"
           vmCfg = configureVM(vmCfg, hostname, cpus, mem)
           
           # Run in dedicated deployment mode
           if deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i
 
-            #Copy scripts to the demo folder.
-            vmCfg.vm.provision :shell, inline: $installerscripts, privileged: false
-
-            #We want to run this only when the VM is first provisioned and get the Master IP to join the cluster
-            vmCfg.vm.provision :trigger, :force => true, :stdout => true, :stderr => true do |trigger|
+            #Get the Master IP to join the cluster.
+            vmCfg.vm.provision :trigger, 
+            :force => true, 
+            :stdout => true, 
+            :stderr => true do |trigger|
               trigger.fire do
                 info"Getting the Master IP to join the cluster..."
-                master_hostname = "omm-01"            
-                get_ip_address = %Q(vagrant ssh #{master_hostname}  -c 'ifconfig | grep -oP "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | sort | tail -n 1 | head -n 1')            
-                master_ip_address = `#{get_ip_address}`            
+                master_hostname = "omm-01"
+
+                get_ip_address = %Q(vagrant ssh \
+                #{master_hostname}  -c 'ifconfig | grep -oP \
+                "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                | sort | tail -n 1 | head -n 1')
+
+                master_ip_address = `#{get_ip_address}`
+
                 if master_ip_address == ""
-                  info"The OpenEBS Maya Master is down, bring it up and manually run: setup_osh.sh script on OpenEBS Storage Host."                              
+                  info"The OpenEBS Maya Master is down, \
+                  bring it up and manually run: \
+                  configure_osh.sh script on OpenEBS Storage Host."
                 else
-                  get_ip_address = %Q(vagrant ssh #{hostname}  -c 'ifconfig | grep -oP "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" | sort | tail -n 1 | head -n 1')      
-                  host_ip_address = `#{get_ip_address}`                                                          
-                  @machine.communicate.sudo("bash /home/ubuntu/demo/installer/scripts/setup_osh.sh -i #{master_ip_address.strip} -r #{MAYA_RELEASE_TAG}")
-                  @machine.communicate.sudo("echo 'export NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> /home/ubuntu/.profile")
-		  @machine.communicate.sudo("echo 'export MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> /home/ubuntu/.profile")
+                  get_ip_address = %Q(vagrant ssh \
+                  #{hostname}  -c 'ifconfig | grep -oP \
+                  "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                  | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+                  | sort | tail -n 1 | head -n 1')
+
+                  host_ip_address = `#{get_ip_address}`
+
+                  if MAYA_RELEASE_TAG == ""
+                  @machine.communicate.sudo("bash \
+                  /home/ubuntu/demo/maya/scripts/configure_osh.sh \
+                  --masterip=#{master_ip_address.strip}")                  
+                 else
+                  @machine.communicate.sudo("bash \
+                  /home/ubuntu/demo/maya/scripts/configure_osh.sh \
+                  --masterip=#{master_ip_address.strip} \
+                  --releasetag=#{MAYA_RELEASE_TAG}")
+                  end
+
+                  @machine.communicate.sudo("echo 'export \
+                  NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
+                  /home/ubuntu/.profile")
+		              @machine.communicate.sudo("echo 'export \
+                  MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
+                  /home/ubuntu/.profile")
                 end  
               end
             end


### PR DESCRIPTION
Improvements in Kubernetes and Maya setup process for slow networks.

Code Changes:
----------------
1. Scripts have to been created to generate vagrant boxes. These vagrant boxes will now come installed with prerequisites for Kubernetes and OpenEBS.
2. The Vagrantfile has been modified to use the generated OpenEBS boxes for setting up Kubernetes and OpenEBS.
3. Refactored the code to adhere to good coding standards.

Tested On:
-----------
Developer Laptop - (kubemaster-01, kubeminion-01, omm-01 and osh-01)
OpenEBS Test Machine - Multi VM. - (kubemaster-01, kubeminion-01, omm-01, osh-01 and osh-02)

Details of code fix:
--------------------
The code has been optimized such that the Vagrantfile and scripts work without glitches on slow networks. Thereby providing a smooth experience to the end user.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>