### PR TITLE
Scripts for creating vagrant boxes. Fix for the issue #76.

### DIFF
--- a/k8s/lib/vagrant/Vagrantfile
+++ b/k8s/lib/vagrant/Vagrantfile
@@ -1,0 +1,140 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+
+BOX_MODE_OPENEBS    = 1
+BOX_MODE_KUBERNETES = 2
+
+box_Mode=ENV['OPENEBS_BUILD_BOX'] || 1
+
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  if ((box_Mode.to_i < BOX_MODE_OPENEBS.to_i) || \
+      (box_Mode.to_i > BOX_MODE_KUBERNETES.to_i))
+        puts "Invalid value set for OPENEBS_BUILD_BOX."
+        puts "Usage: OPENEBS_BUILD_BOX=1 for OpenEBS."
+        puts "Usage: OPENEBS_BUILD_BOX=2 for Kubernetes."
+        puts "Defaulting to OpenEBS..." 
+        puts "Do you want to continue?(y/n):"
+
+        input = STDIN.gets.chomp
+        while 1 do
+           if(input == "n")
+             Kernel.exit!(0)
+           elsif(input == "y")
+             break
+           else
+             puts "Invalid input: type 'y' or 'n'"
+             input = STDIN.gets.chomp
+           end
+        end
+        box_Mode = 1
+    end
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  if box_Mode.to_i == BOX_MODE_KUBERNETES.to_i
+    
+    config.vm.provision :shell, 
+    path: "boxes/k8s/prepare_k8s.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "cat /dev/null > ~/.bash_history && history -c && exit",
+    privileged: true
+
+  elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i
+
+    config.vm.provision :shell,
+    path: "boxes/openebs/prepare_openebs.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "/bin/bash /home/ubuntu/demo/maya/scripts/install_bootstrap.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "/bin/bash /etc/maya.d/scripts/install_docker.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "/bin/bash /etc/maya.d/scripts/install_consul.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "/bin/bash /etc/maya.d/scripts/install_nomad.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "/bin/bash /etc/maya.d/scripts/install_mayaserver.sh",
+    privileged: true
+
+    config.vm.provision :shell,
+    inline: "cat /dev/null > ~/.bash_history && history -c && exit",
+    privileged: true
+
+  end
+end

--- a/k8s/lib/vagrant/boxes/k8s/prepare_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/prepare_k8s.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Get the specs from github.
+specurl="https://api.github.com/repos/openebs/openebs/contents\
+/k8s/demo/specs"
+
+# Get the scripts from github.
+scripturl="https://api.github.com/repos/openebs/openebs/contents\
+/k8s/lib/scripts"
+
+# Get the plugin from github
+pluginurl="https://raw.githubusercontent.com/openebs/openebs/master\
+/k8s/lib/plugin/flexvolume/openebs-iscsi"
+
+# Get kubernetes containers from gcr.io
+gcrUrl="gcr.io/google_containers/"
+PACKAGES=(\
+pause-amd64:3.0 \
+kube-scheduler-amd64:v1.5.5 \
+kube-apiserver-amd64:v1.5.5 \
+kube-controller-manager-amd64:v1.5.5 \
+etcd-amd64:3.0.14-kubeadm \
+kube-discovery-amd64:1.0 \
+kube-proxy-amd64:v1.5.5 \
+kubedns-amd64:1.9 \
+kube-dnsmasq-amd64:1.4 \
+dnsmasq-metrics-amd64:1.0 \
+exechealthz-amd64:1.2 \
+)
+
+# For ubuntu/xenial64 only
+useradd vagrant --password vagrant --home /home/vagrant --create-home -s /bin/bash
+echo "vagrant ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vagrant
+mkdir -p /home/vagrant/.ssh
+wget --no-check-certificate https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub -O /home/vagrant/.ssh/authorized_keys
+chmod 0700 /home/vagrant/.ssh
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+
+# Download and install needed packages.
+sudo apt-get update
+sudo apt-get install -y unzip curl wget
+
+# Install docker and K8s
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+| sudo apt-key add - 
+sudo tee /etc/apt/sources.list.d/kubernetes.list <<EOF >/dev/null
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+sudo apt-get update
+
+# Install docker if you don't have it already.
+sudo apt-get install -y docker.io
+sudo apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+
+#Install JSON Parser for patching kube-proxy
+sudo apt-get install -y jq
+
+# Pull kubernetes container images.
+for i in "${!PACKAGES[@]}"; do
+    sudo docker -- pull $gcrUrl${PACKAGES[i]}
+done
+
+sudo docker -- pull weaveworks/weave-kube:1.9.4
+sudo docker -- pull weaveworks/weave-npc:1.9.4
+
+# Create the demo directory and download scripts
+mapfile -t scriptdownloadurls < <(curl -sS $scripturl \
+| grep "download_url" | awk '{print $2}' \
+| tr -d '",')
+
+mkdir -p /home/ubuntu/demo/k8s/scripts
+cd /home/ubuntu/demo/k8s/scripts
+
+scriptlength=${#scriptdownloadurls[@]}
+for ((i = 0; i != scriptlength; i++)); do
+    if [ -z "${scriptdownloadurls[i]##*configure_k8s_master.sh*}" -o \
+         -z "${scriptdownloadurls[i]##*configure_k8s_host.sh*}" ] ;then
+        wget "${scriptdownloadurls[i]}"
+    fi
+done
+    
+mapfile -t downloadurls < <(curl -sS $specurl \
+| grep "download_url" | awk '{print $2}' \
+| tr -d '",')
+
+#Create demo directory and download specs
+mkdir -p /home/ubuntu/demo/k8s/spec
+cd /home/ubuntu/demo/k8s/spec    
+
+length=${#downloadurls[@]}
+for ((i = 0; i != length; i++)); do
+    if [ -z "${downloadurls[i]##*yaml*}" ] ;then
+        wget "${downloadurls[i]}"
+    fi
+done
+
+K8S_VOL_PLUGINDIR="/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+sudo mkdir -p ${K8S_VOL_PLUGINDIR}
+
+## Install the plugin for dedicated openebs-iscsi storage
+sudo mkdir -p ${K8S_VOL_PLUGINDIR}/openebs~openebs-iscsi
+wget $pluginurl 
+chmod +x openebs-iscsi 
+sudo mv openebs-iscsi ${K8S_VOL_PLUGINDIR}/openebs~openebs-iscsi/
+
+## Restart the kubelet for the new volume plugins to take effect
+sudo systemctl restart kubelet.service

--- a/k8s/lib/vagrant/boxes/openebs/prepare_openebs.sh
+++ b/k8s/lib/vagrant/boxes/openebs/prepare_openebs.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Get the mode for installing - Master or Host.
+releasetag=$1
+
+# Get the releases from github.
+releaseurl="https://api.github.com/repos/openebs/maya/releases"
+
+# Get the specs from github.
+specurl="https://api.github.com/repos/openebs/openebs/contents\
+/k8s/demo/specs"
+
+# Get the scripts from github.
+scripturl="https://api.github.com/repos/openebs/openebs/contents\
+/k8s/lib/scripts" 
+
+# Get the bootstrap scripts from github.
+bootstrapurl="https://raw.githubusercontent.com/openebs/maya/master\
+/scripts/install_bootstrap.sh"
+
+# For ubuntu/xenial64 only
+useradd vagrant --password vagrant --home /home/vagrant --create-home -s /bin/bash
+echo "vagrant ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/vagrant
+mkdir -p /home/vagrant/.ssh
+wget --no-check-certificate https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub -O /home/vagrant/.ssh/authorized_keys
+chmod 0700 /home/vagrant/.ssh
+chmod 0600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+
+# Update apt and get dependencies
+sudo apt-get update
+sudo apt-get install -y unzip curl wget
+
+# Install Maya binaries
+if [ -z "$releasetag" ]; then
+
+wget $(curl -sS $releaseurl | grep "browser_download_url" \
+| awk '{print $2}' | tr -d '"' | head -n 2 | tail -n 1)
+
+else    
+
+wget "https://github.com/openebs/maya/releases/download/\
+$releasetag/maya-linux_amd64.zip"
+
+fi
+
+unzip maya-linux_amd64.zip
+sudo mv maya /usr/bin
+rm -rf maya-linux_amd64.zip
+
+mapfile -t scriptdownloadurls < <(curl -sS $scripturl \
+| grep "download_url" | awk '{print $2}' \
+| tr -d '",')
+
+mkdir -p /home/ubuntu/demo/maya/scripts
+cd /home/ubuntu/demo/maya/scripts
+
+scriptlength=${#scriptdownloadurls[@]}
+for ((i = 0; i != scriptlength; i++)); do
+    if [ -z "${scriptdownloadurls[i]##*configure_omm.sh*}" -o \
+    -z "${scriptdownloadurls[i]##*configure_osh.sh*}" ] ;then
+        wget "${scriptdownloadurls[i]}"
+    fi
+done
+
+wget $bootstrapurl
+
+mapfile -t specdownloadurls < <(curl -sS $specurl \
+| grep "download_url" | awk '{print $2}' \
+| tr -d '",')
+
+#Create demo directory and download specs
+mkdir -p /home/ubuntu/demo/maya/spec
+cd /home/ubuntu/demo/maya/spec    
+
+speclength=${#specdownloadurls[@]}
+for ((i = 0; i != speclength; i++)); do
+    if [ -z "${specdownloadurls[i]##*hcl*}" ] ;then
+        wget "${specdownloadurls[i]}"
+    fi
+done
+


### PR DESCRIPTION
Scripts and Vagrantfile for creating vagrant boxes.

Code Changes:
----------------
1. Scripts have to been created to generate vagrant boxes. These vagrant boxes will now come installed with prerequisites for Kubernetes and OpenEBS.
2. A Vagrantfile has been created for generating the OpenEBS and Kubernetes boxes.

Tested On:
-----------
Developer Laptop - (kubemaster-01, kubeminion-01, omm-01 and osh-01)
OpenEBS Test Machine - Multi VM. - (kubemaster-01, kubeminion-01, omm-01, osh-01 and osh-02)

Details of code fix:
--------------------
Vagrant boxes are being created by which will have Kubernetes and OpenEBS specific environment, using a Vagrantfile and box specific scripts.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>