### PR TITLE
Fixes issue #83 and also contains updates to Vagrantfile to create seperate log files for boxes.

### DIFF
--- a/k8s/demo/Vagrantfile
+++ b/k8s/demo/Vagrantfile
@@ -23,7 +23,7 @@ DEPLOY_MODE_HC = 2
 deploy_Mode=ENV['OPENEBS_DEPLOY_MODE'] || 1
 
 #Specify the release versions to be installed
-MAYA_RELEASE_TAG = ENV['MAYA_RELEASE_TAG'] || "0.2-RC2"
+MAYA_RELEASE_TAG = ENV['MAYA_RELEASE_TAG'] || "0.2-RC3"
 
 ENV['LC_ALL']="en_US.UTF-8"
 
@@ -106,8 +106,7 @@ def configureVM(vmCfg, hostname, cpus, mem)
     #vb.gui = true
     vb.memory = mem
     vb.cpus = cpus
-    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
-    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "ubuntu-xenial-16.04-cloudimg-console.log")]
+    vb.customize ["modifyvm", :id, "--cableconnected1", "on"]   
   end  
   
   return vmCfg
@@ -151,6 +150,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mem = KM_MEM            
       config.vm.define hostname do |vmCfg|
         vmCfg.vm.box = "openebs/k8s-1.5.5"
+	      vmCfg.vm.provider "virtualbox" do |vb|
+           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-k8s-1.5.5-cloudimg-console.log")]
+        end
         vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
         # Run in dedicated deployment mode or hyperconverged mode
@@ -172,6 +174,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mem = KH_MEM            
       config.vm.define hostname do |vmCfg|
         vmCfg.vm.box = "openebs/k8s-1.5.5"
+	      vmCfg.vm.provider "virtualbox" do |vb|
+           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-k8s-1.5.5-cloudimg-console.log")]
+        end
         vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
         # Run in dedicated deployment mode or hyperconverged mode
@@ -244,15 +249,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))     
         config.vm.define hostname do |vmCfg|
           vmCfg.vm.box = "openebs/openebs-0.2"
+	        vmCfg.vm.provider "virtualbox" do |vb|
+           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-openebs-0.2-cloudimg-console.log")]
+          end
           vmCfg = configureVM(vmCfg, hostname, cpus, mem)
 
           # Run in dedicated deployment mode
           if deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i
-
-            vmCfg.vm.provision :shell, 
-            inline: "rm /var/lib/dpkg/lock",                
-            privileged: true              
-
+                  
             # Install OpenEBS Maya Master
             if MAYA_RELEASE_TAG == ""
               vmCfg.vm.provision :shell, 
@@ -302,6 +306,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         (deploy_Mode.to_i == DEPLOY_MODE_NONE.to_i))
         config.vm.define hostname do |vmCfg|
           vmCfg.vm.box = "openebs/openebs-0.2"
+	        vmCfg.vm.provider "virtualbox" do |vb|
+           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-openebs-0.2-cloudimg-console.log")]
+          end
           vmCfg = configureVM(vmCfg, hostname, cpus, mem)
           
           # Run in dedicated deployment mode

--- a/k8s/lib/vagrant/Vagrantfile
+++ b/k8s/lib/vagrant/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure("2") do |config|
     privileged: true
 
     config.vm.provision :shell,
-    inline: "cat /dev/null > ~/.bash_history && history -c && exit",
+    path: "boxes/openebs/cleanup_k8s.sh",
     privileged: true
 
   elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i
@@ -133,7 +133,7 @@ Vagrant.configure("2") do |config|
     privileged: true
 
     config.vm.provision :shell,
-    inline: "cat /dev/null > ~/.bash_history && history -c && exit",
+    path: "boxes/openebs/cleanup_openebs.sh",
     privileged: true
 
   end

--- a/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Cleaning up apt and bash history before packaing the box. 
+sudo apt-get clean
+sudo dd if=/dev/zero of=/EMPTY bs=1M
+sudo rm -f /EMPTY
+cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/boxes/openebs/cleanup_openebs.sh
+++ b/k8s/lib/vagrant/boxes/openebs/cleanup_openebs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Cleaning up apt and bash history before packaing the box. 
+sudo apt-get clean
+sudo dd if=/dev/zero of=/EMPTY bs=1M
+sudo rm -f /EMPTY
+cat /dev/null > ~/.bash_history && history -c && exit


### PR DESCRIPTION
Updates to the Vagrantfile to create cloudimage logs specific to boxes being used. Also contains the fix for issue #83 

Code Changes:
----------------
1. Scripts have to been created to perform vagrant box cleanup before packaging. 
2. A Vagrantfile has been updated to create logs based on the boxes used in the box config.

Tested On:
-----------
Developer Laptop - (kubemaster-01, kubeminion-01, omm-01 and osh-01)
OpenEBS Test Machine - Multi VM. - (kubemaster-01, kubeminion-01, omm-01, osh-01 and osh-02)

Details of code fix:
-------------------
Clears the apt-get cache if any, which might be causing the dpkg/lock issue during the VM creation. 

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>