### PR TITLE
Updating box cleanup scripts and Vagrantfile.

### DIFF
--- a/k8s/lib/vagrant/Vagrantfile
+++ b/k8s/lib/vagrant/Vagrantfile
@@ -103,7 +103,7 @@ Vagrant.configure("2") do |config|
     privileged: true
 
     config.vm.provision :shell,
-    path: "boxes/openebs/cleanup_k8s.sh",
+    path: "boxes/k8s/cleanup_k8s.sh",
     privileged: true
 
   elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i

--- a/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
@@ -2,6 +2,4 @@
 
 # Cleaning up apt and bash history before packaing the box. 
 sudo apt-get clean
-sudo dd if=/dev/zero of=/EMPTY bs=1M
-sudo rm -f /EMPTY
 cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/boxes/openebs/cleanup_openebs.sh
+++ b/k8s/lib/vagrant/boxes/openebs/cleanup_openebs.sh
@@ -2,6 +2,4 @@
 
 # Cleaning up apt and bash history before packaing the box. 
 sudo apt-get clean
-sudo dd if=/dev/zero of=/EMPTY bs=1M
-sudo rm -f /EMPTY
 cat /dev/null > ~/.bash_history && history -c && exit


### PR DESCRIPTION
Updating box cleanup scripts and Vagrantfile.

Code Changes:
----------------

1. Cleanup scripts have been updated. 
2. Updated the path of the scripts in the Vagrantfile.

Tested On:
-----------
Developer Laptop - (kubemaster-01, kubeminion-01, omm-01 and osh-01)

Details of code fix:
--------------------

The creation and removal of /EMPTY directory in the boxes has been removed as it sometimes recreates the folder and starts consuming enormous disk space.
The cleanup script location for the Kubernetes boxes were pointing to the wrong location. Updated the path to point to the precise path.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>