### PR TITLE
Added code to pull jiva images during OSH vagrant up.

### DIFF
--- a/k8s/demo/Vagrantfile
+++ b/k8s/demo/Vagrantfile
@@ -23,7 +23,7 @@ DEPLOY_MODE_HC = 2
 deploy_Mode=ENV['OPENEBS_DEPLOY_MODE'] || 1
 
 #Specify the release versions to be installed
-MAYA_RELEASE_TAG = ENV['MAYA_RELEASE_TAG'] || "0.2-RC3"
+MAYA_RELEASE_TAG = ENV['MAYA_RELEASE_TAG'] || "0.2"
 
 #TODO - Verify
 #LC_ALL is not set on OsX, it will inherit it from SSH on Linux though,
@@ -93,7 +93,6 @@ def configureVM(vmCfg, hostname, cpus, mem)
   vmCfg.vm.provision "shell", inline: <<-SHELL
       echo "ubuntu:ubuntu" | sudo chpasswd
   SHELL
-
   
   #Adding Vagrant-cachier
   if Vagrant.has_plugin?("vagrant-cachier")
@@ -286,11 +285,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
                 host_ip_address = `#{get_ip_address}`
 
-                @machine.communicate.sudo("echo 'export \
-                NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
+                @machine.communicate.sudo("echo \
+		'export NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
                 /home/ubuntu/.profile") 
-		            @machine.communicate.sudo("echo 'export \
-                MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
+		@machine.communicate.sudo("echo \
+		'export MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
                 /home/ubuntu/.profile")
               end
             end            
@@ -355,15 +354,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                   @machine.communicate.sudo("bash \
                   /home/ubuntu/demo/maya/scripts/configure_osh.sh \
                   --masterip=#{master_ip_address.strip} \
-                  --releasetag=#{MAYA_RELEASE_TAG}")
+                  --releasetag=#{MAYA_RELEASE_TAG}")		 
                   end
 
-                  @machine.communicate.sudo("echo 'export \
-                  NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
+                  @machine.communicate.sudo("echo \
+		  'export NOMAD_ADDR=http://#{host_ip_address.strip}:4646' >> \
                   /home/ubuntu/.profile")
-		              @machine.communicate.sudo("echo 'export \
-                  MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
+		  @machine.communicate.sudo("echo \
+		  'export MAPI_ADDR=http://#{host_ip_address.strip}:5656' >> \
                   /home/ubuntu/.profile")
+
+		  @machine.communicate.sudo("docker pull \
+		  openebs/jiva")
                 end  
               end
             end

--- a/k8s/demo/specs/demo-mysql-openebs-plugin.yaml
+++ b/k8s/demo/specs/demo-mysql-openebs-plugin.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mysql
+  labels:
+    name: mysql
+spec:
+  containers:
+  - resources:
+      limits:
+        cpu: 0.5
+    name: mysql
+    image: mysql
+    args:
+      - "--ignore-db-dir"
+      - "lost+found"
+    env:
+      - name: MYSQL_ROOT_PASSWORD
+        value: k8sDem0
+    ports:
+      - containerPort: 3306
+        name: mysql
+    volumeMounts:
+    - mountPath: /var/lib/mysql
+      name: demo-vsm1-vol1
+  volumes:
+  - name: demo-vsm1-vol1
+    flexVolume:
+      driver: "openebs/openebs-iscsi"
+      options:
+        name: "demo-vsm1-vol1"
+        openebsApiUrl: "http://172.28.128.5:5656/latest"
+        size: "5G"


### PR DESCRIPTION
Pull jiva images during OSH vagrant up. A yaml for mysql to run with flex plugin.

Code Changes:
----------------
1. Pull Jiva images during vagrant up of OSH nodes.
2. A new yaml file, which allows mysql to use the flex driver plugin of openebs.
3. Fixed the spacing issue caused in the ~/.profile for NOMAD and MAPI addresses.

Tested On:
-----------
Developer Laptop (omm-01, osh-01, osh-02)

Details of the fix:
------------------
A jiva image will be downloaded during the vagrant up of OSH nodes, thereby allowing faster execution of the pod when run by kubernetes. Also a new yaml is provided which allows mysql to use openebs flex driver. Spacing issue has been resolved in the ~/.profile for the NOMAD and MAPI addresses.
Signed-off-by: yudaykiran <udaykiran.y@gmail.com>