### PR TITLE
Add roles to install and setup kubernetes cluster. Enhancement for PR #104.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ k8s/demo/.vagrant/
 k8s/demo/*.log
 k8s/demo/*test*
 documentation/build/
+k8s/lib/vagrant/*.box
+k8s/lib/vagrant/*.log

--- a/e2e/ansible/inventory/machines.in
+++ b/e2e/ansible/inventory/machines.in
@@ -1,23 +1,25 @@
-# This is an input file used by the OpenEBS ansible framework to
-# generate the 'hosts' file (otherwise called ansible inventory)
-# It consists of multiple comma-separated lines which specify machine
-# details in the following manner :
+# This is a input file used by OpenEBS for generating the hosts.
 #
-# hostcode,ip address,env var for username, env var for password
+# This file contains the mappings of IP addresses to host names and login 
+# details for that host. Each entry should be kept on an individual line. 
+# The IP address should be placed in the first column followed by the 
+# corresponding host name.
+# The IP address and the host name should be separated by at least one
+# comma.
 #
-# For Example:
-# mayamaster,20.10.26.11,MAYAMASTER_USER_NAME,MAYAHOST_USER_PASSWORD
-# mayahost,20.10.26.12,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD
-# mayahost,20.10.26.13,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD
+# Additionally, comments (such as these) may be inserted on individual
+# lines or before the machine name denoted by a '#' symbol.
 #
-# NOTES:
-# 1. Please ensure supported host codes are provided, failing which
-#    the inventory generation will not proceed. Current supported
-#    codes include 'mayamaster', 'mayahost', 'kubemaster', 'kubeminion'
-#
-# 2. Lines can be commented (such as these) by inserting '#' symbol
-#    before the host code
+# For example:
+#master,20.10.26.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+#host,20.10.26.12,USER_NAME,USER_PASSWORD
+#host,20.10.26.14,USER_NAME,USER_PASSWORD
 
-mayamaster,20.10.49.11,MAYAMASTER_USER_NAME,MAYAHOST_USER_PASSWORD
-mayahost,20.10.49.12,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD
-mayahost,20.10.49.13,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD
+
+#master,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+#host,20.10.49.12,USER_NAME,USER_PASSWORD
+#host,20.10.49.13,USER_NAME,USER_PASSWORD
+
+kubemaster,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+kubeminion,20.10.49.12,USER_NAME,USER_PASSWORD
+kubeminion,20.10.49.13,USER_NAME,USER_PASSWORD

--- a/e2e/ansible/roles/k8s-hosts/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Do not change the order of the scripts.
+# They have to been run in the order defined below.
+
+k8s_images: k8s_images.tar
+
+k8s_images_path: "{{ ansible_env.HOME }}/setup/kubernetes"
+
+k8s_dpkg_packages:
+  - kubelet.deb
+  - kubernetes-cni.deb
+  - kubectl.deb
+  - kubeadm.deb

--- a/e2e/ansible/roles/k8s-hosts/meta/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes }
+

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['kubernetes-kubemasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name: 
+  debug:
+    msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
+- name: Load images from Archive
+  command: docker load --input "{{ k8s_images }}"
+  args:
+    chdir: "{{ k8s_images_path }}"
+  become: true
+
+- name: Install deb packages
+  apt:
+    deb: "{{ k8s_images_path }}/{{ item }}"
+  with_items: "{{ k8s_dpkg_packages }}"
+
+- name: Get Token Name from Master
+  shell: >
+    source ~/.profile;
+    kubectl -n kube-system get secrets
+    | grep bootstrap-token | cut -d " " -f1
+    | cut -d "-" -f3
+    | sed "s|\r||g"
+  args:
+    executable: /bin/bash
+  register: result_token_name
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Token from Master
+  shell: >
+    source ~/.profile; 
+    kubectl -n kube-system get secrets bootstrap-token-"{{result_token_name.stdout}}"
+    -o yaml | grep token-secret | cut -d ":" -f2
+    | cut -d " " -f2 | base64 -d
+    | sed "s|{||g;s|}||g"
+    | sed "s|:|.|g" | xargs echo
+  args:
+    executable: /bin/bash
+  register: result_token
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  
+- name: Get Cluster IP from Master
+  shell: >
+    source ~/.profile;
+    kubectl get svc -o yaml | grep clusterIP | cut -d ":" -f2 | cut -d " " -f2
+  args:
+    executable: /bin/bash
+  register: result_cluster
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Save Token and Cluster IP
+  set_fact:
+    cluster_ip: "{{ result_cluster.stdout }}"
+    token: "{{ result_token }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  delegate_facts: True
+          
+- name: Reset kubeadm
+  command: kubeadm reset
+
+- name: Setup k8s Hosts 
+  script: "configure_k8s_host.sh 
+          --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
+          --token={{result_token_name.stdout}}.{{result_token.stdout}} 
+          --clusterip={{result_cluster.stdout}}"

--- a/e2e/ansible/roles/k8s-master/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-master/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+# Do not change the order of the scripts.
+# They have to be run in the order defined below.
+
+configure_scripts:
+  - configure_k8s_master.sh
+  - configure_k8s_cred.sh
+  - configure_k8s_weave.sh
+
+weave_depends:
+  - weave_images.tar
+  - weave-daemonset-k8s-1.6.yaml
+
+k8s_images: k8s_images.tar
+
+weave_images_path: "{{ ansible_env.HOME}}/setup/weave"
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/kubernetes"
+
+# Do not change the order of the packages
+# They have to be installed in the order defined below.
+
+k8s_dpkg_packages:
+  - kubelet.deb
+  - kubernetes-cni.deb
+  - kubectl.deb
+  - kubeadm.deb
+

--- a/e2e/ansible/roles/k8s-master/meta/main.yml
+++ b/e2e/ansible/roles/k8s-master/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: kubernetes }
+

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Create Directory
+  file:
+    path: "{{ weave_images_path }}"
+    state: directory
+
+- name: Copy TAR and Pod YAML to remote
+  copy:
+    src: "{{ item }}"
+    dest: "{{ weave_images_path }}"
+  with_items: "{{ weave_depends }}"
+
+- name: Copy Script to remote
+  copy:
+    src: "{{ configure_scripts[2] }}"
+    dest: "{{ k8s_images_path }}"
+    mode: "u+rwx"
+
+- name: Load images from Archive
+  command: docker load --input "{{ k8s_images }}"
+  args:
+    chdir: "{{ k8s_images_path }}"
+  become: true
+
+- name: Load images from Archive
+  command: docker load --input "{{ weave_depends[0] }}"
+  args:
+    chdir: "{{ weave_images_path }}"
+  become: true
+
+- name: Install deb packages
+  apt:
+    deb: "{{ k8s_images_path }}/{{ item }}"
+  with_items: "{{ k8s_dpkg_packages }}"
+
+- name: kubeadm init
+  script: "{{ configure_scripts[0] }}"
+
+- name: Copy k8s credentials to $HOME
+  script: "{{ configure_scripts[1] }}"
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[2] }}" 
+  args:
+    executable: /bin/bash

--- a/e2e/ansible/roles/kubernetes/defaults/main.yml
+++ b/e2e/ansible/roles/kubernetes/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+k8s_deb_packages:
+  - unzip
+  - curl
+  - wget
+  - apt-transport-https
+  - docker-engine
+  - jq
+  - socat
+  - ebtables
+
+k8s_images_path: "{{ ansible_env.HOME}}/setup/kubernetes"
+
+k8s_images: k8s_images.tar
+
+k8s_dpkg_packages:
+  - kubeadm.deb
+  - kubectl.deb
+  - kubelet.deb 
+  - kubernetes-cni.deb  
+

--- a/e2e/ansible/roles/kubernetes/tasks/main.yml
+++ b/e2e/ansible/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Get Package Updates
+  apt:
+    update_cache: yes
+  become: true
+
+- name: Add apt-key
+  apt_key:
+    url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+    state: present
+  become: true
+
+- name: Add Kubernetes apt repository
+  apt_repository:
+    repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+    state: present
+  become: true
+
+- name: Get Package Updates
+  apt:
+    update_cache: yes
+  become: true
+
+- name: Install APT Packages
+  apt:
+    name: "{{ item }}" 
+    state: present
+  become: true
+  with_items: "{{ k8s_deb_packages }}"
+
+- name: Create Directory
+  file:
+    path: "{{ k8s_images_path }}"
+    state: directory
+
+- name: Copy TAR to remote
+  copy:
+    src: "{{ k8s_images }}"
+    dest: "{{ k8s_images_path }}"
+
+- name: Copy local deb files to K8s-Master and K8s-Minions
+  copy:
+   src: "{{ item }}"
+   dest: "{{ k8s_images_path }}"
+  with_items: "{{ k8s_dpkg_packages }}"


### PR DESCRIPTION
Add roles to install and setup kubernetes cluster.

## Code Changes:
--------------------------------------------------
- Added new role 'kubernetes', installs common packages for kubemaster and kubeminion.
- Added new role 'k8s-master', runs 'kubeadm init' and sets up kubernetes master.
- Added new role 'k8s-hosts', runs 'kubeadm join' in kubernetes minion to join a kubernetes cluster.

## Tested On:
-------------------------------------------------
Developer Laptops - (Using Vagrant Boxes- Ubuntu)
OpenEBS Test Machine - Multi VM. - (ESX 6.0 Ubuntu VMs)

## Details of the fix:
------------------------------------------------
This is a new development which involves creating roles kubernetes, k8s-master and k8s-hosts to be run in ansible.

Signed-off-by: yudaykiran [udaykiran.y@gmail.com](url)