### PR TITLE
Add preparatory role to aid kubernetes cluster setup. Enhancement for PR#104

### DIFF
--- a/e2e/ansible/inventory/machines.in
+++ b/e2e/ansible/inventory/machines.in
@@ -1,7 +1,8 @@
+###############################################################################
 # This is an input file used by the OpenEBS ansible framework to
 # generate the 'hosts' file (otherwise called ansible inventory)
-# It consists of multiple comma-separated lines which specify machine
-# details in the following manner :
+# It consists of multiple comma-separated lines which specify the
+# machine details in the following manner :
 #
 # hostcode,ip address,env var for username, env var for password
 #
@@ -11,12 +12,20 @@
 # mayahost,20.10.26.13,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD
 #
 # NOTES:
-# 1. Please ensure supported host codes are provided, failing which
-#    the inventory generation will not proceed. Current supported
-#    codes include 'mayamaster', 'mayahost', 'kubemaster', 'kubeminion'
 #
-# 2. Lines can be commented (such as these) by inserting '#' symbol
-#    before the host code
+# 1. Please ensure supported host codes are provided, failing which
+# the inventory generation will not proceed. Current supported
+# codes include 'mayamaster', 'mayahost', 'kubemaster', 'kubeminion'
+#
+# 2. A dictionary of supported codes is present in the python script
+# generate_inventory.py, which can be updated by interested users to 
+# include additional hostcodes 
+#
+# 3. Lines can be commented (such as these) by inserting '#' symbol
+# before the host code
+#
+################################################################################
+
 
 mayamaster,20.10.49.11,MAYAMASTER_USER_NAME,MAYAHOST_USER_PASSWORD
 mayahost,20.10.49.12,MAYAHOST_USER_NAME,MAYAHOST_USER_PASSWORD

--- a/e2e/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-##################################################### PREPARATION OF K8S-LOCALHOST BOX ##########################################################
+##################################################### PREPARATION OF K8S-LOCALHOST BOX #########################################################
 
 deb_local_packages:
   - docker.io
@@ -12,16 +12,22 @@ pip_local_packages:
 # Links for .deb packages that will be installed on all K8s boxes (masters, minions), i.e, 
 # these packages will be copied into kubernetes role's .files
 
-K8s_deb_packages:
+k8s_deb_packages:
   - https://packages.cloud.google.com/apt/pool/kubeadm_1.6.3-00_amd64_ff5e882c88a5db71803aab900c0b341eb63038558da73c51c3d351070b0c62af.deb
   - https://packages.cloud.google.com/apt/pool/kubectl_1.6.3-00_amd64_05d48fa118b6538ee2bc0b864aeb09f2cede83990fc8819875f698a5dece0c9b.deb
   - https://packages.cloud.google.com/apt/pool/kubelet_1.6.3-00_amd64_a94b0cfa5b26939d87097dfd45260474c1effcad879e35940eb6d36e7d953d6c.deb
   - https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.5.1-00_amd64_08cbe5c42366ec3184cc91a4353f6e066f2d7325b4db1cb4f87c7dcc8c0eb620.deb
 
+k8s_deb_package_alias:
+  - kubeadm.deb
+  - kubectl.deb
+  - kubelet.deb
+  - kubernetes-cni.deb
+
 # Container images that needs to be placed on all K8s boxes (masters, minions)
 # These images will be downloaded, tar'ed and pushed into the kubernetes role's .files
 
-K8s_images:
+k8s_images:
   - gcr.io/google_containers/pause-amd64:3.0
   - gcr.io/google_containers/etcd-amd64:3.0.17
   - gcr.io/google_containers/kube-scheduler-amd64:v1.6.2
@@ -31,10 +37,6 @@ K8s_images:
   - gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
   - gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
   - gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
-
-# Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
-
-weave_template_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml
 
 ###################################################### PREPARATION OF K8S-MASTER ROLE ###########################################################
 
@@ -52,6 +54,9 @@ weave_images:
   - weaveworks/weave-kube:1.9.4
   - weaveworks/weave-npc:1.9.4
 
+# Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
+
+weave_template_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml
 
 ###################################################### PREPARATION OF K8S-HOST ROLE #############################################################
 

--- a/e2e/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/defaults/main.yml
@@ -1,0 +1,63 @@
+---
+##################################################### PREPARATION OF K8S-LOCALHOST BOX ##########################################################
+
+deb_local_packages:
+  - docker.io
+
+pip_local_packages:
+  - 'docker-py==1.9.0'
+
+###################################################### PREPARATION OF KUBERNETES ROLE  ##########################################################
+
+# Links for .deb packages that will be installed on all K8s boxes (masters, minions), i.e, 
+# these packages will be copied into kubernetes role's .files
+
+K8s_deb_packages:
+  - https://packages.cloud.google.com/apt/pool/kubeadm_1.6.3-00_amd64_ff5e882c88a5db71803aab900c0b341eb63038558da73c51c3d351070b0c62af.deb
+  - https://packages.cloud.google.com/apt/pool/kubectl_1.6.3-00_amd64_05d48fa118b6538ee2bc0b864aeb09f2cede83990fc8819875f698a5dece0c9b.deb
+  - https://packages.cloud.google.com/apt/pool/kubelet_1.6.3-00_amd64_a94b0cfa5b26939d87097dfd45260474c1effcad879e35940eb6d36e7d953d6c.deb
+  - https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.5.1-00_amd64_08cbe5c42366ec3184cc91a4353f6e066f2d7325b4db1cb4f87c7dcc8c0eb620.deb
+
+# Container images that needs to be placed on all K8s boxes (masters, minions)
+# These images will be downloaded, tar'ed and pushed into the kubernetes role's .files
+
+K8s_images:
+  - gcr.io/google_containers/pause-amd64:3.0
+  - gcr.io/google_containers/etcd-amd64:3.0.17
+  - gcr.io/google_containers/kube-scheduler-amd64:v1.6.2
+  - gcr.io/google_containers/kube-apiserver-amd64:v1.6.2
+  - gcr.io/google_containers/kube-controller-manager-amd64:v1.6.2
+  - gcr.io/google_containers/kube-proxy-amd64:v1.6.2
+  - gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
+  - gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
+
+# Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
+
+weave_template_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml
+
+###################################################### PREPARATION OF K8S-MASTER ROLE ###########################################################
+
+# Links for scripts to be placed into K8s-master role's .files 
+
+k8s_master_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_cred.sh
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_master.sh
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_weave.sh
+
+# Container images that needs to be placed in K8s-master box
+# These images will be downloaded, tar'ed and pushed into K8s-master role's .files 
+
+weave_images: 
+  - weaveworks/weave-kube:1.9.4
+  - weaveworks/weave-npc:1.9.4
+
+
+###################################################### PREPARATION OF K8S-HOST ROLE #############################################################
+
+# Links for scripts to be placed into K8s-host role's .files
+
+k8s_host_scripts: 
+  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_host.sh
+
+

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -1,0 +1,159 @@
+---
+## K8S-LOCALHOST PREPARATION
+
+- name: Install APT Packages
+  apt: 
+    name: "{{item}}"
+    state: present
+  with_items: "{{deb_local_packages}}"
+  become: true
+  delegate_to: 127.0.0.1
+  tags: install_apt_packages
+
+- name: Install PIP Packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_local_packages }}"
+  become: true
+  delegate_to: 127.0.0.1 
+  tags: install_pip_packages
+
+## KUBERNETES ROLE PREPARATION
+
+- name: Get .deb kubernetes packages google cloud 
+  get_url: 
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  with_items: "{{ K8s_deb_packages }}"
+  become: true
+  tags: get_deb_packages 
+
+- name: Fetch K8s images from gcr.io/google_containers
+  docker_image: 
+    name: "{{item}}"
+    state: present
+    pull: true
+    force: yes
+  register: result
+  until: "'Pulled image {{ item }}' in  result.actions"
+  delay: 60
+  retries: 3  
+  with_items: "{{ K8s_images }}"
+  become: true
+  tags: fetch_K8s_images
+
+- name: Print K8s image names
+  shell: printf "{{ item }}\n" >> imagelist.tmp
+  with_items: "{{ K8s_images }}"
+  tags: list_K8s_images
+
+- name: TAR the K8s images 
+  shell: sudo docker save $(cat imagelist.tmp) -o k8s_images.tar
+  tags: tar_K8s_images
+
+- name: Remove the .tmp file created to hold image list
+  file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+  tags: remove_tmp_files
+
+- name: Move K8s_images.tar into kubernetes role
+  shell: mv {{playbook_dir}}/k8s_images.tar {{ playbook_dir }}/roles/kubernetes/files
+  tags: move_K8s_images.tar
+
+- name: Remove K8s images from K8s-localhost
+  docker_image:
+    name: "{{ item }}" 
+    state: absent
+  with_items: "{{ K8s_images }}"
+  become: true
+  tags: remove_K8s_images 
+
+- name: Fetch the weave .yaml template from GitHub
+  get_url:
+    url: "{{ weave_template_link }}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/templates"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  become: true
+  tags: fetch_weave_template
+
+## K8S-MASTER ROLE PREPARATION
+
+- name: Fetch configure_K8s scripts into k8s-master role
+  get_url: 
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_master_scripts }}"
+  become: true
+  tags: fetch_k8s_master_scripts
+
+- name: Fetch weave images from dockerhub
+  docker_image:
+    name: "{{ item }}"
+    state: present
+    pull: true
+    force: yes
+  register: result
+  until: "'Pulled image {{ item }}' in  result.actions"
+  delay: 60
+  retries: 3
+  with_items: "{{ weave_images }}" 
+  become: true
+  tags: fetch_weave_images
+
+- name: Print weave image names
+  shell: printf "{{ item }}\n" >> imagelist.tmp
+  with_items: "{{ weave_images }}"
+  tags: list_weave_images
+
+- name: TAR the weave images
+  shell: sudo docker save $(cat imagelist.tmp) -o weave_images.tar
+  tags: tar_weave_images
+
+- name: Remove the .tmp file created to hold image list
+  file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+  tags: remove_tmp_files
+
+- name: Move weave_images.tar into k8s-master role
+  shell: mv {{playbook_dir}}/weave_images.tar {{ playbook_dir }}/roles/k8s-master/files
+  tags: move_weave_images.tar
+
+- name: Remove weave images from K8s-localhost
+  docker_image:
+    name: "{{ item }}" 
+    state: absent
+  with_items: "{{ weave_images }}"
+  become: true
+  tags: remove_weave_images 
+
+## K8S-HOSTS ROLE PREPARATION
+
+- name: Fetch configure_K8s scripts into k8s-host role
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ playbook_dir }}/roles/k8s-hosts/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3 
+  with_items: "{{ k8s_host_scripts }}"
+  become: true
+  tags: fetch_k8s_hosts_scripts
+  
+  
+
+  

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -8,7 +8,6 @@
   with_items: "{{deb_local_packages}}"
   become: true
   delegate_to: 127.0.0.1
-  tags: install_apt_packages
 
 - name: Install PIP Packages
   pip:
@@ -17,22 +16,22 @@
   with_items: "{{ pip_local_packages }}"
   become: true
   delegate_to: 127.0.0.1 
-  tags: install_pip_packages
 
 ## KUBERNETES ROLE PREPARATION
 
 - name: Get .deb kubernetes packages google cloud 
   get_url: 
-    url: "{{ item }}"
-    dest: "{{ playbook_dir }}/roles/kubernetes/files"
+    url: "{{ item.0 }}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/files/{{item.1}}"
     force: yes
   register: result
   until:  "'OK' in result.msg"
   delay: 5
   retries: 3
-  with_items: "{{ K8s_deb_packages }}"
+  with_together: 
+    - "{{ k8s_deb_packages }}"
+    - "{{ k8s_deb_package_alias }}"
   become: true
-  tags: get_deb_packages 
 
 - name: Fetch K8s images from gcr.io/google_containers
   docker_image: 
@@ -41,49 +40,32 @@
     pull: true
     force: yes
   register: result
-  until: "'Pulled image {{ item }}' in  result.actions"
+  until: "'Pulled image' and item in result.actions[0]"
   delay: 60
   retries: 3  
-  with_items: "{{ K8s_images }}"
+  with_items: "{{ k8s_images }}"
   become: true
-  tags: fetch_K8s_images
+  tags: fetch_k8_images  
 
 - name: Print K8s image names
   shell: printf "{{ item }}\n" >> imagelist.tmp
-  with_items: "{{ K8s_images }}"
-  tags: list_K8s_images
+  with_items: "{{ k8s_images }}"
 
 - name: TAR the K8s images 
-  shell: sudo docker save $(cat imagelist.tmp) -o k8s_images.tar
-  tags: tar_K8s_images
+  shell: docker save $(cat imagelist.tmp) -o k8s_images.tar
 
 - name: Remove the .tmp file created to hold image list
   file: path="{{playbook_dir}}/imagelist.tmp" state=absent
-  tags: remove_tmp_files
 
 - name: Move K8s_images.tar into kubernetes role
   shell: mv {{playbook_dir}}/k8s_images.tar {{ playbook_dir }}/roles/kubernetes/files
-  tags: move_K8s_images.tar
 
 - name: Remove K8s images from K8s-localhost
   docker_image:
     name: "{{ item }}" 
     state: absent
-  with_items: "{{ K8s_images }}"
+  with_items: "{{ k8s_images }}"
   become: true
-  tags: remove_K8s_images 
-
-- name: Fetch the weave .yaml template from GitHub
-  get_url:
-    url: "{{ weave_template_link }}"
-    dest: "{{ playbook_dir }}/roles/kubernetes/templates"
-    force: yes
-  register: result
-  until:  "'OK' in result.msg"
-  delay: 5
-  retries: 3
-  become: true
-  tags: fetch_weave_template
 
 ## K8S-MASTER ROLE PREPARATION
 
@@ -98,7 +80,6 @@
   retries: 3 
   with_items: "{{ k8s_master_scripts }}"
   become: true
-  tags: fetch_k8s_master_scripts
 
 - name: Fetch weave images from dockerhub
   docker_image:
@@ -107,29 +88,24 @@
     pull: true
     force: yes
   register: result
-  until: "'Pulled image {{ item }}' in  result.actions"
+  until: "'Pulled image' and item in result.actions[0]"
   delay: 60
   retries: 3
   with_items: "{{ weave_images }}" 
   become: true
-  tags: fetch_weave_images
 
 - name: Print weave image names
   shell: printf "{{ item }}\n" >> imagelist.tmp
   with_items: "{{ weave_images }}"
-  tags: list_weave_images
 
 - name: TAR the weave images
-  shell: sudo docker save $(cat imagelist.tmp) -o weave_images.tar
-  tags: tar_weave_images
+  shell: docker save $(cat imagelist.tmp) -o weave_images.tar
 
 - name: Remove the .tmp file created to hold image list
   file: path="{{playbook_dir}}/imagelist.tmp" state=absent
-  tags: remove_tmp_files
 
 - name: Move weave_images.tar into k8s-master role
   shell: mv {{playbook_dir}}/weave_images.tar {{ playbook_dir }}/roles/k8s-master/files
-  tags: move_weave_images.tar
 
 - name: Remove weave images from K8s-localhost
   docker_image:
@@ -137,7 +113,17 @@
     state: absent
   with_items: "{{ weave_images }}"
   become: true
-  tags: remove_weave_images 
+
+- name: Fetch the weave .yaml template from GitHub
+  get_url:
+    url: "{{ weave_template_link }}"
+    dest: "{{ playbook_dir }}/roles/k8s-master/files"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  become: true
 
 ## K8S-HOSTS ROLE PREPARATION
 
@@ -152,7 +138,6 @@
   retries: 3 
   with_items: "{{ k8s_host_scripts }}"
   become: true
-  tags: fetch_k8s_hosts_scripts
   
   
 

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -45,7 +45,6 @@
   retries: 3  
   with_items: "{{ k8s_images }}"
   become: true
-  tags: fetch_k8_images  
 
 - name: Print K8s image names
   shell: printf "{{ item }}\n" >> imagelist.tmp


### PR DESCRIPTION
- A new role called "K8s-localhost" has been created to :

  a) Configure the kubernetes management/test-harness box

  b) Fetch and place requisite shell scripts, template files and docker images into other k8s roles' folders
     (kubernetes, k8s-master, k8s-hosts) as part of a preparatory procedure, before execution of the said
     roles begin.
 

 