### PR TITLE
PR #104: Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/roles/k8s-hosts/handlers/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Reload systemd
+  command: systemctl daemon-reload
+  become: true
+
+- name: Restart kubelet
+  service:
+    name: kubelet 
+    state: restarted
+    enabled: yes
+  become: true

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -73,3 +73,8 @@
           --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
           --token={{result_token_name.stdout}}.{{result_token.stdout}} 
           --clusterip={{result_cluster.stdout}}"
+  notify: 
+    - Reload systemd
+    - Restart kubelet
+
+- meta: flush_handlers 

--- a/e2e/ansible/roles/master/tasks/main.yml
+++ b/e2e/ansible/roles/master/tasks/main.yml
@@ -21,3 +21,5 @@
   become: true
   register: result
   notify: Restart M_APIServer
+
+- meta: flush_handlers


### PR DESCRIPTION
Add handlers for kubelet restart and daemon reload in k8s-hosts.

Code Changes:
----------------
- Add handlers to perform daemon reload and kubelet restart on k8s-hosts.
- Add notifier to invoke handlers on k8s-hosts.
- Add flush_handlers for master role.

Tested On:
-----------
Developer Laptop - (Using Vagrant Boxes- Ubuntu)

Details of the fix:
------------------
Handlers have been added to fix the volume attach/detach mechanism to work as expected. The config change needed a daemon reload and restart of kubelet, which is fixed by the code changes.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>