### PR TITLE
PR #104: Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -4,7 +4,7 @@
   roles:
     - inventory
       
-- hosts: openebs-mayamaster
+- hosts: openebs-mayamasters
 
   roles:
     - master

--- a/e2e/ansible/inventory/machines.in
+++ b/e2e/ansible/inventory/machines.in
@@ -3,17 +3,8 @@
 # generate the 'hosts' file (otherwise called ansible inventory)
 # It consists of multiple comma-separated lines which specify the
 # machine details in the following manner :
-# This is a input file used by OpenEBS for generating the hosts.
 #
-# This file contains the mappings of IP addresses to host names and login 
-# details for that host. Each entry should be kept on an individual line. 
-# The IP address should be placed in the first column followed by the 
-# corresponding host name.
-# The IP address and the host name should be separated by at least one
-# comma.
-#
-# Additionally, comments (such as these) may be inserted on individual
-# lines or before the machine name denoted by a '#' symbol.
+# hostcode,ipaddress,env(username),env(password)
 #
 # NOTES:
 #
@@ -36,10 +27,9 @@
 #host,20.10.26.14,USER_NAME,USER_PASSWORD
 
 
-#master,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
-#host,20.10.49.12,USER_NAME,USER_PASSWORD
-#host,20.10.49.13,USER_NAME,USER_PASSWORD
-
+mayamaster,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+mayahost,20.10.49.12,USER_NAME,USER_PASSWORD
+mayahost,20.10.49.13,USER_NAME,USER_PASSWORD
 kubemaster,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
 kubeminion,20.10.49.12,USER_NAME,USER_PASSWORD
 kubeminion,20.10.49.13,USER_NAME,USER_PASSWORD

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod-vars.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod-vars.yml
@@ -1,0 +1,13 @@
+---
+mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/8e33dac25b2c86f9228a98335b07f45585e51485/k8s/demo/specs/demo-mysql-openebs-plugin.yaml
+
+pod_yaml_alias: demo-mysql-openebs-plugin.yaml
+
+mysql_vol_size: 5G
+
+openebs_iscsi_driver: https://raw.githubusercontent.com/openebs/openebs/v0.2/k8s/lib/plugin/flexvolume/openebs-iscsi
+
+flexvol_driver_alias: openebs-iscsi
+
+flexvol_driver_path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/openebs~openebs-iscsi/
+

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod-vars.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod-vars.yml
@@ -5,9 +5,4 @@ pod_yaml_alias: demo-mysql-openebs-plugin.yaml
 
 mysql_vol_size: 5G
 
-openebs_iscsi_driver: https://raw.githubusercontent.com/openebs/openebs/v0.2/k8s/lib/plugin/flexvolume/openebs-iscsi
-
-flexvol_driver_alias: openebs-iscsi
-
-flexvol_driver_path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/openebs~openebs-iscsi/
 

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
@@ -21,8 +21,19 @@
       args: 
         executable: /bin/bash
       register: result
-      delegate_to: "{{groups['openebs-mayamasters'].0}}"      
+      delegate_to: "{{groups['openebs-mayamasters'].0}}"     
+      ignore_errors: true
+      no_log: true
  
+    - name: 
+      debug: 
+        msg: "Ending play, m-apiserver is unreachable"
+      when: "'m-apiserver' not in result.stderr"
+
+    - name: 
+      meta: end_play
+      when: "'m-apiserver' not in result.stderr"
+    
     - name: Fetch m-API server location    
       shell: "echo {{result.stderr_lines[2]}} | grep -i 'm-apiserver' | awk '{print $4}'"
       register: result_mAPI
@@ -41,37 +52,6 @@
         line: "        size: \"{{mysql_vol_size}}\""
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Get the openebs-iscsi flexvolume driver
-      get_url:
-        url: "{{ openebs_iscsi_driver }}"
-        dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
-        force: yes
-      register: result
-      until:  "'OK' in result.msg"
-      delay: 5
-      retries: 3
-      delegate_to: "{{ item }}"
-      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
-      become: true
-
-    - name: Create flexvol driver destination 
-      file: 
-        path: "{{ flexvol_driver_path }}"
-        state: directory
-        mode: 0755
-      delegate_to: "{{ item }}"
-      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
- 
-    - name: Copy script to flexvol driver location
-      copy: 
-        src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
-        dest: "{{ flexvol_driver_path }}"
-        mode: "u+rwx"
-        force: yes
-        remote_src: yes
-      delegate_to: "{{ item }}"
-      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
-       
     - name: Deploy mysql pod
       shell: source ~/.profile; kubectl create -f demo-mysql-openebs-plugin.yaml
       args: 

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
@@ -1,0 +1,90 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - test-k8s-mysql-pod-vars.yml
+ 
+  tasks:
+    - name: Download YAML for mysql plugin
+      get_url: 
+        url: "{{ mysql_plugin_link }}"
+        dest: "{{ ansible_env.HOME}}/{{ pod_yaml_alias }}"
+        force: yes
+      register: result
+      until:  "'OK' in result.msg"
+      delay: 5
+      retries: 3
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      become: true
+
+    - name: Get m-API server info 
+      shell: source ~/.profile; maya omm-status
+      args: 
+        executable: /bin/bash
+      register: result
+      delegate_to: "{{groups['openebs-mayamasters'].0}}"      
+ 
+    - name: Fetch m-API server location    
+      shell: "echo {{result.stderr_lines[2]}} | grep -i 'm-apiserver' | awk '{print $4}'"
+      register: result_mAPI
+
+    - name: Replace mAPI server location in plugin YAML
+      lineinfile:
+        path: "{{ ansible_env.HOME}}/{{ pod_yaml_alias }}"
+        regexp: "openebsApiUrl:"
+        line: "        openebsApiUrl: \"{{result_mAPI.stdout}}/latest\""
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+            
+    - name: Replace volume size in plugin YAML
+      lineinfile:
+        path: "{{ ansible_env.HOME }}/{{ pod_yaml_alias }}"
+        regexp: "size:"
+        line: "        size: \"{{mysql_vol_size}}\""
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Get the openebs-iscsi flexvolume driver
+      get_url:
+        url: "{{ openebs_iscsi_driver }}"
+        dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+        force: yes
+      register: result
+      until:  "'OK' in result.msg"
+      delay: 5
+      retries: 3
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
+      become: true
+
+    - name: Create flexvol driver destination 
+      file: 
+        path: "{{ flexvol_driver_path }}"
+        state: directory
+        mode: 0755
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
+ 
+    - name: Copy script to flexvol driver location
+      copy: 
+        src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+        dest: "{{ flexvol_driver_path }}"
+        mode: "u+rwx"
+        force: yes
+        remote_src: yes
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups['kubernetes-kubeminions'] }}" 
+       
+    - name: Deploy mysql pod
+      shell: source ~/.profile; kubectl create -f demo-mysql-openebs-plugin.yaml
+      args: 
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Confirm pod status is running
+      shell: source ~/.profile; kubectl get pods
+      args: 
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result
+      until: "'Running' in result.stdout_lines[1]"
+      delay: 100 
+      retries: 3
+      

--- a/e2e/ansible/roles/cleanup/tasks/main.yml
+++ b/e2e/ansible/roles/cleanup/tasks/main.yml
@@ -16,10 +16,10 @@
 - name: Tear down iSCSI sessions
   open_iscsi: 
     login: no
-    target: "{{hostvars[groups['openebs-mayamaster'][0]]['openebs_target_iqn']}}"
+    target: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_iqn']}}"
 
 - name: Remove stale node entries for ISCSI target
-  shell: iscsiadm -m node -T "{{hostvars[groups['openebs-mayamaster'][0]]['openebs_target_iqn']}}" -o delete
+  shell: iscsiadm -m node -T "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_iqn']}}" -o delete
   become: true
 
 - name: Tear down the storage containers
@@ -27,5 +27,5 @@
   args: 
     executable: /bin/bash
   ignore_errors: false 
-  delegate_to: "{{groups['openebs-mayamaster'].0}}"
+  delegate_to: "{{groups['openebs-mayamasters'].0}}"
   tags: ['vol_delete']

--- a/e2e/ansible/roles/fio/tasks/main.yml
+++ b/e2e/ansible/roles/fio/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Establish ISCSI Connection
   open_iscsi:
     show_nodes: yes
-    portal: "{{hostvars[groups['openebs-mayamaster'][0]]['openebs_target_portal']}}"
+    portal: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_portal']}}"
     discover: yes
     login: yes
   register: result

--- a/e2e/ansible/roles/hosts/tasks/main.yml
+++ b/e2e/ansible/roles/hosts/tasks/main.yml
@@ -1,2 +1,2 @@
 - name: Setup Maya      
-  command: maya setup-osh -self-ip={{hostvars[inventory_hostname]['ansible_ssh_host']}} -omm-ips={{hostvars[groups['openebs-mayamaster'][0]]['ansible_ssh_host']}}
+  command: maya setup-osh -self-ip={{hostvars[inventory_hostname]['ansible_ssh_host']}} -omm-ips={{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}

--- a/e2e/ansible/roles/iometer/tasks/main.yml
+++ b/e2e/ansible/roles/iometer/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Establish ISCSI Connection
   open_iscsi:
     show_nodes: yes
-    portal: "{{hostvars[groups['openebs-mayamaster'][0]]['openebs_target_portal']}}"
+    portal: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_portal']}}"
     discover: yes
     login: yes
   register: result

--- a/e2e/ansible/roles/k8s-hosts/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/defaults/main.yml
@@ -11,3 +11,10 @@ k8s_dpkg_packages:
   - kubernetes-cni.deb
   - kubectl.deb
   - kubeadm.deb
+
+openebs_iscsi_driver: https://raw.githubusercontent.com/openebs/openebs/v0.2/k8s/lib/plugin/flexvolume/openebs-iscsi
+
+flexvol_driver_alias: openebs-iscsi
+
+flexvol_driver_path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec/openebs~openebs-iscsi/
+

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -64,6 +64,31 @@
     token: "{{ result_token }}"
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   delegate_facts: True
+
+- name: Get the openebs-iscsi flexvolume driver
+  get_url:
+    url: "{{ openebs_iscsi_driver }}"
+    dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  become: true
+
+- name: Create flexvol driver destination
+  file:
+    path: "{{ flexvol_driver_path }}"
+    state: directory
+    mode: 0755
+
+- name: Copy script to flexvol driver location
+  copy:
+    src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+    dest: "{{ flexvol_driver_path }}"
+    mode: "u+rwx"
+    force: yes
+    remote_src: yes
           
 - name: Reset kubeadm
   command: kubeadm reset

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -17,7 +17,19 @@
   become: true
   delegate_to: 127.0.0.1 
 
-## KUBERNETES ROLE PREPARATION
+## Common preparation tasks
+
+- name: Create files directory in kubernetes role
+  file:
+    path: "{{ playbook_dir }}/roles/{{item}}/files"
+    state: directory
+    mode: 0755
+  with_items:
+    - kubernetes
+    - k8s-master
+    - k8s-hosts
+
+## kubernetes role preparation
 
 - name: Get .deb kubernetes packages google cloud 
   get_url: 

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -33,6 +33,9 @@
     deb: "{{ k8s_images_path }}/{{ item }}"
   with_items: "{{ k8s_dpkg_packages }}"
 
+- name: kubeadm reset before init
+  command: kubeadm reset 
+
 - name: kubeadm init
   script: "{{ configure_scripts[0] }}"
 

--- a/e2e/ansible/roles/vagrant/tasks/main.yml
+++ b/e2e/ansible/roles/vagrant/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: Update Nomad IP in .profile  
   lineinfile:
     destfile : /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/.profile
-    line: export NOMAD_ADDR=http://{{hostvars[groups['openebs-mayamaster'][0]]['ansible_ssh_host']}}:4646
+    line: export NOMAD_ADDR=http://{{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}:4646
     state: present
 
 - name: Update M-APIServer IP in .profile
   lineinfile:
     destfile : /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/.profile
-    line: export MAPI_ADDR=http://{{hostvars[groups['openebs-mayamaster'][0]]['ansible_ssh_host']}}:5656
+    line: export MAPI_ADDR=http://{{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}:5656
     state: present

--- a/e2e/ansible/roles/volume/tasks/main.yml
+++ b/e2e/ansible/roles/volume/tasks/main.yml
@@ -3,7 +3,7 @@
   shell: source ~/.profile; maya vsm-create -name={{openebs_vol_name}} -size={{openebs_vol_size}}
   args:
     executable: /bin/bash
-  delegate_to: "{{groups['openebs-mayamaster'].0}}" 
+  delegate_to: "{{groups['openebs-mayamasters'].0}}" 
 
 - name: Get Volume Info
   shell: source ~/.profile; maya vsm-stats {{openebs_vol_name}}
@@ -13,7 +13,7 @@
   until: "'Online' in result.stdout"
   delay: 60
   retries: 10
-  delegate_to: "{{groups['openebs-mayamaster'].0}}" 
+  delegate_to: "{{groups['openebs-mayamasters'].0}}" 
 
 - name: Fetch Target Portal
   shell: "echo {{result.stdout_lines[4]}} | grep -i 'portal' | awk '{print $2}'"
@@ -27,5 +27,5 @@
   set_fact:
     openebs_target_portal: "{{result_portal.stdout}}"
     openebs_target_iqn: "{{result_iqn.stdout}}"
-  delegate_to: "{{groups['openebs-mayamaster'].0}}"
+  delegate_to: "{{groups['openebs-mayamasters'].0}}"
   delegate_facts: true

--- a/e2e/ansible/run-tests.yml
+++ b/e2e/ansible/run-tests.yml
@@ -8,7 +8,7 @@
 #    a) Volume properties can be set in ./roles/volume/defaults/main.yml 
 #    b) fio run duration can be set in ./roles/fio/defaults/main.yml
 # 
-- include: playbooks/test-fio.yml
+#- include: playbooks/test-fio.yml
 #
 ###########################################################################################
 # TC NAME: test-iometer
@@ -26,3 +26,11 @@
 #- include: playbooks/test-iometer.yml dockerfile_path="{{files_path.stdout}}"
 #
 ###########################################################################################
+# TC NAME: test-k8s-mysql-pod
+# TC DETAILS: Deploys mysql pod on a k8s cluster with storage provisioned by flexvol driver
+# TC NOTES:           
+#    
+#- include: playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
+#
+###########################################################################################
+

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -1,14 +1,24 @@
 ---
 - hosts: openebs-mayamasters
-
   roles:
     - master
     - {role: vagrant, when: is_vagrant_vm | bool} 
 
 - hosts: openebs-mayahosts
-
   roles:
     - hosts
     - {role: vagrant, when: is_vagrant_vm | bool}
 
+- hosts: localhost
+  roles: 
+    - k8s-localhost 
 
+- hosts: kubernetes-kubemasters
+  roles:
+    - k8s-master
+
+- hosts: kubernetes-kubeminions
+  roles: 
+    - k8s-hosts
+
+   

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: openebs-mayamaster
+- hosts: openebs-mayamasters
 
   roles:
     - master


### PR DESCRIPTION
Code Changes : 
----------------

- Creation of a new testcase playbook with associated vars files to deploy mysql pod on kubernetes cluster (test-k8s-mysql-pod.yml, test-k8s-mysql-pod-vars.yml). This is placed in a separate testcase-directory within playbooks folder

- Updates to k8s roles: 
    - k8s-localhost : Create 'files' folder inside k8s roles before placing images,files,scripts,templates in it
    - k8s-master : Added kubeadm reset before performing kubeadm init to avoid error "/var/lib/kubelet is not empty" which caused kubeadm init command to fail
    - k8s-hosts: Added step to install openebs k8s flexvol driver for iscsi

- Updates to maya roles 
     - Edited the tasks inside roles and in playbooks to reflect new naming convention for maya-master group (openebs-mayamasters)

- Included the k8s setup roles as part the setup-openebs playbook

- Included the new mysql pod deployment testcase in run-tests playbook

- Cleaned up the comments in machines.in input file 

Tested On: 
-----------

Bare-metal setup, Non-vagrant Ubuntu 16.04 64 bit VMs

