### PR TITLE
PR #104: Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/roles/hosts/tasks/main.yml
+++ b/e2e/ansible/roles/hosts/tasks/main.yml
@@ -1,2 +1,17 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['openebs-mayamasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name:
+  debug:
+  msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
 - name: Setup Maya      
   command: maya setup-osh -self-ip={{hostvars[inventory_hostname]['ansible_ssh_host']}} -omm-ips={{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -23,6 +23,7 @@
   apt:
     deb: "{{ k8s_images_path }}/{{ item }}"
   with_items: "{{ k8s_dpkg_packages }}"
+  become: true
 
 - name: Get Token Name from Master
   shell: >
@@ -81,6 +82,7 @@
     path: "{{ flexvol_driver_path }}"
     state: directory
     mode: 0755
+  become: true
 
 - name: Copy script to flexvol driver location
   copy:
@@ -89,15 +91,18 @@
     mode: "u+rwx"
     force: yes
     remote_src: yes
+  become: true
           
 - name: Reset kubeadm
   command: kubeadm reset
+  become: true
 
 - name: Setup k8s Hosts 
   script: "configure_k8s_host.sh 
           --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
           --token={{result_token_name.stdout}}.{{result_token.stdout}} 
           --clusterip={{result_cluster.stdout}}"
+  become: true
   notify: 
     - Reload systemd
     - Restart kubelet

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -32,12 +32,15 @@
   apt:
     deb: "{{ k8s_images_path }}/{{ item }}"
   with_items: "{{ k8s_dpkg_packages }}"
+  become: true
 
 - name: kubeadm reset before init
-  command: kubeadm reset 
+  command: kubeadm reset
+  become: true
 
 - name: kubeadm init
   script: "{{ configure_scripts[0] }}"
+  become: true
 
 - name: Copy k8s credentials to $HOME
   script: "{{ configure_scripts[1] }}"

--- a/e2e/ansible/roles/localhost/defaults/main.yml
+++ b/e2e/ansible/roles/localhost/defaults/main.yml
@@ -2,7 +2,6 @@
 deb_local_packages:
   - docker.io
   - open-iscsi
-  - fio
 
 pip_local_packages:
   - 'docker-py==1.9.0'


### PR DESCRIPTION
Added permission escalation for operations requiring root privileges. Verifying running status of mayamaster before executing the setup-osh command.

Code Changes:
----------------

- Add check to verify whether mayamaster is running before running the setup-osh command.
- Add permission escalation for package installations, command and file operations requiring root privileges.
- Remove package 'fio' from dependency list as this package is no longer required.

Tested On:
-----------

Developer Laptop - (Using Vagrant Boxes- Ubuntu)

Details of the fix:
------------------

For some of the operations where ansible requires root privileges, ansible fails to run those tasks without  the become: true attribute being set.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>