### PR TITLE
PR #104 Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -7,7 +7,7 @@ run_demo: true
 #Option specifically for vagrant VMs.
 #Accepted Entries(true, false): default:false
 
-is_vagrant_vm: false
+is_vagrant_vm: true 
   
 #User-defined size for the volume that openebs creates:
 #Accepted Entries(Valid Volume Sizes): default:5G

--- a/e2e/ansible/inventory/machines.in
+++ b/e2e/ansible/inventory/machines.in
@@ -8,16 +8,23 @@
 #
 # NOTES:
 #
-# 1. Please ensure supported host codes are provided, failing which
+# 1. Ensure supported host codes are provided, failing which
 # the inventory generation will not proceed. Current supported
-# codes include 'mayamaster', 'mayahost', 'kubemaster', 'kubeminion'
+# codes include 'localhost, 'mayamaster', 'mayahost', 'kubemaster', 
+# 'kubeminion'
 #
-# 2. A dictionary of supported codes is present in the python script
-# generate_inventory.py, which can be updated by interested users to 
-# include additional hostcodes 
+# 2. The 'localhost' hostcode is a mandataory line in this file
+# and has a default IP of 127.0.0.1
 #
-# 3. Lines can be commented (such as these) by inserting '#' symbol
+# 3. A dictionary of supported codes ("SupportedHostCodes") is present 
+# in the python script generate_inventory.py, which can be updated by 
+# interested users to include additional hostcodes
+#
+# 4. Lines can be commented (such as these) by inserting '#' symbol
 # before the host code
+#
+# 5. Ensure the environment variables are set in the .profile of the 
+# ansible user
 #
 ################################################################################
 
@@ -26,7 +33,7 @@
 #host,20.10.26.12,USER_NAME,USER_PASSWORD
 #host,20.10.26.14,USER_NAME,USER_PASSWORD
 
-
+localhost,127.0.0.1,LOCAL_USER_NAME,LOCAL_USER_PASSWORD
 mayamaster,20.10.49.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
 mayahost,20.10.49.12,USER_NAME,USER_PASSWORD
 mayahost,20.10.49.13,USER_NAME,USER_PASSWORD

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod-vars.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod-vars.yml
@@ -1,0 +1,8 @@
+---
+percona_mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/88d02b8bfea4e5ef0ee94d4359a180f1c203684d/k8s/demo/specs/demo-percona-mysql-openebs-plugin.yaml
+
+pod_yaml_alias: demo-percona-mysql-openebs-plugin.yaml
+
+percona_mysql_vol_size: 5G
+
+

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
  
   vars_files: 
-    - test-k8s-mysql-pod-vars.yml
+    - test-k8s-percona-mysql-pod-vars.yml
  
   tasks:
 
@@ -14,7 +14,7 @@
 
     - name: Download YAML for mysql plugin
       get_url: 
-        url: "{{ mysql_plugin_link }}"
+        url: "{{ percona_mysql_plugin_link }}"
         dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
         force: yes
       register: result
@@ -56,10 +56,10 @@
       lineinfile:
         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
         regexp: "size:"
-        line: "        size: \"{{mysql_vol_size}}\""
+        line: "        size: \"{{percona_mysql_vol_size}}\""
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Deploy mysql pod
+    - name: Deploy percona mysql pod
       shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
       args: 
         executable: /bin/bash

--- a/e2e/ansible/roles/cleanup/tasks/main.yml
+++ b/e2e/ansible/roles/cleanup/tasks/main.yml
@@ -17,6 +17,7 @@
   open_iscsi: 
     login: no
     target: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_iqn']}}"
+  become: true
 
 - name: Remove stale node entries for ISCSI target
   shell: iscsiadm -m node -T "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_iqn']}}" -o delete
@@ -28,4 +29,3 @@
     executable: /bin/bash
   ignore_errors: false 
   delegate_to: "{{groups['openebs-mayamasters'].0}}"
-  tags: ['vol_delete']

--- a/e2e/ansible/roles/common/tasks/main.yml
+++ b/e2e/ansible/roles/common/tasks/main.yml
@@ -13,25 +13,23 @@
 
 - name: Create Directory
   file:
-    path: /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/demo/openebs/
+    path: "{{ansible_env.HOME}}/demo/openebs/"
     state: directory
-  become: true
 
 - name: Download Maya
   get_url:
     url: "{{ item }}"
-    dest:  /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/demo/openebs/
+    dest:  "{{ansible_env.HOME}}/demo/openebs/"
     force: yes
   register: result
   until:  "'OK' in result.msg"
   delay: 5
   retries: 3
   with_items: "{{ openebs_maya_url }}"
-  become: true
 
 - name: Unzip Maya
   unarchive:
-    src: /home/{{ hostvars[inventory_hostname]['ansible_ssh_user'] }}/demo/openebs/maya-linux_amd64.zip
+    src: "{{ansible_env.HOME}}/demo/openebs/maya-linux_amd64.zip"
     dest: /usr/bin/
     remote_src: True
   become: true

--- a/e2e/ansible/roles/hosts/tasks/main.yml
+++ b/e2e/ansible/roles/hosts/tasks/main.yml
@@ -1,2 +1,18 @@
+---
+- name: Get Master Status
+  command: ansible "{{groups['openebs-mayamasters'].0}}" -m ping
+  register: result_status
+  delegate_to: 127.0.0.1
+
+- name:
+  debug:
+    msg: "Ending play, Master UNREACHABLE."
+  when: "'FAILED' in result_status.stdout"
+
+- name: Ending Playbook Run - Master is not UP.
+  meta: end_play
+  when: "'FAILED' in result_status.stdout"
+
 - name: Setup Maya      
   command: maya setup-osh -self-ip={{hostvars[inventory_hostname]['ansible_ssh_host']}} -omm-ips={{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}
+  become: true

--- a/e2e/ansible/roles/master/handlers/main.yml
+++ b/e2e/ansible/roles/master/handlers/main.yml
@@ -4,3 +4,4 @@
     name: m-apiserver
     state: restarted
     enabled: yes
+  become: true

--- a/e2e/ansible/roles/master/tasks/main.yml
+++ b/e2e/ansible/roles/master/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Setup Maya      
   command: maya setup-omm -self-ip="{{hostvars[inventory_hostname]['ansible_ssh_host']}}"
+  become: true
 
 - name: Update INI file
   ini_file:

--- a/e2e/ansible/roles/prerequisites/tasks/main.yml
+++ b/e2e/ansible/roles/prerequisites/tasks/main.yml
@@ -4,6 +4,5 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ pip_pre_packages }}"
-  become: true
   delegate_to: 127.0.0.1
 

--- a/e2e/ansible/roles/vagrant/tasks/main.yml
+++ b/e2e/ansible/roles/vagrant/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Update Nomad IP in .profile  
   lineinfile:
-    destfile : /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/.profile
+    destfile : "{{ansible_env.HOME}}/.profile"
     line: export NOMAD_ADDR=http://{{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}:4646
     state: present
 
 - name: Update M-APIServer IP in .profile
   lineinfile:
-    destfile : /home/{{hostvars[inventory_hostname]['ansible_ssh_user']}}/.profile
+    destfile : "{{ansible_env.HOME}}/.profile"
     line: export MAPI_ADDR=http://{{hostvars[groups['openebs-mayamasters'][0]]['ansible_ssh_host']}}:5656
     state: present

--- a/e2e/ansible/run-tests.yml
+++ b/e2e/ansible/run-tests.yml
@@ -33,4 +33,10 @@
 #- include: playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
 #
 ###########################################################################################
-
+# TC NAME: test-k8s-percona-mysql-pod
+# TC DETAILS: Deploys percona pod on k8s cluster with storage provisioned by flexvol driver
+# TC NOTES:           
+#    
+#- include: playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod.yml
+#
+###########################################################################################


### PR DESCRIPTION
Code Changes:
----------------

- Updated inventory generation file (generate-inventory.py) to include localhost details
  and added 'ansible_become_pass' arg for all hosts. This is needed for tasks that run
  with privilege escalation in case of non-root users

- Changed "is_vagrant_vm" variable to true in global vars file all.yml to facilitate updates
  to .profile of ansible_user

- Updated hosts role to check for status of maya-master before joining cluster

- Updated the vagrant role to use {{ansible_env.HOME}} ansible variable instead od constructing
  the ansible user's home directory path

- Updated the following roles to use the privilege escalation directive only where absolutely
  necessary, while removing them for other steps (if present). This was done to facilitate
  successful playbook execution on non-root users

   - master, hosts, common, prerequisites, cleanup

- Updated the test-k8s-mysql-pod testcase playbook to use $HOME of k8s-master machine instead of
  ansible user's home

- Added a new testcase playbook along with associated vars file to deploy percona-mysql pod on k8s
  cluster

- Updated the run_tests.yml playbook to include testcase block for test-k8s-percona-mysql-pod

- Updated the machines.in template with entry for localhost. Also updated the notes with regard
  to the localhost entry

Tested On:
-----------
Bare-metal/Non-vagrant VMs with
 - Non root users on all boxes - test harness/localhost, maya/k8s master, maya/k8s hosts