### PR TITLE
PR #104: Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -75,7 +75,6 @@
   until:  "'OK' in result.msg"
   delay: 5
   retries: 3
-  become: true
 
 - name: Create flexvol driver destination
   file:

--- a/e2e/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/defaults/main.yml
@@ -43,7 +43,6 @@ k8s_images:
 # Links for scripts to be placed into K8s-master role's .files 
 
 k8s_master_scripts: 
-  - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_cred.sh
   - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_master.sh
   - https://raw.githubusercontent.com/openebs/openebs/master/k8s/lib/scripts/configure_k8s_weave.sh
 

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -14,7 +14,6 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ pip_local_packages }}"
-  become: true
   delegate_to: 127.0.0.1 
 
 ## Common preparation tasks
@@ -43,7 +42,6 @@
   with_together: 
     - "{{ k8s_deb_packages }}"
     - "{{ k8s_deb_package_alias }}"
-  become: true
 
 - name: Fetch K8s images from gcr.io/google_containers
   docker_image: 
@@ -92,7 +90,6 @@
   delay: 5
   retries: 3 
   with_items: "{{ k8s_master_scripts }}"
-  become: true
 
 - name: Fetch weave images from dockerhub
   docker_image:
@@ -138,7 +135,6 @@
   until:  "'OK' in result.msg"
   delay: 5
   retries: 3
-  become: true
 
 ## K8S-HOSTS ROLE PREPARATION
 
@@ -152,8 +148,19 @@
   delay: 5
   retries: 3 
   with_items: "{{ k8s_host_scripts }}"
-  become: true
-  
-  
 
-  
+- name: Get Current User
+  command: whoami 
+  register: user
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ item }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  with_items:
+    - "{{ playbook_dir }}/roles/k8s-hosts/files"
+    - "{{ playbook_dir }}/roles/k8s-master/files"
+    - "{{ playbook_dir }}/roles/kubernetes/files"

--- a/e2e/ansible/roles/k8s-master/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-master/defaults/main.yml
@@ -4,7 +4,6 @@
 
 configure_scripts:
   - configure_k8s_master.sh
-  - configure_k8s_cred.sh
   - configure_k8s_weave.sh
 
 weave_depends:

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -4,15 +4,20 @@
     path: "{{ weave_images_path }}"
     state: directory
 
-- name: Copy TAR and Pod YAML to remote
+- name: Copy TAR to remote
   copy:
-    src: "{{ item }}"
+    src: "{{ weave_depends[0] }}"
     dest: "{{ weave_images_path }}"
-  with_items: "{{ weave_depends }}"
+  become: true
+
+- name: Copy Pod YAML to remote
+  copy:
+    src: "{{ weave_depends[1] }}"
+    dest: "{{ weave_images_path }}"
 
 - name: Copy Script to remote
   copy:
-    src: "{{ configure_scripts[2] }}"
+    src: "{{ configure_scripts[1] }}"
     dest: "{{ k8s_images_path }}"
     mode: "u+rwx"
 
@@ -42,10 +47,32 @@
   script: "{{ configure_scripts[0] }}"
   become: true
 
-- name: Copy k8s credentials to $HOME
-  script: "{{ configure_scripts[1] }}"
+- name: Get Current User
+  command: whoami
+  register: user
+
+- name: Copy k8s credentials to $HOME 
+  copy:
+    src: "/etc/kubernetes/admin.conf" 
+    remote_src: True
+    dest: "{{ ansible_env.HOME}}"
+  become: true
+
+- name: Change file permissions
+  file:
+    path: "{{ ansible_env.HOME }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"     
+    state: directory
+  become: true
+
+- name: Update KUBECONFIG in .profile
+  lineinfile:
+    destfile : "{{ansible_env.HOME}}/.profile"
+    line: export KUBECONFIG=$HOME/admin.conf
+    state: present
 
 - name: Patch kube-proxy for CNI Networks
-  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[2] }}" 
+  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}" 
   args:
     executable: /bin/bash


### PR DESCRIPTION
Converted the k8s-cred logic into ansible tasks and removed the dependency on the script. Updating the permission escalalation changes to work for root and non-root users.

Code Changes:
----------------
- Implemented the k8s-cred script logic into ansible and removed its dependency from the list of items
  to be downloaded from the git repository.
- Revisiting permission escalations for package installations, command and file operations and adding become
  as true only at the required places.
- Added code to change the owner for the files folder to the current user, so that the copy module will not fail
  even if any file in those folders has a root permission only.

Tested On:
-----------
Developer Laptop - (Using Vagrant Boxes- Ubuntu)

Details of the fix:
------------------
For some of the operations where ansible requires root privileges, ansible fails to run those tasks without the become: true attribute being set.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>