### PR TITLE
 PR#104 Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -1,26 +1,42 @@
 ---
-- hosts: localhost
+## Create the hosts file
 
+- hosts: localhost
   roles:
     - inventory
+
+## Setup the OpenEBS maya master
       
 - hosts: openebs-mayamasters
-
   roles:
     - master
     - {role: vagrant, when: is_vagrant_vm | bool} 
 
-- hosts: openebs-mayahosts
+## Setup the OpenEBS storage nodes
 
+- hosts: openebs-mayahosts
   roles:
     - hosts
     - {role: vagrant, when: is_vagrant_vm | bool}
 
-- hosts: localhost  
+## Prepare the test harness for kubernetes role execution
 
+- hosts: localhost
   roles:
-    - {role: localhost, when: run_demo | bool} 
-    - {role: volume, when: run_demo | bool}
-    - {role: fio, when: run_demo | bool}
-    - {role: cleanup, when: run_demo | bool}
+    - k8s-localhost
 
+## Setup the kubernetes master
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - k8s-master
+
+## Setup the kubernetes minions
+
+- hosts: kubernetes-kubeminions
+  roles:
+    - k8s-hosts
+
+## Run the OpenEBS test suite
+
+- include: run-tests.yml 

--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -1,15 +1,9 @@
 ---
-#Option to run the sample demo of OpenEBS
-#Accepted Entries(true, false): default:true
+#########################################
+# OpenEBS Deployment Specifications     #
+#########################################
 
-run_demo: true
-
-#Option specifically for vagrant VMs.
-#Accepted Entries(true, false): default:false
-
-is_vagrant_vm: true 
-  
-#User-defined size for the volume that openebs creates:
+#User-defined size for the volume that openebs creates
 #Accepted Entries(Valid Volume Sizes): default:5G
 
 openebs_vol_size: 5G
@@ -17,9 +11,38 @@ openebs_vol_size: 5G
 #Available CIDR for allocating IP Addresses for containers
 #Accepted Entries (Valid CIDR): default:172.28.128.1/24
 
-cn_network_cidr: 172.28.128.1/24 
+cn_network_cidr: 20.10.49.110/25
 
-#Network interface for CIDR.
+#Network interface for CIDR
 #Accepted Entries (Valid Network Interface): default:enp0s8
 
-cn_interface: enp0s8
+cn_interface: ens160
+
+#Mode of openEBS deployment 
+#Accepted Entries (dedicated, hyperconverged): default:dedicated 
+
+deployment_mode: dedicated
+
+#Option specifically for vagrant VMs
+#Accepted Entries(true, false): default:false
+
+is_vagrant_vm: true
+
+#########################################
+# Ansible Runtime Specifications        #
+#########################################
+
+#Option to run the sample demo of OpenEBS
+#Accepted Entries(true, false): default:true
+
+run_demo: true
+
+#########################################
+# OpenEBS Test Specifications           #
+#########################################
+
+#Option to run cleanup functions in tests
+#Accepted Entries(true, false): default:true
+
+clean: true
+

--- a/e2e/ansible/playbooks/test-fio/fio-cleanup.yml
+++ b/e2e/ansible/playbooks/test-fio/fio-cleanup.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost  
+
+  vars_files:
+    - fio-vars.yml
+
+  roles:
+    - {role: cleanup, when: run_demo | bool}
+

--- a/e2e/ansible/playbooks/test-fio/fio-prerequisites.yml
+++ b/e2e/ansible/playbooks/test-fio/fio-prerequisites.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost  
+
+  roles:
+    - {role: localhost, when: run_demo | bool} 
+

--- a/e2e/ansible/playbooks/test-fio/fio-vars.yml
+++ b/e2e/ansible/playbooks/test-fio/fio-vars.yml
@@ -1,0 +1,2 @@
+---
+io_run_duration: 120 #in sec

--- a/e2e/ansible/playbooks/test-fio/fio.yml
+++ b/e2e/ansible/playbooks/test-fio/fio.yml
@@ -1,9 +1,10 @@
 ---
 - hosts: localhost  
 
+  vars_files: 
+    - fio-vars.yml
+
   roles:
-    - {role: localhost, when: run_demo | bool} 
     - {role: volume, when: run_demo | bool}
     - {role: fio, when: run_demo | bool}
-    - {role: cleanup, when: run_demo | bool}
 

--- a/e2e/ansible/playbooks/test-iometer/iometer-cleanup.yml
+++ b/e2e/ansible/playbooks/test-iometer/iometer-cleanup.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost  
+
+  roles:
+    - {role: cleanup, when: run_demo | bool}
+

--- a/e2e/ansible/playbooks/test-iometer/iometer-prerequisites.yml
+++ b/e2e/ansible/playbooks/test-iometer/iometer-prerequisites.yml
@@ -1,0 +1,6 @@
+---
+- hosts: localhost  
+
+  roles:
+    - {role: localhost, when: run_demo | bool} 
+

--- a/e2e/ansible/playbooks/test-iometer/iometer.yml
+++ b/e2e/ansible/playbooks/test-iometer/iometer.yml
@@ -2,8 +2,6 @@
 - hosts: localhost  
 
   roles:
-    - {role: localhost, when: run_demo | bool} 
     - {role: volume, when: run_demo | bool}
     - {role: iometer, when: run_demo | bool}
-    - {role: cleanup, when: run_demo | bool}
 

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/Dockerfile
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu
+MAINTAINER OpenEBS
+RUN apt-get update
+RUN apt-get install -y mysql-client timelimit 
+COPY MySQLLoadGenerate.sh /

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/MySQLLoadGenerate.sh
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/MySQLLoadGenerate.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+MySQLDump()
+{
+while true
+do
+ mysql -uroot -pk8sDem0 -h $pod_ip -e "INSERT INTO Hardware select * FROM Hardware;" Inventory
+ sleep 2
+done
+}
+
+PrepareMySQL()
+{
+mysql -uroot -pk8sDem0 -h $pod_ip -e "CREATE DATABASE Inventory;"
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"CREATE TABLE Hardware (Name VARCHAR(20),HWtype VARCHAR(20),Model VARCHAR(20));" Inventory 
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"INSERT INTO Hardware (Name,HWtype,Model) VALUES ('TestBox','Server','DellR820');" Inventory
+}
+
+pod_ip=$1
+PrepareMySQL;
+MySQLDump; 
+

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+
+  vars_files:
+    - k8s-mysql-pod-vars.yml 
+
+  tasks: 
+    
+    - name: Wait {{ mysql_load_duration }} sec for I/O completion
+      wait_for:
+        timeout: "{{ mysql_load_duration }}"
+
+    - name: Delete mysql pod 
+      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Confirm pod has been deleted
+      shell: source ~/.profile; kubectl get pods
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result
+      until: "'mysql' not in result.stdout"
+      delay: 10
+      retries: 3
+
+    - name: Tear down the OpenEBS volume
+      shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
+      args:
+        executable: /bin/bash
+      ignore_errors: false
+      delegate_to: "{{groups['openebs-mayamasters'].0}}"
+
+   

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
@@ -1,0 +1,23 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - k8s-mysql-pod-vars.yml 
+ 
+  tasks:
+    
+    - name: Install python-pip on K8S-minion
+      apt:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ deb_packages }}"
+      become: true 
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: Install PIP packages on K8s-minion
+      pip: 
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ pip_packages }}"
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
+      become: true  
+      

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-vars.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod-vars.yml
@@ -5,4 +5,15 @@ pod_yaml_alias: demo-mysql-openebs-plugin.yaml
 
 mysql_vol_size: 5G
 
+files:
+  - Dockerfile
+  - MySQLLoadGenerate.sh
+
+deb_packages:
+  - python-pip
+
+pip_packages:
+  - 'docker-py==1.9.0'
+
+mysql_load_duration: 120
 

--- a/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod.yml
+++ b/e2e/ansible/playbooks/test-k8s-mysql-pod/k8s-mysql-pod.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
  
   vars_files: 
-    - test-k8s-mysql-pod-vars.yml
+    - k8s-mysql-pod-vars.yml 
  
   tasks:
 
@@ -71,7 +71,53 @@
         executable: /bin/bash
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
       register: result
-      until: "'Running' in result.stdout_lines[1]"
+      until: "'mysql' and 'Running' in result.stdout_lines[1]"
       delay: 300 
       retries: 6
-      
+     
+    - name: Get $HOME of K8s minion for kubernetes user
+      shell: source ~/.profile; echo $HOME
+      args:
+        executable: /bin/bash
+      register: result_kube_home
+      delegate_to: "{{groups['kubernetes-kubeminions'].0}}"      
+
+    - name: Get IP address of mysql pod
+      shell: source ~/.profile; kubectl describe pod mysql
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result_IP
+
+    - name: Set IP of Pod to variable
+      set_fact:
+        pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
+
+    - name: Copy files into kube minion
+      copy:
+        src: "{{ item }}"
+        dest: "{{ result_kube_home.stdout }}"
+      with_items: "{{ files }}"
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: Build the mysql-client image
+      docker_image:
+        name: mysql-client
+        state: present
+        path: "{{ result_kube_home.stdout }}"
+        rm: true
+        timeout: 600
+      become: true
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: mysql-client docker instantiate
+      docker_container:
+        name: client
+        image: mysql-client
+        network_mode: host
+        command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
+        state: started
+      become: true
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/Dockerfile
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu
+MAINTAINER OpenEBS
+RUN apt-get update
+RUN apt-get install -y mysql-client timelimit 
+COPY MySQLLoadGenerate.sh /

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/MySQLLoadGenerate.sh
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/MySQLLoadGenerate.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+MySQLDump()
+{
+while true
+do
+ mysql -uroot -pk8sDem0 -h $pod_ip -e "INSERT INTO Hardware select * FROM Hardware;" Inventory
+ sleep 2
+done
+}
+
+PrepareMySQL()
+{
+mysql -uroot -pk8sDem0 -h $pod_ip -e "CREATE DATABASE Inventory;"
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"CREATE TABLE Hardware (Name VARCHAR(20),HWtype VARCHAR(20),Model VARCHAR(20));" Inventory 
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"INSERT INTO Hardware (Name,HWtype,Model) VALUES ('TestBox','Server','DellR820');" Inventory
+}
+
+pod_ip=$1
+PrepareMySQL;
+MySQLDump; 
+

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+
+  vars_files:
+    - k8s-percona-pod-vars.yml 
+
+  tasks:
+
+    - name: Wait {{ mysql_load_duration }} sec for I/O completion
+      wait_for:
+        timeout: "{{ mysql_load_duration }}" 
+
+    - name: Delete percona mysql pod 
+      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Confirm percona pod has been deleted
+      shell: source ~/.profile; kubectl get pods
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result
+      until: "'percona' not in result.stdout"
+      delay: 10
+      retries: 3
+
+    - name: Tear down the OpenEBS volume
+      shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
+      args:
+        executable: /bin/bash
+      ignore_errors: false
+      delegate_to: "{{groups['openebs-mayamasters'].0}}"
+
+   

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,0 +1,23 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - k8s-percona-pod-vars.yml 
+ 
+  tasks:
+    
+    - name: Install python-pip on K8S-minion
+      apt:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ deb_packages }}"
+      become: true 
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: Install PIP packages on K8s-minion
+      pip: 
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ pip_packages }}"
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
+      become: true  
+      

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
@@ -5,4 +5,15 @@ pod_yaml_alias: demo-percona-mysql-openebs-plugin.yaml
 
 percona_mysql_vol_size: 5G
 
+files: 
+  - Dockerfile
+  - MySQLLoadGenerate.sh
+
+deb_packages:
+  - python-pip
+  
+pip_packages:
+  - 'docker-py==1.9.0'
+
+mysql_load_duration: 120
 

--- a/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
  
   vars_files: 
-    - test-k8s-percona-mysql-pod-vars.yml
+    - k8s-percona-pod-vars.yml 
  
   tasks:
 
@@ -71,7 +71,51 @@
         executable: /bin/bash
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
       register: result
-      until: "'Running' in result.stdout_lines[1]"
+      until: "'percona' and 'Running' in result.stdout_lines[1]"
       delay: 300 
       retries: 6
-      
+     
+    - name: Get $HOME of K8s minion for kubernetes user
+      shell: source ~/.profile; echo $HOME
+      args:
+        executable: /bin/bash
+      register: result_kube_home
+      delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+    - name: Get IP address of mysql pod
+      shell: source ~/.profile; kubectl describe pod percona 
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result_IP
+
+    - name: Set IP of Pod to variable
+      set_fact:
+        pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
+
+    - name: Copy files into kube minion
+      copy:
+        src: "{{ item }}"
+        dest: "{{ result_kube_home.stdout }}"
+      with_items: "{{ files }}"
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: Build the mysql-client image
+      docker_image:
+        name: mysql-client
+        state: present
+        path: "{{ result_kube_home.stdout }}"
+        rm: true
+        timeout: 600
+      become: true
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+    - name: mysql-client docker instantiate
+      docker_container:
+        name: client
+        image: mysql-client
+        network_mode: host
+        command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
+        state: started
+      become: true
+      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"

--- a/e2e/ansible/roles/cleanup/tasks/main.yml
+++ b/e2e/ansible/roles/cleanup/tasks/main.yml
@@ -1,11 +1,7 @@
 ---
-- name: Wait until I/O completion
+- name: Wait {{ io_run_duration }} sec for I/O completion
   wait_for:
-    timeout: 120 
-
-- name: Confirm cleanup step
-  pause:
-    prompt: 'Please confirm you want to proceed with cleanup! Press return to continue. Press Ctrl+c and then "a" to abort'
+    timeout: "{{ io_run_duration }}"
 
 - name: Unmount the ext4 filesystem
   mount: 
@@ -16,6 +12,7 @@
 - name: Tear down iSCSI sessions
   open_iscsi: 
     login: no
+    portal: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_portal']}}"
     target: "{{hostvars[groups['openebs-mayamasters'][0]]['openebs_target_iqn']}}"
   become: true
 

--- a/e2e/ansible/roles/fio/defaults/main.yml
+++ b/e2e/ansible/roles/fio/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 openebs_image: openebs/tests-fio
 
-fio_run_duration: 300 #in sec

--- a/e2e/ansible/roles/fio/tasks/main.yml
+++ b/e2e/ansible/roles/fio/tasks/main.yml
@@ -44,7 +44,7 @@
   docker_container:
     name: fio-runner
     image: "{{openebs_image}}"
-    command: /fio_runner.sh Basic "{{fio_run_duration}}" 
+    command: /fio_runner.sh Basic "{{io_run_duration}}" 
     volumes:
       - /mnt/iscsi:/datadir1
     state: started

--- a/e2e/ansible/run-iometer-demo.yml
+++ b/e2e/ansible/run-iometer-demo.yml
@@ -1,0 +1,18 @@
+###########################################################################################
+# PLAYBOOK NAME: iometer-demo
+# PLAYBOOK DETAILS: Sets up env for IOmeter run on the storage by running dynamo from container
+# PLAYBOOK NOTES:
+#    a) Keep IOmeter application started on a windows machine before running playbook
+#    b) Windows IOmeter host IP address can be set in ./roles/iometer/defaults/main.yml
+#    c) Volume properties can be set in ./roles/volume/defaults/main.yml
+#
+#- include: playbooks/test-iometer/iometer-prerequisites.yml
+#
+#- hosts: localhost
+#  tasks:
+#     - shell: echo "{{hostvars['localhost'].playbook_dir}}"/files
+#       register: files_path
+#
+#- include: playbooks/test-iometer/iometer.yml dockerfile_path="{{files_path.stdout}}"
+#
+###########################################################################################

--- a/e2e/ansible/run-tests.yml
+++ b/e2e/ansible/run-tests.yml
@@ -8,35 +8,35 @@
 #    a) Volume properties can be set in ./roles/volume/defaults/main.yml 
 #    b) fio run duration can be set in ./roles/fio/defaults/main.yml
 # 
-#- include: playbooks/test-fio.yml
+#- include: playbooks/test-fio/fio-prerequisites.yml
 #
-###########################################################################################
-# TC NAME: test-iometer
-# TC DETAILS: Sets up env for IOmeter run on the storage by running dynamo from container
-# TC NOTES: 
-#    a) Keep IOmeter application started on a windows machine before running playbook  
-#    b) Windows IOmeter host IP address can be set in ./roles/iometer/defaults/main.yml
-#    c) Volume properties can be set in ./roles/volume/defaults/main.yml
+#- include: playbooks/test-fio/fio.yml
 #
-#- hosts: localhost
-#  tasks:
-#     - shell: echo "{{hostvars['localhost'].playbook_dir}}"/files
-#       register: files_path
-#
-#- include: playbooks/test-iometer.yml dockerfile_path="{{files_path.stdout}}"
+#- include: playbooks/test-fio/fio-cleanup.yml
+#  when: clean | bool
 #
 ###########################################################################################
 # TC NAME: test-k8s-mysql-pod
 # TC DETAILS: Deploys mysql pod on a k8s cluster with storage provisioned by flexvol driver
 # TC NOTES:           
 #    
-#- include: playbooks/test-k8s-mysql-pod/test-k8s-mysql-pod.yml
+#- include: playbooks/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
+#
+#- include: playbooks/test-k8s-mysql-pod/k8s-mysql-pod.yml
+#
+#- include: playbooks/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
+#  when: clean | bool
 #
 ###########################################################################################
 # TC NAME: test-k8s-percona-mysql-pod
 # TC DETAILS: Deploys percona pod on k8s cluster with storage provisioned by flexvol driver
 # TC NOTES:           
 #    
-#- include: playbooks/test-k8s-percona-mysql-pod/test-k8s-percona-mysql-pod.yml
+#- include: playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+#
+#- include: playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+#
+#- include: playbooks/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+#  when: clean | bool
 #
 ###########################################################################################


### PR DESCRIPTION
Code Changes:
----------------

- Improved the k8s pod testcases (mysql, percona) to perform load generation
  for a specified duration from a mysql-client container that runs on a k8s
  minion. A shell script from within the mysql-client container creates sample
  hardware inventory database and fills it.

  (Above tests include a docker build step to create the mysql-client container,
   this will be optimized to pull the image from a test-repo once it is created)

- Added a structure to the testcase directories. Now each testcase will have
  its own vars, pre-requisites,cleanup .yml/playbooks and auxiliary files in
  addition to the test playbook itself

- Removed the I/O run duration variable (fio_run_duration) from the fio role
  and added it as a testcase specific variable (io_run_duration in fio_vars.yml)
  Also updated the cleanup role in lieu of above changes

- Modified the global variable specification file all.yml based on general
  best-practices to include separate sections for deployment, test, run-time
  variables. This is expected to scale/evolve with additional sections and
  variables

- Added two new global variables into all.yml

   - 'clean' to specify whether or not the cleanup is performed during tests
   - 'mode' to specify openebs maya and storage node deployment mode,
     i.e., either dedicated OR hyperconverged (i.e., as k8s pods)

- Updated the run-tests playbook to reflect the new testcase structure

- Removed the iometer test into a separate demo-playbook (run-iometer-demo.yml)
  in the ansible directory. This is considering the fact that it is more of a
  demo use-case and is not intended to part of the CI run

- Updated the ci.yml to include steps for kubernetes setup and invoke the test
  suite

Changes tested on:
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs  as non-root user on test harness and target hosts