### PR TITLE
PR#104 Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/openebs-on-premise-deployment-guide.md
+++ b/e2e/ansible/openebs-on-premise-deployment-guide.md
@@ -30,7 +30,7 @@ The following instructions have been verified on:
 
 - All linux machines are required to have : 
   
-  - Basic development packages (dpkg-dev,gcc,g++,libc6-dev,make)
+  - Basic development packages (dpkg-dev,gcc,g++,libc6-dev,make,libssl-dev,sshpass)
   - Python2.7-minimal 
   - SSH services enabled
   

--- a/e2e/ansible/plugins/callback/openebs.py
+++ b/e2e/ansible/plugins/callback/openebs.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 
 
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+from ansible import constants as C
 
 #Implementation of Custom Class that inherits the 'default' stdout_callback plugin 
 #and overrides the v2_runner_retry api for displaying the 'FAILED - RETRYING' only 
@@ -22,3 +23,25 @@ class CallbackModule(CallbackModule_default):
         if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
            msg+= "Result was: %s" % self._dump_results(result._result)
         self._display.v('%s' %(msg))
+
+    def v2_runner_on_skipped(self, result):
+
+        if C.DISPLAY_SKIPPED_HOSTS:
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+                msg = "skipping: [%s] => %s" % (result._host.get_name(), self._dump_results(result._result))
+                self._display.display(msg, color=C.COLOR_SKIP)
+            else: 
+                self._display.display("skipping task..", color=C.COLOR_SKIP)
+
+    def v2_runner_item_on_skipped(self, result):
+        
+        if C.DISPLAY_SKIPPED_HOSTS:
+            if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
+                msg = "skipping: [%s] => (item=%s) => %s" % (result._host.get_name(), self._get_item(result._result), self._dump_results(result._result))
+                self._display.display(msg, color=C.COLOR_SKIP)
+
+
+
+
+
+

--- a/e2e/ansible/roles/k8s-openebs-cleanup/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-cleanup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+openebs_operator_alias: openebs-operator.yaml 
+
+

--- a/e2e/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Delete the openebs operator 
+  shell: source ~/.profile; kubectl delete -f {{ openebs_operator_alias }}
+  args: 
+    executable: /bin/bash
+
+- name: Confirm pod has been deleted
+  shell: source ~/.profile; kubectl get pods 
+  args:
+    executable: /bin/bash
+  register: result
+  until: "'maya-apiserver' not in result.stdout"
+  delay: 10
+  retries: 3
+
+
+  
+

--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+
+openebs_operator_alias: openebs-operator.yaml 
+
+

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+- name: Download YAML for openebs operator
+  get_url:
+    url: "{{ openebs_operator_link }}"
+    dest: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
+- name: Get kubernetes master name
+  shell: hostname
+  args:
+    executable: /bin/bash
+  register: result
+
+- name: Get kubernetes master status
+  shell: source ~/.profile; kubectl get nodes | grep {{ result.stdout.lower()}} | awk '{print $2}'
+  args:
+    executable: /bin/bash
+  register: result
+
+- name: 
+  debug: 
+    msg: "Ending play, K8S Master NOT READY"
+  when: result.stdout != "Ready"
+
+- name: Ending Playbook Run - K8S master is NOT READY
+  meta: end_play
+  when: result.stdout != "Ready"
+
+- name: Deploy the openebs operator yml
+  shell: source ~/.profile; kubectl apply -f {{ openebs_operator_alias }} 
+  args:
+    executable: /bin/bash
+
+- name: Confirm maya-apiserver pod is running
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  register: result_pod
+  until: "'maya-apiserver' and 'Running' in result_pod.stdout_lines[1]"
+  delay: 300
+  retries: 6
+
+- name: Create fact for pod name
+  set_fact: 
+    pod_name: "{{ result_pod.stdout_lines[1].split()[0] }}"
+
+- name: Confirm that maya-cli is available in the maya-apiserver pod
+  shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -- maya version
+  args:
+    executable: /bin/bash
+  register: result_vers
+  failed_when: "'Maya' not in result_vers.stdout"
+
+
+

--- a/e2e/ansible/setup-kubernetes.yml
+++ b/e2e/ansible/setup-kubernetes.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  roles: 
+    - k8s-localhost 
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - k8s-master
+
+- hosts: kubernetes-kubeminions
+  roles: 
+    - k8s-hosts   

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -1,24 +1,16 @@
 ---
 - hosts: openebs-mayamasters
   roles:
-    - master
-    - {role: vagrant, when: is_vagrant_vm | bool} 
+    - {role: master, when: deployment_mode == "dedicated"}
+    - {role: vagrant, when: is_vagrant_vm | bool and deployment_mode == "dedicated"}
 
 - hosts: openebs-mayahosts
   roles:
-    - hosts
-    - {role: vagrant, when: is_vagrant_vm | bool}
+    - {role: hosts, when: deployment_mode == "dedicated"}
+    - {role: vagrant, when: is_vagrant_vm | bool and deployment_mode == "dedicated"}
 
-- hosts: localhost
+- hosts: kubernetes-kubemasters 
   roles: 
-    - k8s-localhost 
+    - {role: k8s-openebs-operator, when: deployment_mode == "hyperconverged"}
 
-- hosts: kubernetes-kubemasters
-  roles:
-    - k8s-master
 
-- hosts: kubernetes-kubeminions
-  roles: 
-    - k8s-hosts
-
-   


### PR DESCRIPTION
Code Changes : 
-----------------

- Created a new role to deploy the openebs operator in k8s (k8s-openebs-operator). This is in view of facilitating hyperconverged openebs deployment on the baremetal environment. 

   The role performs the following functions :

  - Deploys the openebs operator yaml in the k8s master (after confirming that the k8s master is ready and available)

  - Waits for the maya-apiservice pod to come-up and checks the health of the deployment by verifying maya-cli is available in the pod

- Created a new role to cleanup the openebs deployments in k8s (k8s-openebs-cleanup)

- Split the setup_openebs playbook into the following two playbooks :

  - setup_kubernetes.yml : Sets up the k8s cluster

  - setup_openebs.yml: Sets up the maya-server and openebs storage hosts either in dedicated OR hyperconverged mode depending on the deployment_mode global variable

- Updated the custom ansible stdout_callback plugin 'openebs' to reduce the content printed on console when skipping tasks. The detailed content is now viewed only upon performing a verbose run (-v)

- Updated the pre-requisites section in openebs-on-premise-deployment-guide to include a few more mandatory development packages on the baremetal boxes/VMs

Tested On:
------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts
