### PR TITLE
PR#104 Improvements to Ansible based CI framework 

### DIFF
--- a/e2e/ansible/README.md
+++ b/e2e/ansible/README.md
@@ -44,9 +44,10 @@ ansible
 ├── files
 ├── inventory
 │   └── group_vars
+|   └── host_vars
 ├── playbooks
-│   ├ dedicated
-│   └ hyperconverged
+│   └── dedicated
+│   └── hyperconverged
 ├── plugins
 │   └── callback
 └── roles

--- a/e2e/ansible/inventory/README.md
+++ b/e2e/ansible/inventory/README.md
@@ -10,6 +10,7 @@ A brief description of the files in this directory is given below :
   file
 - hosts : Default inventory file referred to in the playbooks
 - group_vars/all.yml : Contains global variables for ansible playbooks 
+- host_vars/localhost.yml : Contains localhost attributes such as sudo password which are needed for privilege escalation
 
 The machines.in needs to be updated with the details of the hosts used in the openebs setup prior to execution of the ansible 
 playbooks. Provided below are some instructions to consider while doing this
@@ -31,3 +32,27 @@ playbooks. Provided below are some instructions to consider while doing this
 
 - Lines can be commented (such as these) by inserting '#' symbol before the host code
 
+The contents of a typical ansible inventory 'hosts' file is as shown below :
+
+```
+localhost ansible_connection=local ansible_become_pass="{{ lookup('env','LOCAL_USER_PASSWORD') }}"
+
+[openebs-mayamasters]
+mayamaster01 ansible_ssh_host=20.10.49.11
+
+[openebs-mayamasters:vars]
+ansible_ssh_user="{{ lookup('env','MACHINES_USER_NAME') }}"
+ansible_ssh_pass="{{ lookup('env','MACHINES_USER_PASSWORD') }}"
+ansible_become_pass="{{ lookup('env','MACHINES_USER_PASSWORD') }}"
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+
+[openebs-mayahosts]
+mayahost01 ansible_ssh_host=20.10.49.12
+mayahost02 ansible_ssh_host=20.10.49.13
+
+[openebs-mayahosts:vars]
+ansible_ssh_user="{{ lookup('env','USER_NAME') }}"
+ansible_ssh_pass="{{ lookup('env','USER_PASSWORD') }}"
+ansible_become_pass="{{ lookup('env','USER_PASSWORD') }}"
+ansible_ssh_extra_args='-o StrictHostKeyChecking=no'
+```

--- a/e2e/ansible/inventory/host_vars/localhost.yml
+++ b/e2e/ansible/inventory/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+ansible_connection: local 
+ansible_become_pass: "{{ lookup('env','LOCAL_USER_PASSWORD') }}"

--- a/e2e/ansible/roles/inventory/tasks/main.yml
+++ b/e2e/ansible/roles/inventory/tasks/main.yml
@@ -1,12 +1,8 @@
 ---
-- name: Source the env 
-  shell : source ~/.profile
+- name: Generate Inventory
+  shell: source ~/.profile; python {{role_path}}/files/generate-inventory.py {{inventory_input_path}}/machines.in
   args:
     executable: /bin/bash
-  delegate_to: 127.0.0.1
-
-- name: Generate Inventory
-  command: "python {{role_path}}/files/generate-inventory.py {{inventory_input_path}}/machines.in"
   delegate_to: 127.0.0.1
 
 - name: Sync Inventory

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -14,7 +14,8 @@
     name: "{{ item }}"
     state: present
   with_items: "{{ pip_local_packages }}"
-  delegate_to: 127.0.0.1 
+  delegate_to: 127.0.0.1
+  become: true 
 
 ## Common preparation tasks
 

--- a/e2e/ansible/roles/prerequisites/tasks/main.yml
+++ b/e2e/ansible/roles/prerequisites/tasks/main.yml
@@ -5,4 +5,4 @@
     state: present
   with_items: "{{ pip_pre_packages }}"
   delegate_to: 127.0.0.1
-
+  become: true


### PR DESCRIPTION
Code Changes: 
----------------

- Added privilege escalation (become: true) for tasks using the ansible pip module as the workaround for segmentation faults seen during the pip installation (Refer Issue #143)

- For non-root users, the above modification necessitates providing the sudo password for localhost while installing dependencies in the inventory role - note that this is executed as part of the pre-requisites playbook which generates the ansible hosts file itself and is the first step in the openEBS CI setup/deployment.

  A host_vars dir is added in the inventory to hold localhost vars by default, mainly the sudo password in a localhost.yml to facilitate the execution of the inventory generation role

- Updated the tasks/main.yml in the inventory role to perform a source of the .profile in the same task as the one in which generate_inventory python script is being called - instead of performing a source in a separate task. This is necessary as ansible spawns a new SSH session for execution of each task and the env variables may sometimes not persist across sessions

- Updated the README in the Ansible project folder and Inventory folder to reflect the new directory structure and host_vars details

Changes tested on: 
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts