### PR TITLE
PR#104 Improvements to Ansible based CI framework

### DIFF
--- a/e2e/ansible/openebs-on-premise-deployment-guide.md
+++ b/e2e/ansible/openebs-on-premise-deployment-guide.md
@@ -94,7 +94,7 @@ drwxrwxr-x 17 testuser testuser  4096 Jun  5 09:29 roles
   ```
   
 - Note that the above playbook needs to be run separately and not as part of any the "master" playbook run as the changes to ansible 
-  default configuration may file to take effect dynamically
+  default configuration may fail to take effect dynamically
   
 - Execute the pre-requisites ansible playbook to generate the ansible inventory, i.e., 'hosts' file from the data provided in the 
   machines.in file

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+
+  vars_files:
+    - k8s-crunchy-pg-vars.yml 
+
+  tasks:
+
+    - name: Get $HOME of K8s master for kubernetes user
+      shell: source ~/.profile; echo $HOME
+      args:
+        executable: /bin/bash
+      register: result_kube_home
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Run the shell script to cleanup postgres cluster
+      shell: source ~/.profile; ./cleanup.sh
+      args:
+        chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
+        executable: /bin/bash
+      register: postgres_cleanup
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      ignore_errors: true
+
+    - name: Confirm postgres pods have been deleted
+      shell: source ~/.profile; kubectl get pods
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result
+      until: "'pgset' not in result.stdout"
+      delay: 120 
+      retries: 6
+
+
+   

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - k8s-crunchy-pg-vars.yml
+ 
+  tasks:
+    
+    - name: Install subversion on K8S-master
+      apt:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ deb_packages }}"
+      become: true 
+      delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+      

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-vars.yml
@@ -1,0 +1,8 @@
+---
+crunchy_pg_git_dir: https://github.com/openebs/openebs/tree/master/k8s/demo/crunchy-postgres
+
+postgres_vol_size: 5G
+
+deb_packages:
+  - subversion
+  

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -1,0 +1,90 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - k8s-crunchy-pg-vars.yml 
+ 
+  tasks:
+
+    - name: Get $HOME of K8s master for kubernetes user
+      shell: source ~/.profile; echo $HOME
+      args: 
+        executable: /bin/bash
+      register: result_kube_home
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Check whether maya-apiserver pod is deployed
+      shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+      args: 
+        executable: /bin/bash
+      register: result
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+
+    - name: 
+      debug: 
+        msg: "Ending play, maya-apiserver is not running"
+      when: "'Running' not in result.stdout"
+
+    - name: 
+      meta: end_play
+      when: "'Running' not in result.stdout"
+
+    - name: Replace 'tree/master' with 'trunk' in the crunchy-postgres link
+      debug:
+        msg={{ crunchy_pg_git_dir | regex_replace('tree/master', 'trunk')}}
+      register: git_svn_link
+
+    - name: Set the modified link as a fact
+      set_fact:
+        crunchy_dir: "{{ git_svn_link.msg }}"
+      
+    - name: Download the crunch-postgres folder kubemaster home
+      subversion:
+        repo: "{{ crunchy_dir }}"
+        export: yes
+        dest: "{{ result_kube_home.stdout }}/crunchy-postgres"
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+ 
+    - name: Replace volume size in set.json
+      lineinfile:
+        path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
+        regexp: "\"storage\":"
+        line: "              \"storage\": \"{{postgres_vol_size}}\""
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Comment the cleanup step in the run.sh  
+      lineinfile:
+        path: "{{ result_kube_home.stdout }}/crunchy-postgres/run.sh" 
+        regexp: 'cleanup.sh'
+        line: '#$DIR/cleanup.sh'
+        backup: yes
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Run the shell script to setup postgres cluster
+      shell: source ~/.profile; ./run.sh
+      args:  
+        chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
+        executable: /bin/bash
+      register: result
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    - name: Confirm the postgres statefulset is running 
+      shell: source ~/.profile; kubectl get pods | grep pgset
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: setup
+      until: "'pgset-0' and 'Running' in setup.stdout_lines[0] and 'pgset-1' and 'Running' in setup.stdout_lines[1]"
+      delay: 300
+      retries: 6
+
+    - name: Verify that the postgres master and replica are available as cluster services
+      shell: source ~/.profile; kubectl get svc
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: result_service
+      failed_when: "'pgset-master' and 'pgset-replica' not in result_service.stdout"
+
+  
+
+

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -55,6 +55,16 @@
   register: result_vers
   failed_when: "'Maya' not in result_vers.stdout"
 
+- name: Download YAML for openebs storage classes
+  get_url:
+    url: "{{ openebs_storageclasses_link }}"
+    dest: "{{ ansible_env.HOME }}/{{ openebs_storageclasses_alias }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+
 - name: Deploy the openebs storageclasses yml
   shell: source ~/.profile; kubectl apply -f {{ openebs_storageclasses_alias }}
   args:

--- a/e2e/ansible/run-hyperconverged-tests.yml
+++ b/e2e/ansible/run-hyperconverged-tests.yml
@@ -3,7 +3,7 @@
 
 ###########################################################################################
 # TC NAME: test-k8s-percona-mysql-pod
-# TC DETAILS: Deploys percona pod on k8s cluster with storage provisioned by openebs provisioner 
+# TC DETAILS: Deploys percona pod on k8s cluster with openebs storage
 # TC NOTES:           
 #    
 - include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -11,6 +11,28 @@
 - include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
 #
 - include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+  when: clean | bool
+#
+###########################################################################################
+# TC NAME: test-k8s-jupyter-server-pod 
+# TC DETAILS: Deploys jupyet notebook server on k8s cluster with openebs storage
+# TC NOTES:           
+#    
+- include: playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+#
+- include: playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+  when: clean | bool
+#
+###########################################################################################
+# TC NAME: test-k8s-crunchy-postgres
+# TC DETAILS: Deploys a postgresql cluster on k8s cluster with openebs storage
+# TC NOTES:           
+#    
+- include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
+#
+- include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+#
+- include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
   when: clean | bool
 #
 ###########################################################################################

--- a/e2e/ansible/run-iometer-demo.yml
+++ b/e2e/ansible/run-iometer-demo.yml
@@ -6,7 +6,7 @@
 #    b) Windows IOmeter host IP address can be set in ./roles/iometer/defaults/main.yml
 #    c) Volume properties can be set in ./roles/volume/defaults/main.yml
 #
-- include: playbooks/test-iometer/iometer-prerequisites.yml
-- include: playbooks/test-iometer/iometer.yml 
+- include: playbooks/dedicated/test-iometer/iometer-prerequisites.yml
+- include: playbooks/dedicated/test-iometer/iometer.yml 
 #
 ###########################################################################################


### PR DESCRIPTION
Code Changes: 
-----------------
- Added a new test playbook with associated vars, prerequisites, and cleanup playbooks for deploying a 
  postgresql cluster with openebs storage on the K8S cluster. The playbook makes use of configuration 
  templates and scripts provided by CrunchyData for deployment of postgres statefulset on K8s

  The test playbook:

  - Downloads the crunchy-postgres folder from k8s/demo in openebs git repo (through svn export)
  - Applies user defined storage volume size in the .json template
  - Run the setup script
  - Verifies successful deployment of the statefulset and availability of the postgre-master and replica services in the K8S cluster

   The test will be enhanced over time to include utilization of DB by client applications as part of load generation

- Updated the run-hyperconverged-tests playbook to include the jupyter and crunchy-postgres usecases

- Updated the tasks/main.yml in the k8s-openebs-operator role to include a missing step to download the openebs-storageclasses yaml file

- Updated the run-iometer-demo playbook to reflect the new playbook path inside the dedicated folder

- Fixed a typo in the openebs-on-premise-deployment-guide

Changes tested on: 
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts