### PR TITLE
PR#104 Added testcase failure reporting and slack notification capabilities 

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -21,7 +21,7 @@ cn_interface: ens160
 #Mode of openEBS deployment 
 #Accepted Entries (dedicated, hyperconverged): default:dedicated 
 
-deployment_mode: dedicated
+deployment_mode: hyperconverged 
 
 #Option specifically for vagrant VMs
 #Accepted Entries(true, false): default:false
@@ -38,6 +38,8 @@ is_vagrant_vm: true
 run_demo: true
 
 ara_setup: true 
+
+slack_notify: true
 
 #########################################
 # OpenEBS Test Specifications           #

--- a/e2e/ansible/openebs-on-premise-deployment-guide.md
+++ b/e2e/ansible/openebs-on-premise-deployment-guide.md
@@ -81,8 +81,8 @@ drwxrwxr-x 17 testuser testuser  4096 Jun  5 09:29 roles
   
 - Edit the global variables file ```inventory/group_vars/all.yml``` to reflect the desired storage volume properties and network CIDR
   that will be used by the maya api server to allot the IP for the volume containers. Also update the ansible run-time properties to 
-  reflect the machine type (is_vagrant) and whether the playbook execution needs to be recorded using the Ansible Run Analysis framework 
-  (setup_ara)
+  reflect the machine type (is_vagrant), whether the playbook execution needs to be recorded using the Ansible Run Analysis framework 
+  (setup_ara), whether slack notifications are needed (in case they are required, a $SLACK_TOKEN env variable needs to be setup. The token is usually the last part of the slack webhook URL which is user generated)  etc.., 
   
 - Execute the setup_ara playbook to install the ARA notification plugins and custom modules. This step will cause changes to 
   the ansible configuration file ansible.cfg (though a backup will be taken at the time of execution in case you need to revert). A web 

--- a/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
@@ -1,36 +1,29 @@
 ---
-- hosts: localhost
+- name: Wait {{ mysql_load_duration }} sec for I/O completion
+  wait_for:
+    timeout: "{{ mysql_load_duration }}"
 
-  vars_files:
-    - k8s-mysql-pod-vars.yml 
+- name: Delete mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-  tasks: 
-    
-    - name: Wait {{ mysql_load_duration }} sec for I/O completion
-      wait_for:
-        timeout: "{{ mysql_load_duration }}"
+- name: Confirm pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'mysql' not in result.stdout"
+  delay: 10
+  retries: 3
 
-    - name: Delete mysql pod 
-      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Confirm pod has been deleted
-      shell: source ~/.profile; kubectl get pods
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'mysql' not in result.stdout"
-      delay: 10
-      retries: 3
-
-    - name: Tear down the OpenEBS volume
-      shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
-      args:
-        executable: /bin/bash
-      ignore_errors: false
-      delegate_to: "{{groups['openebs-mayamasters'].0}}"
+- name: Tear down the OpenEBS volume
+  shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
+  args:
+    executable: /bin/bash
+  ignore_errors: false
+  delegate_to: "{{groups['openebs-mayamasters'].0}}"
 
    

--- a/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
@@ -1,23 +1,16 @@
-- hosts: localhost
- 
-  vars_files: 
-    - k8s-mysql-pod-vars.yml 
- 
-  tasks:
-    
-    - name: Install python-pip on K8S-minion
-      apt:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ deb_packages }}"
-      become: true 
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+- name: Install python-pip on K8S-minion
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ deb_packages }}"
+  become: true 
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Install PIP packages on K8s-minion
-      pip: 
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ pip_packages }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
-      become: true  
+- name: Install PIP packages on K8s-minion
+  pip: 
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_packages }}"
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
+  become: true  
       

--- a/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-vars.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-vars.yml
@@ -1,4 +1,6 @@
 ---
+test_name: dedicated_mysql_db_on_k8s
+
 mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/8e33dac25b2c86f9228a98335b07f45585e51485/k8s/demo/specs/demo-mysql-openebs-plugin.yaml
 
 pod_yaml_alias: demo-mysql-openebs-plugin.yaml

--- a/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod.yml
@@ -5,119 +5,138 @@
  
   tasks:
 
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args: 
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   - block: 
+      
+       - include: k8s-mysql-pod-prerequisites.yml
 
-    - name: Download YAML for mysql plugin
-      get_url: 
-        url: "{{ mysql_plugin_link }}"
-        dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        force: yes
-      register: result
-      until:  "'OK' in result.msg"
-      delay: 5
-      retries: 3
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Get m-API server info 
-      shell: source ~/.profile; maya omm-status
-      args: 
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['openebs-mayamasters'].0}}"     
-      ignore_errors: true
-      no_log: true
+       - name: Download YAML for mysql plugin
+         get_url: 
+           url: "{{ mysql_plugin_link }}"
+           dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           force: yes
+         register: result
+         until:  "'OK' in result.msg"
+         delay: 5
+         retries: 3
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Get m-API server info 
+         shell: source ~/.profile; maya omm-status
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['openebs-mayamasters'].0}}"     
+         ignore_errors: true
+         no_log: true
  
-    - name: 
-      debug: 
-        msg: "Ending play, m-apiserver is unreachable"
-      when: "'m-apiserver' not in result.stderr"
+       - name: 
+         debug: 
+           msg: "Ending play, m-apiserver is unreachable"
+         when: "'m-apiserver' not in result.stderr"
 
-    - name: 
-      meta: end_play
-      when: "'m-apiserver' not in result.stderr"
+       - name: 
+         meta: end_play
+         when: "'m-apiserver' not in result.stderr"
     
-    - name: Fetch m-API server location    
-      shell: echo "{{result.stderr}}" | grep -i 'm-apiserver' | awk '{print $4}'
-      register: result_mAPI
+       - name: Fetch m-API server location    
+         shell: echo "{{result.stderr}}" | grep -i 'm-apiserver' | awk '{print $4}'
+         register: result_mAPI
 
-    - name: Replace mAPI server location in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "openebsApiUrl:"
-        line: "        openebsApiUrl: \"{{result_mAPI.stdout}}/latest\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+       - name: Replace mAPI server location in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "openebsApiUrl:"
+           line: "        openebsApiUrl: \"{{result_mAPI.stdout}}/latest\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
             
-    - name: Replace volume size in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "size:"
-        line: "        size: \"{{mysql_vol_size}}\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Replace volume size in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "size:"
+           line: "        size: \"{{mysql_vol_size}}\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Deploy mysql pod
-      shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Deploy mysql pod
+         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Confirm pod status is running
-      shell: source ~/.profile; kubectl get pods
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'mysql' and 'Running' in result.stdout_lines[1]"
-      delay: 300 
-      retries: 6
+       - name: Confirm pod status is running
+         shell: source ~/.profile; kubectl get pods
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'mysql' and 'Running' in result.stdout_lines[1]"
+         delay: 300 
+         retries: 6
      
-    - name: Get $HOME of K8s minion for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args:
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubeminions'].0}}"      
+       - name: Get $HOME of K8s minion for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"      
 
-    - name: Get IP address of mysql pod
-      shell: source ~/.profile; kubectl describe pod mysql
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result_IP
+       - name: Get IP address of mysql pod
+         shell: source ~/.profile; kubectl describe pod mysql
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_IP
 
-    - name: Set IP of Pod to variable
-      set_fact:
-        pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
+       - name: Set IP of Pod to variable
+         set_fact:
+           pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
 
-    - name: Copy files into kube minion
-      copy:
-        src: "{{ item }}"
-        dest: "{{ result_kube_home.stdout }}"
-      with_items: "{{ files }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Copy files into kube minion
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         with_items: "{{ files }}"
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Build the mysql-client image
-      docker_image:
-        name: mysql-client
-        state: present
-        path: "{{ result_kube_home.stdout }}"
-        rm: true
-        timeout: 600
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Build the mysql-client image
+         docker_image:
+           name: mysql-client
+           state: present
+           path: "{{ result_kube_home.stdout }}"
+           rm: true
+           timeout: 600
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: mysql-client docker instantiate
-      docker_container:
-        name: client
-        image: mysql-client
-        network_mode: host
-        command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
-        state: started
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: mysql-client docker instantiate
+         docker_container:
+           name: client
+           image: mysql-client
+           network_mode: host
+           command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
+           state: started
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
+       - include: k8s-mysql-pod-cleanup.yml
+         when: clean | bool
 
+       - set_fact:
+           flag: "Pass"
+          
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always: 
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN') 

--- a/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -1,36 +1,29 @@
 ---
-- hosts: localhost
+- name: Wait {{ mysql_load_duration }} sec for I/O completion
+  wait_for:
+    timeout: "{{ mysql_load_duration }}" 
 
-  vars_files:
-    - k8s-percona-pod-vars.yml 
+- name: Delete percona mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-  tasks:
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 10
+  retries: 3
 
-    - name: Wait {{ mysql_load_duration }} sec for I/O completion
-      wait_for:
-        timeout: "{{ mysql_load_duration }}" 
-
-    - name: Delete percona mysql pod 
-      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Confirm percona pod has been deleted
-      shell: source ~/.profile; kubectl get pods
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'percona' not in result.stdout"
-      delay: 10
-      retries: 3
-
-    - name: Tear down the OpenEBS volume
-      shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
-      args:
-        executable: /bin/bash
-      ignore_errors: false
-      delegate_to: "{{groups['openebs-mayamasters'].0}}"
+- name: Tear down the OpenEBS volume
+  shell: source ~/.profile; maya vsm-stop demo-vsm1-vol1 
+  args:
+    executable: /bin/bash
+  ignore_errors: false
+  delegate_to: "{{groups['openebs-mayamasters'].0}}"
 
    

--- a/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,23 +1,16 @@
-- hosts: localhost
- 
-  vars_files: 
-    - k8s-percona-pod-vars.yml 
- 
-  tasks:
-    
-    - name: Install python-pip on K8S-minion
-      apt:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ deb_packages }}"
-      become: true 
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+- name: Install python-pip on K8S-minion
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ deb_packages }}"
+  become: true 
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Install PIP packages on K8s-minion
-      pip: 
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ pip_packages }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
-      become: true  
+- name: Install PIP packages on K8s-minion
+  pip: 
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_packages }}"
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
+  become: true  
       

--- a/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
@@ -1,4 +1,6 @@
 ---
+test_name: dedicated_percona_db_on_k8s 
+
 percona_mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/88d02b8bfea4e5ef0ee94d4359a180f1c203684d/k8s/demo/specs/demo-percona-mysql-openebs-plugin.yaml
 
 pod_yaml_alias: demo-percona-mysql-openebs-plugin.yaml

--- a/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -5,117 +5,139 @@
  
   tasks:
 
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args: 
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   - block:
 
-    - name: Download YAML for mysql plugin
-      get_url: 
-        url: "{{ percona_mysql_plugin_link }}"
-        dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        force: yes
-      register: result
-      until:  "'OK' in result.msg"
-      delay: 5
-      retries: 3
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: k8s-percona-pod-prerequisites.yml
+       
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Get m-API server info 
-      shell: source ~/.profile; maya omm-status
-      args: 
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['openebs-mayamasters'].0}}"     
-      ignore_errors: true
-      no_log: true
+       - name: Download YAML for mysql plugin
+         get_url: 
+           url: "{{ percona_mysql_plugin_link }}"
+           dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           force: yes
+         register: result
+         until:  "'OK' in result.msg"
+         delay: 5
+         retries: 3
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Get m-API server info 
+         shell: source ~/.profile; maya omm-status
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['openebs-mayamasters'].0}}"     
+         ignore_errors: true
+         no_log: true
  
-    - name: 
-      debug: 
-        msg: "Ending play, m-apiserver is unreachable"
-      when: "'m-apiserver' not in result.stderr"
+       - name: 
+         debug: 
+           msg: "Ending play, m-apiserver is unreachable"
+         when: "'m-apiserver' not in result.stderr"
 
-    - name: 
-      meta: end_play
-      when: "'m-apiserver' not in result.stderr"
+       - name: 
+         meta: end_play
+         when: "'m-apiserver' not in result.stderr"
     
-    - name: Fetch m-API server location    
-      shell: echo "{{result.stderr}}" | grep -i 'm-apiserver' | awk '{print $4}'
-      register: result_mAPI
+       - name: Fetch m-API server location    
+         shell: echo "{{result.stderr}}" | grep -i 'm-apiserver' | awk '{print $4}'
+         register: result_mAPI
 
-    - name: Replace mAPI server location in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "openebsApiUrl:"
-        line: "        openebsApiUrl: \"{{result_mAPI.stdout}}/latest\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+       - name: Replace mAPI server location in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "openebsApiUrl:"
+           line: "        openebsApiUrl: \"{{result_mAPI.stdout}}/latest\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
             
-    - name: Replace volume size in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "size:"
-        line: "        size: \"{{percona_mysql_vol_size}}\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Replace volume size in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "size:"
+           line: "        size: \"{{percona_mysql_vol_size}}\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Deploy percona mysql pod
-      shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Deploy percona mysql pod
+         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Confirm pod status is running
-      shell: source ~/.profile; kubectl get pods
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'percona' and 'Running' in result.stdout_lines[1]"
-      delay: 300 
-      retries: 6
+       - name: Confirm pod status is running
+         shell: source ~/.profile; kubectl get pods
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout_lines[1]"
+         delay: 300 
+         retries: 6
      
-    - name: Get $HOME of K8s minion for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args:
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+       - name: Get $HOME of K8s minion for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
-    - name: Get IP address of mysql pod
-      shell: source ~/.profile; kubectl describe pod percona 
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result_IP
+       - name: Get IP address of mysql pod
+         shell: source ~/.profile; kubectl describe pod percona 
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_IP
 
-    - name: Set IP of Pod to variable
-      set_fact:
-        pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
+       - name: Set IP of Pod to variable
+         set_fact:
+           pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
 
-    - name: Copy files into kube minion
-      copy:
-        src: "{{ item }}"
-        dest: "{{ result_kube_home.stdout }}"
-      with_items: "{{ files }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Copy files into kube minion
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         with_items: "{{ files }}"
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Build the mysql-client image
-      docker_image:
-        name: mysql-client
-        state: present
-        path: "{{ result_kube_home.stdout }}"
-        rm: true
-        timeout: 600
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Build the mysql-client image
+         docker_image:
+           name: mysql-client
+           state: present
+           path: "{{ result_kube_home.stdout }}"
+           rm: true
+           timeout: 600
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: mysql-client docker instantiate
-      docker_container:
-        name: client
-        image: mysql-client
-        network_mode: host
-        command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
-        state: started
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: mysql-client docker instantiate
+         docker_container:
+           name: client
+           image: mysql-client
+           network_mode: host
+           command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
+           state: started
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+       - include: k8s-percona-pod-cleanup.yml
+         when: clean | bool
+
+       - set_fact:
+           flag: "Pass"
+   
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN') 
+         

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
@@ -1,36 +1,29 @@
 ---
-- hosts: localhost
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-  vars_files:
-    - k8s-crunchy-pg-vars.yml 
+- name: Run the shell script to cleanup postgres cluster
+  shell: source ~/.profile; ./cleanup.sh
+  args:
+    chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
+    executable: /bin/bash
+  register: postgres_cleanup
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  ignore_errors: true
 
-  tasks:
-
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args:
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Run the shell script to cleanup postgres cluster
-      shell: source ~/.profile; ./cleanup.sh
-      args:
-        chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
-        executable: /bin/bash
-      register: postgres_cleanup
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      ignore_errors: true
-
-    - name: Confirm postgres pods have been deleted
-      shell: source ~/.profile; kubectl get pods
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'pgset' not in result.stdout"
-      delay: 120 
-      retries: 6
+- name: Confirm postgres pods have been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'pgset' not in result.stdout"
+  delay: 120 
+  retries: 6
 
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
@@ -1,16 +1,9 @@
-- hosts: localhost
- 
-  vars_files: 
-    - k8s-crunchy-pg-vars.yml
- 
-  tasks:
-    
-    - name: Install subversion on K8S-master
-      apt:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ deb_packages }}"
-      become: true 
-      delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+- name: Install subversion on K8S-master
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ deb_packages }}"
+  become: true 
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
       

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-vars.yml
@@ -1,4 +1,6 @@
 ---
+test_name: hyperconverged_postgres_statefulset_on_k8s
+
 crunchy_pg_git_dir: https://github.com/openebs/openebs/tree/master/k8s/demo/crunchy-postgres
 
 postgres_vol_size: 5G

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -4,87 +4,110 @@
     - k8s-crunchy-pg-vars.yml 
  
   tasks:
+   
+   - block:
 
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args: 
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Check whether maya-apiserver pod is deployed
-      shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-      args: 
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
-
-    - name: 
-      debug: 
-        msg: "Ending play, maya-apiserver is not running"
-      when: "'Running' not in result.stdout"
-
-    - name: 
-      meta: end_play
-      when: "'Running' not in result.stdout"
-
-    - name: Replace 'tree/master' with 'trunk' in the crunchy-postgres link
-      debug:
-        msg={{ crunchy_pg_git_dir | regex_replace('tree/master', 'trunk')}}
-      register: git_svn_link
-
-    - name: Set the modified link as a fact
-      set_fact:
-        crunchy_dir: "{{ git_svn_link.msg }}"
-      
-    - name: Download the crunch-postgres folder kubemaster home
-      subversion:
-        repo: "{{ crunchy_dir }}"
-        export: yes
-        dest: "{{ result_kube_home.stdout }}/crunchy-postgres"
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
- 
-    - name: Replace volume size in set.json
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
-        regexp: "\"storage\":"
-        line: "              \"storage\": \"{{postgres_vol_size}}\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Comment the cleanup step in the run.sh  
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/crunchy-postgres/run.sh" 
-        regexp: 'cleanup.sh'
-        line: '#$DIR/cleanup.sh'
-        backup: yes
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Run the shell script to setup postgres cluster
-      shell: source ~/.profile; ./run.sh
-      args:  
-        chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Confirm the postgres statefulset is running 
-      shell: source ~/.profile; kubectl get pods | grep pgset
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: setup
-      until: "'pgset-0' and 'Running' in setup.stdout_lines[0] and 'pgset-1' and 'Running' in setup.stdout_lines[1]"
-      delay: 300
-      retries: 6
-
-    - name: Verify that the postgres master and replica are available as cluster services
-      shell: source ~/.profile; kubectl get svc
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result_service
-      failed_when: "'pgset-master' and 'pgset-replica' not in result_service.stdout"
-
+       - include: k8s-crunchy-pg-prerequisites.yml
   
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+
+       - name: 
+         debug: 
+           msg: "Ending play, maya-apiserver is not running"
+         when: "'Running' not in result.stdout"
+
+       - name: 
+         meta: end_play
+         when: "'Running' not in result.stdout"
+
+       - name: Replace 'tree/master' with 'trunk' in the crunchy-postgres link
+         debug:
+           msg={{ crunchy_pg_git_dir | regex_replace('tree/master', 'trunk')}}
+         register: git_svn_link
+
+       - name: Set the modified link as a fact
+         set_fact:
+           crunchy_dir: "{{ git_svn_link.msg }}"
+      
+       - name: Download the crunch-postgres folder kubemaster home
+         subversion:
+           repo: "{{ crunchy_dir }}"
+           export: yes
+           dest: "{{ result_kube_home.stdout }}/crunchy-postgres"
+           force: yes
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+ 
+       - name: Replace volume size in set.json
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
+           regexp: "\"storage\":"
+           line: "              \"storage\": \"{{postgres_vol_size}}\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Comment the cleanup step in the run.sh with 
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/crunchy-postgres/run.sh" 
+           regexp: 'cleanup.sh'
+           line: '#$DIR/cleanup.sh'
+           backup: yes
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Run the shell script to setup postgres cluster
+         shell: source ~/.profile; ./run.sh
+         args:  
+           chdir: "{{ result_kube_home.stdout }}/crunchy-postgres"
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Confirm the postgres statefulset is running 
+         shell: source ~/.profile; kubectl get pods | grep pgset
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: setup
+         until: "'pgset-0' and 'Running' in setup.stdout_lines[0] and 'pgset-1' and 'Running' in setup.stdout_lines[1]"
+         delay: 300
+         retries: 6
+
+       - name: Verify that the postgres master and replica are available as cluster services
+         shell: source ~/.profile; kubectl get svc
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_service
+         failed_when: "'pgset-master' and 'pgset-replica' not in result_service.stdout"
+
+       - include: k8s-crunchy-pg-cleanup.yml
+         when: clean | bool
+
+       - set_fact:
+           flag: "Pass"
+       
+     rescue:
+       - set_fact:
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+
+ 
+    
 
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
@@ -1,26 +1,19 @@
 ---
-- hosts: localhost
+- name: Delete jupyter server pod 
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-  vars_files:
-    - k8s-jupyter-pod-vars.yml 
-
-  tasks:
-
-    - name: Delete jupyter server pod 
-      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Confirm jupyter pod has been deleted
-      shell: source ~/.profile; kubectl get pods
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'jupyter' not in result.stdout"
-      delay: 120 
-      retries: 6
+- name: Confirm jupyter pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'jupyter' not in result.stdout"
+  delay: 120 
+  retries: 6
 
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
@@ -1,4 +1,6 @@
 ---
+test_name: hyperconverged_jupyter_server_on_k8s
+
 jupyter_plugin_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/jupyter/demo-jupyter-openebs.yaml 
 pod_yaml_alias: demo-jupyter-openebs.yaml
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
@@ -4,84 +4,88 @@
     - k8s-jupyter-pod-vars.yml 
  
   tasks:
+   
+   - block:
 
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args: 
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Download YAML for jupyter notebook server plugin
-      get_url: 
-        url: "{{ jupyter_plugin_link }}"
-        dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        force: yes
-      register: result
-      until:  "'OK' in result.msg"
-      delay: 5
-      retries: 3
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Download YAML for jupyter notebook server plugin
+         get_url: 
+           url: "{{ jupyter_plugin_link }}"
+           dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           force: yes
+         register: result
+         until:  "'OK' in result.msg"
+         delay: 5
+         retries: 3
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Check whether maya-apiserver is deployed
-      shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-      args: 
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+       - name: Check whether maya-apiserver is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
 
-    - name: 
-      debug: 
-        msg: "Ending play, maya-apiserver is not running"
-      when: "'Running' not in result.stdout"
+       - name: 
+         debug: 
+           msg: "Ending play, maya-apiserver is not running"
+         when: "'Running' not in result.stdout"
 
-    - name: 
-      meta: end_play
-      when: "'Running' not in result.stdout"
+       - name: 
+         meta: end_play
+         when: "'Running' not in result.stdout"
     
-    - name: Replace volume size in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "storage:"
-        line: "      storage: \"{{jupyter_server_vol_size}}\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Replace volume size in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "storage:"
+           line: "      storage: \"{{jupyter_server_vol_size}}\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Deploy jupyter notebook server pod
-      shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Deploy jupyter notebook server pod
+         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Confirm pod status is running
-      shell: source ~/.profile; kubectl get pods | grep jupyter
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'jupyter' and 'Running' in result.stdout"
-      delay: 300 
-      retries: 6
+       - name: Confirm pod status is running
+         shell: source ~/.profile; kubectl get pods | grep jupyter
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'jupyter' and 'Running' in result.stdout"
+         delay: 300 
+         retries: 6
 
-    - name: Verify that the jupyter notebook server is a cluster service
-      shell: source ~/.profile; kubectl get svc 
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result_service
-      failed_when: "'jupyter-service' not in result_service.stdout"
+       - name: Verify that the jupyter notebook server is a cluster service
+         shell: source ~/.profile; kubectl get svc 
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_service
+         failed_when: "'jupyter-service' not in result_service.stdout"
 
-      
+       - include: k8s-jupyter-pod-cleanup.yml 
+         when: clean | bool
+
+       - set_fact:
+           flag: "Pass"
        
+     rescue: 
+       - set_fact:
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}' 
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
                   
-
-
-
-
-
-
-
-
-
-
-       
-     

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -1,30 +1,23 @@
 ---
-- hosts: localhost
+- name: Wait {{ mysql_load_duration }} sec for I/O completion
+  wait_for:
+    timeout: "{{ mysql_load_duration }}" 
 
-  vars_files:
-    - k8s-percona-pod-vars.yml 
+- name: Delete percona mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-  tasks:
-
-    - name: Wait {{ mysql_load_duration }} sec for I/O completion
-      wait_for:
-        timeout: "{{ mysql_load_duration }}" 
-
-    - name: Delete percona mysql pod 
-      shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-    - name: Confirm percona pod has been deleted
-      shell: source ~/.profile; kubectl get pods
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'percona' not in result.stdout"
-      delay: 120 
-      retries: 6
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 120 
+  retries: 6
 
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,23 +1,17 @@
-- hosts: localhost
- 
-  vars_files: 
-    - k8s-percona-pod-vars.yml 
- 
-  tasks:
-    
-    - name: Install python-pip on K8S-minion
-      apt:
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ deb_packages }}"
-      become: true 
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+---
+- name: Install python-pip on K8S-minion
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ deb_packages }}"
+  become: true 
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Install PIP packages on K8s-minion
-      pip: 
-        name: "{{ item }}"
-        state: present
-      with_items: "{{ pip_packages }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
-      become: true  
+- name: Install PIP packages on K8s-minion
+  pip: 
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_packages }}"
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}" 
+  become: true  
       

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
@@ -1,4 +1,6 @@
 ---
+test_name: hyperconverged_percona_db_on_k8s
+
 percona_mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml 
 
 pod_yaml_alias: demo-percona-mysql-pvc.yaml

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -4,105 +4,126 @@
     - k8s-percona-pod-vars.yml 
  
   tasks:
+   - block:
 
-    - name: Get $HOME of K8s master for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args: 
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: k8s-percona-pod-prerequisites.yml 
 
-    - name: Download YAML for percona mysql plugin
-      get_url: 
-        url: "{{ percona_mysql_plugin_link }}"
-        dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        force: yes
-      register: result
-      until:  "'OK' in result.msg"
-      delay: 5
-      retries: 3
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Check whether maya-apiserver pod is deployed
-      shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-      args: 
-        executable: /bin/bash
-      register: result
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+       - name: Download YAML for percona mysql plugin
+         get_url: 
+           url: "{{ percona_mysql_plugin_link }}"
+           dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           force: yes
+         register: result
+         until:  "'OK' in result.msg"
+         delay: 5
+         retries: 3
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: 
-      debug: 
-        msg: "Ending play, maya-apiserver is not running"
-      when: "'Running' not in result.stdout"
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
 
-    - name: 
-      meta: end_play
-      when: "'Running' not in result.stdout"
+       - name: 
+         debug: 
+           msg: "Ending play, maya-apiserver is not running"
+         when: "'Running' not in result.stdout"
+
+       - name: 
+         meta: end_play
+         when: "'Running' not in result.stdout"
     
-    - name: Replace volume size in plugin YAML
-      lineinfile:
-        path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-        regexp: "storage:"
-        line: "      storage: \"{{percona_mysql_vol_size}}\""
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Replace volume size in plugin YAML
+         lineinfile:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: "storage:"
+           line: "      storage: \"{{percona_mysql_vol_size}}\""
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Deploy percona mysql pod
-      shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Deploy percona mysql pod
+         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-    - name: Confirm pod status is running
-      shell: source ~/.profile; kubectl get pods | grep percona
-      args: 
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result
-      until: "'percona' and 'Running' in result.stdout"
-      delay: 300 
-      retries: 6
+       - name: Confirm pod status is running
+         shell: source ~/.profile; kubectl get pods | grep percona
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 300 
+         retries: 6
      
-    - name: Get $HOME of K8s minion for kubernetes user
-      shell: source ~/.profile; echo $HOME
-      args:
-        executable: /bin/bash
-      register: result_kube_home
-      delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+       - name: Get $HOME of K8s minion for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
-    - name: Get IP address of percona mysql pod
-      shell: source ~/.profile; kubectl describe pod percona 
-      args:
-        executable: /bin/bash
-      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      register: result_IP
+       - name: Get IP address of percona mysql pod
+         shell: source ~/.profile; kubectl describe pod percona 
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_IP
 
-    - name: Set IP of Pod to variable
-      set_fact:
-        pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
+       - name: Set IP of Pod to variable
+         set_fact:
+           pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
 
-    - name: Copy files into kube minion
-      copy:
-        src: "{{ item }}"
-        dest: "{{ result_kube_home.stdout }}"
-      with_items: "{{ files }}"
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Copy files into kube minion
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         with_items: "{{ files }}"
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: Build the mysql-client image
-      docker_image:
-        name: mysql-client
-        state: present
-        path: "{{ result_kube_home.stdout }}"
-        rm: true
-        timeout: 600
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: Build the mysql-client image
+         docker_image:
+           name: mysql-client
+           state: present
+           path: "{{ result_kube_home.stdout }}"
+           rm: true
+           timeout: 600
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-    - name: mysql-client docker instantiate
-      docker_container:
-        name: client
-        image: mysql-client
-        network_mode: host
-        command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
-        state: started
-      become: true
-      delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+       - name: mysql-client docker instantiate
+         docker_container:
+           name: client
+           image: mysql-client
+           network_mode: host
+           command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
+           state: started
+         become: true
+         delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+       - include: k8s-percona-pod-cleanup.yml
+         when: clean | bool 
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack: 
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-cleanup/tasks/main.yml
@@ -23,7 +23,7 @@
   args:
     executable: /bin/bash
   register: result
-  until: "'maya-apiserver' and 'openebs-provisioner' not in result.stdout"
+  until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
   delay: 10
   retries: 6
 

--- a/e2e/ansible/run-dedicated-tests.yml
+++ b/e2e/ansible/run-dedicated-tests.yml
@@ -1,6 +1,13 @@
 ---
 # This .yml runs tests against the dedicated openebs setup
 
+##########################################################################################
+- hosts: localhost
+  tasks:
+    - slack: 
+        token: "{{ lookup('env','SLACK_TOKEN') }}" 
+        msg: "{{ ansible_date_time.time }} OPENEBS TESTSUITE: STARTED"
+      when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 ###########################################################################################
 # TC NAME: test-fio
 # TC DETAILS: Runs fio with a basic rw workload profile on the storage from a container
@@ -8,35 +15,32 @@
 #    a) Volume properties can be set in ./roles/volume/defaults/main.yml 
 #    b) fio run duration can be set in ./roles/fio/defaults/main.yml
 # 
-- include: playbooks/dedicated/test-fio/fio-prerequisites.yml
+#- include: playbooks/dedicated/test-fio/fio-prerequisites.yml
 #
-- include: playbooks/dedicated/test-fio/fio.yml
+#- include: playbooks/dedicated/test-fio/fio.yml
 #
-- include: playbooks/dedicated/test-fio/fio-cleanup.yml
-  when: clean | bool
+#- include: playbooks/dedicated/test-fio/fio-cleanup.yml
+#  when: clean | bool
 #
 ###########################################################################################
 # TC NAME: test-k8s-mysql-pod
 # TC DETAILS: Deploys mysql pod on a k8s cluster with storage provisioned by flexvol driver
 # TC NOTES:           
-#    
-- include: playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-prerequisites.yml
 #
 - include: playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod.yml
-#
-- include: playbooks/dedicated/test-k8s-mysql-pod/k8s-mysql-pod-cleanup.yml
-  when: clean | bool
 #
 ###########################################################################################
 # TC NAME: test-k8s-percona-mysql-pod
 # TC DETAILS: Deploys percona pod on k8s cluster with storage provisioned by flexvol driver
 # TC NOTES:           
 #    
-- include: playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
-#
 - include: playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
 #
-- include: playbooks/dedicated/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
-  when: clean | bool
-#
+###########################################################################################
+- hosts: localhost
+  tasks:
+    - slack: 
+        token: "{{ lookup('env','SLACK_TOKEN') }}" 
+        msg: "{{ ansible_date_time.time }} OPENEBS TESTSUITE: ENDED"
+      when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 ###########################################################################################

--- a/e2e/ansible/run-hyperconverged-tests.yml
+++ b/e2e/ansible/run-hyperconverged-tests.yml
@@ -1,17 +1,20 @@
 ---
 # This .yml runs tests against the hyperconverged openebs setup
 
+
+##########################################################################################
+- hosts: localhost
+  tasks:
+    - slack: 
+        token: "{{ lookup('env','SLACK_TOKEN') }}" 
+        msg: "{{ ansible_date_time.time }} OPENEBS TESTSUITE: STARTED"
+      when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 ###########################################################################################
 # TC NAME: test-k8s-percona-mysql-pod
 # TC DETAILS: Deploys percona pod on k8s cluster with openebs storage
 # TC NOTES:           
-#    
-- include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
 #
 - include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
-#
-- include: playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
-  when: clean | bool
 #
 ###########################################################################################
 # TC NAME: test-k8s-jupyter-server-pod 
@@ -20,19 +23,18 @@
 #    
 - include: playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
 #
-- include: playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
-  when: clean | bool
-#
 ###########################################################################################
 # TC NAME: test-k8s-crunchy-postgres
 # TC DETAILS: Deploys a postgresql cluster on k8s cluster with openebs storage
 # TC NOTES:           
 #    
-- include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
-#
 - include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
 #
-- include: playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
-  when: clean | bool
-#
+###########################################################################################
+- hosts: localhost
+  tasks:
+    - slack: 
+        token: "{{ lookup('env','SLACK_TOKEN') }}" 
+        msg: "{{ ansible_date_time.time }} OPENEBS TESTSUITE: ENDED"
+      when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 ###########################################################################################


### PR DESCRIPTION
Code Changes:
----------------

- Converted the pre-requisites and cleanup playbooks in the tests to task files which are then included in the main application test playbook

  This was done to facilitate use of 'Ansible blocks' error-handling feature. This feature allows a set of tasks to be grouped under a 'block', failure in any of which causes the control to jump to a 'rescue section' followed by a default section called 'always' which will be executed everytime. This is analogous to the try-except-finally paradigm in python/other languages.

  The test playbooks were modified to include blocks in order to be able to set "Pass" and "Fail" flags for a test execution and report/notify it (either to a results file OR a slack channel etc..,)

  However, ansible-blocks can include tasks/task-files alone and not roles and playbook includes.

- Introduced slack-integration to report test results to a channel. The always section in test playbooks (see above point) currently performs a test result notification. This needs a $SLACK_TOKEN to be setup as env variable.

- Updated global variable file all.yml to include a control variable for slack notification

- Updated the run-dedicated-tests and run-hyperconverged-tests to include a single test playbook instead of prerequisites/test/cleanup.

  Note: The said changes have not been made for fio test as it uses roles. They will be converted to task files soon. It stays commented for now.

- Updated the tasks/main.yml in k8s-openebs-cleanup role to ensure neither of maya-apiserver OR openebs-provisioner are running post cleanup (replaced 'and' operator with 'or' operator)

- Updated the openebs-deployment-guide to reflect details of the slack_notify switch

Changes tested on: 
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts