### PR TITLE
PR#104 Added a playbook to prepare environment before Jenkins CI run

### DIFF
--- a/e2e/ansible/setup_env.yml
+++ b/e2e/ansible/setup_env.yml
@@ -1,0 +1,35 @@
+---
+# Takes 'run_ci' and 'ci_mode' as extra vars
+# Copies the machines.in & Vagrantfile templates into respective directories based on the extra vars
+# Updates inventory/group_vars/all.yml based on the extra vars
+
+- hosts: localhost
+  tasks:
+   - block:
+       - name: Copy the machines.in template to inventory dir
+         copy:
+           src: "{{ playbook_dir }}/templates/{{ ci_mode }}/machines.{{ ci_mode }}"
+           dest: "{{ inventory_dir }}/machines.in"
+
+       - name: Copy the Vagrantfile template to ansible dir  
+         copy: 
+           src: "{{ playbook_dir }}/templates/{{ ci_mode }}/Vagrantfile.{{ ci_mode }}"
+           dest: "{{ playbook_dir }}/Vagrantfile"
+
+       - name: Change OpenEBS mode in all.yml
+         lineinfile: 
+           path: "{{ inventory_dir }}/group_vars/all.yml"
+           regexp: "deployment_mode:"
+           line: "deployment_mode: {{ ci_mode }}"
+           backup: yes
+       
+     rescue:
+       - debug: 
+           msg: "Env setup failed, please pass a valid ci_mode as argument"
+
+     when: run_ci == "yes" and ci_mode is defined
+
+
+              
+
+

--- a/e2e/ansible/templates/dedicated/Vagrantfile.dedicated
+++ b/e2e/ansible/templates/dedicated/Vagrantfile.dedicated
@@ -1,0 +1,107 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "openebs/test"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.network "private_network", type: "dhcp"
+  config.ssh.username = "ubuntu"
+  config.vm.provision "shell", inline: <<-SHELL
+      echo "ubuntu:ubuntu" | sudo chpasswd
+  SHELL
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-test.log")]
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+
+  config.vm.define "maya-master" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.31"
+    vmCfg.vm.hostname = "omm-01"
+  end
+
+  config.vm.define "mayahost-01" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.32"
+    vmCfg.vm.hostname = "osh-01"        
+  end
+
+  config.vm.define "mayahost-02" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.33"
+    vmCfg.vm.hostname = "osh-02"    
+  end
+
+  config.vm.define "kubemaster" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.34"
+    vmCfg.vm.hostname = "kubemaster-01"
+  end
+
+  config.vm.define "kubeminion-01" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.35"
+    vmCfg.vm.hostname = "kubeminion-01"
+  end
+
+  config.vm.define "kubeminion-02" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.36"
+    vmCfg.vm.hostname = "kubeminion-02"
+  end
+end

--- a/e2e/ansible/templates/dedicated/machines.dedicated
+++ b/e2e/ansible/templates/dedicated/machines.dedicated
@@ -1,0 +1,42 @@
+###############################################################################
+# This is an input file used by the OpenEBS ansible framework to
+# generate the 'hosts' file (otherwise called ansible inventory)
+# It consists of multiple comma-separated lines which specify the
+# machine details in the following manner :
+#
+# hostcode,ipaddress,env(username),env(password)
+#
+# NOTES:
+#
+# 1. Ensure supported host codes are provided, failing which
+# the inventory generation will not proceed. Current supported
+# codes include 'localhost, 'mayamaster', 'mayahost', 'kubemaster', 
+# 'kubeminion'
+#
+# 2. The 'localhost' hostcode is a mandataory line in this file
+# and has a default IP of 127.0.0.1
+#
+# 3. A dictionary of supported codes ("SupportedHostCodes") is present 
+# in the python script generate_inventory.py, which can be updated by 
+# interested users to include additional hostcodes
+#
+# 4. Lines can be commented (such as these) by inserting '#' symbol
+# before the host code
+#
+# 5. Ensure the environment variables are set in the .profile of the 
+# ansible user
+#
+################################################################################
+
+# For example:
+#master,20.10.26.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+#host,20.10.26.12,USER_NAME,USER_PASSWORD
+#host,20.10.26.14,USER_NAME,USER_PASSWORD
+
+localhost,127.0.0.1,LOCAL_USER_NAME,LOCAL_USER_PASSWORD
+mayamaster,172.28.128.31,USER_NAME,USER_PASSWORD
+mayahost,172.28.128.32,USER_NAME,USER_PASSWORD
+mayahost,172.28.128.33,USER_NAME,USER_PASSWORD
+kubemaster,172.28.128.34,USER_NAME,USER_PASSWORD
+kubeminion,172.28.128.35,USER_NAME,USER_PASSWORD
+kubeminion,172.28.128.36,USER_NAME,USER_PASSWORD

--- a/e2e/ansible/templates/hyperconverged/Vagrantfile.hyperconverged
+++ b/e2e/ansible/templates/hyperconverged/Vagrantfile.hyperconverged
@@ -1,0 +1,93 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "openebs/test"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  # config.vm.network "private_network", type: "dhcp"
+  config.ssh.username = "ubuntu"
+  config.vm.provision "shell", inline: <<-SHELL
+      echo "ubuntu:ubuntu" | sudo chpasswd
+  SHELL
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-test.log")]
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+
+ # Machines for HyperConverged(HC) setup 
+  config.vm.define "HCMaster" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.31"
+    vmCfg.vm.hostname = "hcm-01"
+  end
+
+  config.vm.define "HCHost-01" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.32"
+    vmCfg.vm.hostname = "hch-01"        
+  end
+
+  config.vm.define "HCHost-02" do |vmCfg|
+    vmCfg.vm.network "private_network", ip: "172.28.128.33"
+    vmCfg.vm.hostname = "hch-02"    
+  end
+end

--- a/e2e/ansible/templates/hyperconverged/machines.hyperconverged
+++ b/e2e/ansible/templates/hyperconverged/machines.hyperconverged
@@ -1,0 +1,39 @@
+###############################################################################
+# This is an input file used by the OpenEBS ansible framework to
+# generate the 'hosts' file (otherwise called ansible inventory)
+# It consists of multiple comma-separated lines which specify the
+# machine details in the following manner :
+#
+# hostcode,ipaddress,env(username),env(password)
+#
+# NOTES:
+#
+# 1. Ensure supported host codes are provided, failing which
+# the inventory generation will not proceed. Current supported
+# codes include 'localhost, 'mayamaster', 'mayahost', 'kubemaster', 
+# 'kubeminion'
+#
+# 2. The 'localhost' hostcode is a mandataory line in this file
+# and has a default IP of 127.0.0.1
+#
+# 3. A dictionary of supported codes ("SupportedHostCodes") is present 
+# in the python script generate_inventory.py, which can be updated by 
+# interested users to include additional hostcodes
+#
+# 4. Lines can be commented (such as these) by inserting '#' symbol
+# before the host code
+#
+# 5. Ensure the environment variables are set in the .profile of the 
+# ansible user
+#
+################################################################################
+
+# For example:
+#master,20.10.26.11,MACHINES_USER_NAME,MACHINES_USER_PASSWORD
+#host,20.10.26.12,USER_NAME,USER_PASSWORD
+#host,20.10.26.14,USER_NAME,USER_PASSWORD
+
+localhost,127.0.0.1,LOCAL_USER_NAME,LOCAL_USER_PASSWORD
+kubemaster,172.28.128.31,USER_NAME,USER_PASSWORD
+kubeminion,172.28.128.32,USER_NAME,USER_PASSWORD
+kubeminion,172.28.128.33,USER_NAME,USER_PASSWORD


### PR DESCRIPTION
Code Changes: 
----------------
- Depending on the deployment mode selected by Jenkins for performing the automated test run, the environment needs to configured accordingly

 This includes:
  - Setting the deployment mode flag in group_vars/all.yml
  - Copying pre-defined Vagrantfiles from templates folder into the ansible dir
  - Copying the machines.in templates from templates folder into the inventory dir

- The setup_env playbook takes two arguments as extra_vars - run_ci and ci_mode to perform the above functions

- Created the templates folder (referred above) to hold Vagrantfile and machine.in (input for the generate_inventory.py script) templates for dedicated and hyperconverged modes 

Changes tested on:
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts