### PR TITLE
PR#104 Cronjob with associated scripts to sync working openebs repo with master in jenkins box

### DIFF
--- a/e2e/scripts/cron-file.txt
+++ b/e2e/scripts/cron-file.txt
@@ -1,0 +1,26 @@
+# This file can be used to apply the crontab for a given user
+# Edit this file to introduce tasks to be run by cron.
+#
+# Usage : crontab cron-file.txt
+# 
+# Each task to run has to be defined through a single line
+# indicating with different fields when the task will be run
+# and what command to run for the task
+#
+# To define the time you can provide concrete values for
+# minute (m), hour (h), day of month (dom), month (mon),
+# and day of week (dow) or use '*' in these fields (for 'any').#
+# Notice that tasks will be started based on the cron's system
+# daemon's notion of time and timezones.
+#
+# Output of the crontab jobs (including errors) is sent through
+# email to the user the crontab file belongs to (unless redirected).
+#
+# For example, you can run a backup of all your user accounts
+# at 5 a.m every week with:
+# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
+#
+# For more information see the manual pages of crontab(5) and cron(8)
+# 
+# m h  dom mon dow   command
+00 06 * * * cd ~/openebs && ./git_monitor.sh 

--- a/e2e/scripts/git_monitor.sh
+++ b/e2e/scripts/git_monitor.sh
@@ -1,0 +1,13 @@
+#################################################################################
+# This is a script that will be run periodically as part of a cronjob on the
+# Jenkins master (build machine) to check whether there are any updates to the
+# e2e folder in the openebs repository (https://github.com/openebs/openebs),
+# which contains the test automation code, and apply them to the local working
+# repo (via git pull).In the event of any changes, a jenkins CI run is triggered
+# to verify the sanity of the latest code.
+#
+# The script actions are logged into git_update.log, which will be available in
+# the same directory as this script
+#################################################################################
+
+./git_update.sh 2>&1 | awk '{ print strftime("%c:"),$0; fflush();}' >> git_update.log 

--- a/e2e/scripts/git_update.sh
+++ b/e2e/scripts/git_update.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+###################################################################################
+# This script is invoked by the git_monitor.sh script to merge latest automation
+# code into the Jenkins master and run the CI suite. It uses env variables in order 
+# to store jenkins related info needed to trigger the CI job.These should to be set 
+# prior to scheduling the cron job. 
+#
+# For ex:
+# 
+# export JENKINS_MASTER_IP="20.10.30.253"
+# export JENKINS_PORT="8080" 
+# export JENKINS_USER="openebs"
+# export JENKINS_USER_API_KEY="41d9e9efee80939f116fd77e5e1cd736"
+# export JOB_NAME="jiva"
+# export BUILD_TOKEN="openebstestbuild"
+#
+###################################################################################
+
+# source the user .profile to load the env variables
+source ~/.profile 
+
+# file touched by the jenkins job to indicate run in progress
+file=ci.running
+
+# url to trigger jenkins CI job 
+ci_trigger_url="curl -f --user $JENKINS_USER:$JENKINS_USER_API_KEY \
+http://$JENKINS_MASTER_IP:$JENKINS_PORT/job/$JOB_NAME/build?token=$BUILD_TOKEN"
+
+# look for file indicating ongoing CI job, exit if present 
+if [ -f "$file" ]; then
+    echo "##### CI RUN IN PROGRESS, WON'T POLL FOR E2E UPDATES #####"
+    exit
+fi
+
+echo "##### POLL FOR UPDATES TO THE CI FRAMEWORK #####"
+
+# perform git stash to store local changes separately and revert to cloned state
+git stash
+
+# perform git pull to fetch & merge updated files from repository
+content="`git pull`"
+
+# trigger/schedule a CI run if e2e/Ansible is updated 
+if [[ "$content" =~ "e2e/Ansible" ]]
+then
+    echo $content; echo "Triggering CI..."
+    $ci_trigger_url > /dev/null 2>&1
+    retcode=$? 
+    if [ $retcode -ne 0 ] 
+    then
+        echo "Failed to trigger CI, found non-zero exit status ($retcode)"
+        exit
+    else
+        echo "Started CI suite"
+    fi
+else
+    echo "No changes to e2e, no action taken"
+fi
+
+


### PR DESCRIPTION
Code Changes : 
-----------------
- Created a cron template with associated scripts to monitor changes in the e2e folder
  of the openebs repo and merge them to the local working directory on the jenkins box

- The script also triggers a CI run on jenkins with the updated test automation code via
  a build token

- Once applied, the cronjob will run at 6 AM everyday

Changes tested on :  
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts
