### PR TITLE
PR#104 Reduce CI time by looking for downloaded files on test-harness & also fixes for issue #153

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -1,4 +1,21 @@
----
+#########################################
+# Kubernetes Deployment Specification   #
+#########################################
+
+#Kubernetes Version to be used for deployment
+#Accepted Entries (Valid Kubernetes Version): default:1.6.3
+
+k8s_version: 1.6.3
+weave_version: 1.9.4
+
+k8s_version_list:
+  - 1.6.2
+  - 1.6.3
+  - 1.6.4
+  - 1.6.5
+  - 1.6.6
+  - 1.7.0
+
 #########################################
 # OpenEBS Deployment Specifications     #
 #########################################
@@ -49,4 +66,3 @@ slack_notify: true
 #Accepted Entries(true, false): default:true
 
 clean: true
-

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
@@ -4,6 +4,6 @@
     state: present
   with_items: "{{ deb_packages }}"
   become: true 
-  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
       

--- a/e2e/ansible/roles/k8s-hosts/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/defaults/main.yml
@@ -2,7 +2,7 @@
 # Do not change the order of the scripts.
 # They have to been run in the order defined below.
 
-k8s_images: k8s_images.tar
+k8s_images: k8s_images_{{ k8s_version }}.tar
 
 k8s_images_path: "{{ ansible_env.HOME }}/setup/kubernetes"
 

--- a/e2e/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/defaults/main.yml
@@ -13,9 +13,9 @@ pip_local_packages:
 # these packages will be copied into kubernetes role's .files
 
 k8s_deb_packages:
-  - https://packages.cloud.google.com/apt/pool/kubeadm_1.6.3-00_amd64_ff5e882c88a5db71803aab900c0b341eb63038558da73c51c3d351070b0c62af.deb
-  - https://packages.cloud.google.com/apt/pool/kubectl_1.6.3-00_amd64_05d48fa118b6538ee2bc0b864aeb09f2cede83990fc8819875f698a5dece0c9b.deb
-  - https://packages.cloud.google.com/apt/pool/kubelet_1.6.3-00_amd64_a94b0cfa5b26939d87097dfd45260474c1effcad879e35940eb6d36e7d953d6c.deb
+  - https://packages.cloud.google.com/apt/pool/kubeadm_{{ k8s_version }}-00_amd64_ff5e882c88a5db71803aab900c0b341eb63038558da73c51c3d351070b0c62af.deb
+  - https://packages.cloud.google.com/apt/pool/kubectl_{{ k8s_version }}-00_amd64_05d48fa118b6538ee2bc0b864aeb09f2cede83990fc8819875f698a5dece0c9b.deb
+  - https://packages.cloud.google.com/apt/pool/kubelet_{{ k8s_version }}-00_amd64_a94b0cfa5b26939d87097dfd45260474c1effcad879e35940eb6d36e7d953d6c.deb
   - https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.5.1-00_amd64_08cbe5c42366ec3184cc91a4353f6e066f2d7325b4db1cb4f87c7dcc8c0eb620.deb
 
 k8s_deb_package_alias:
@@ -30,10 +30,10 @@ k8s_deb_package_alias:
 k8s_images:
   - gcr.io/google_containers/pause-amd64:3.0
   - gcr.io/google_containers/etcd-amd64:3.0.17
-  - gcr.io/google_containers/kube-scheduler-amd64:v1.6.2
-  - gcr.io/google_containers/kube-apiserver-amd64:v1.6.2
-  - gcr.io/google_containers/kube-controller-manager-amd64:v1.6.2
-  - gcr.io/google_containers/kube-proxy-amd64:v1.6.2
+  - gcr.io/google_containers/kube-scheduler-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-apiserver-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-controller-manager-amd64:v{{ k8s_version }}
+  - gcr.io/google_containers/kube-proxy-amd64:v{{ k8s_version }}
   - gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1
   - gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.1
   - gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1
@@ -50,8 +50,8 @@ k8s_master_scripts:
 # These images will be downloaded, tar'ed and pushed into K8s-master role's .files 
 
 weave_images: 
-  - weaveworks/weave-kube:1.9.4
-  - weaveworks/weave-npc:1.9.4
+  - weaveworks/weave-kube:{{ weave_version }}
+  - weaveworks/weave-npc:{{ weave_version }}
 
 # Link to download default weave template (.yaml) to be placed in roles/kubernetes/templates
 

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -44,40 +44,48 @@
     - "{{ k8s_deb_packages }}"
     - "{{ k8s_deb_package_alias }}"
 
-- name: Fetch K8s images from gcr.io/google_containers
-  docker_image: 
-    name: "{{item}}"
-    state: present
-    pull: true
-    force: yes
-  register: result
-  until: "'Pulled image' and item in result.actions[0]"
-  delay: 60
-  retries: 3  
-  with_items: "{{ k8s_images }}"
-  become: true
+- name: Check whether deb packages and images are already downloaded
+  stat: 
+    path: "{{ playbook_dir }}/roles/kubernetes/files/k8s_images_{{ k8s_version }}.tar"
+  register: stat_result
 
-- name: Print K8s image names
-  shell: printf "{{ item }}\n" >> imagelist.tmp
-  with_items: "{{ k8s_images }}"
+- block:
+    - name: Fetch K8s images from gcr.io/google_containers
+      docker_image: 
+        name: "{{item}}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3  
+      with_items: "{{ k8s_images }}"
+      become: true
 
-- name: TAR the K8s images 
-  shell: docker save $(cat imagelist.tmp) -o k8s_images.tar
-  become: true
+    - name: Print K8s image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ k8s_images }}"
 
-- name: Remove the .tmp file created to hold image list
-  file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+    - name: TAR the K8s images 
+      shell: docker save $(cat imagelist.tmp) -o k8s_images_{{ k8s_version }}.tar
+      become: true
 
-- name: Move K8s_images.tar into kubernetes role
-  shell: mv {{playbook_dir}}/k8s_images.tar {{ playbook_dir }}/roles/kubernetes/files
-  become: true
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
 
-- name: Remove K8s images from K8s-localhost
-  docker_image:
-    name: "{{ item }}" 
-    state: absent
-  with_items: "{{ k8s_images }}"
-  become: true
+    - name: Move K8s_images_{{ k8s_version }}.tar into kubernetes role
+      shell: mv {{playbook_dir}}/k8s_images_{{ k8s_version }}.tar {{ playbook_dir }}/roles/kubernetes/files
+      become: true
+
+    - name: Remove K8s images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ k8s_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false 
 
 ## K8S-MASTER ROLE PREPARATION
 
@@ -92,40 +100,43 @@
   retries: 3 
   with_items: "{{ k8s_master_scripts }}"
 
-- name: Fetch weave images from dockerhub
-  docker_image:
-    name: "{{ item }}"
-    state: present
-    pull: true
-    force: yes
-  register: result
-  until: "'Pulled image' and item in result.actions[0]"
-  delay: 60
-  retries: 3
-  with_items: "{{ weave_images }}" 
-  become: true
+- block: 
+    - name: Fetch weave images from dockerhub
+      docker_image:
+        name: "{{ item }}"
+        state: present
+        pull: true
+        force: yes
+      register: result
+      until: "'Pulled image' and item in result.actions[0]"
+      delay: 60
+      retries: 3
+      with_items: "{{ weave_images }}" 
+      become: true
 
-- name: Print weave image names
-  shell: printf "{{ item }}\n" >> imagelist.tmp
-  with_items: "{{ weave_images }}"
+    - name: Print weave image names
+      shell: printf "{{ item }}\n" >> imagelist.tmp
+      with_items: "{{ weave_images }}"
 
-- name: TAR the weave images
-  shell: docker save $(cat imagelist.tmp) -o weave_images.tar
-  become: true
+    - name: TAR the weave images
+      shell: docker save $(cat imagelist.tmp) -o weave_images_{{ weave_version }}.tar
+      become: true
 
-- name: Remove the .tmp file created to hold image list
-  file: path="{{playbook_dir}}/imagelist.tmp" state=absent
+    - name: Remove the .tmp file created to hold image list
+      file: path="{{playbook_dir}}/imagelist.tmp" state=absent
 
-- name: Move weave_images.tar into k8s-master role
-  shell: mv {{playbook_dir}}/weave_images.tar {{ playbook_dir }}/roles/k8s-master/files
-  become: true
+    - name: Move weave_images_{{ weave_version }}.tar into k8s-master role
+      shell: mv {{playbook_dir}}/weave_images_{{ weave_version }}.tar {{ playbook_dir }}/roles/k8s-master/files
+      become: true
 
-- name: Remove weave images from K8s-localhost
-  docker_image:
-    name: "{{ item }}" 
-    state: absent
-  with_items: "{{ weave_images }}"
-  become: true
+    - name: Remove weave images from K8s-localhost
+      docker_image:
+        name: "{{ item }}" 
+        state: absent
+      with_items: "{{ weave_images }}"
+      become: true
+  
+  when: stat_result.stat.exists == false
 
 - name: Fetch the weave .yaml template from GitHub
   get_url:

--- a/e2e/ansible/roles/k8s-master/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-master/defaults/main.yml
@@ -7,10 +7,10 @@ configure_scripts:
   - configure_k8s_weave.sh
 
 weave_depends:
-  - weave_images.tar
+  - weave_images_{{ k8s_version }}.tar
   - weave-daemonset-k8s-1.6.yaml
 
-k8s_images: k8s_images.tar
+k8s_images: k8s_images_{{ k8s_version }}.tar
 
 weave_images_path: "{{ ansible_env.HOME}}/setup/weave"
 

--- a/e2e/ansible/roles/k8s-master/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-master/defaults/main.yml
@@ -7,7 +7,7 @@ configure_scripts:
   - configure_k8s_weave.sh
 
 weave_depends:
-  - weave_images_{{ k8s_version }}.tar
+  - weave_images_{{ weave_version }}.tar
   - weave-daemonset-k8s-1.6.yaml
 
 k8s_images: k8s_images_{{ k8s_version }}.tar

--- a/e2e/ansible/roles/kubernetes/defaults/main.yml
+++ b/e2e/ansible/roles/kubernetes/defaults/main.yml
@@ -11,7 +11,7 @@ k8s_deb_packages:
 
 k8s_images_path: "{{ ansible_env.HOME}}/setup/kubernetes"
 
-k8s_images: k8s_images.tar
+k8s_images: k8s_images_{{ k8s_version }}.tar
 
 k8s_dpkg_packages:
   - kubeadm.deb


### PR DESCRIPTION
Code Changes: 
-----------------
- The k8s-localhost ansible role is used to prepare the test-harness box for setting up a kubernetes cluster by creating some directories and placing some files into them (these will be consumed by the k8s-master/host ansible roles - which appear after the k8s-localhost role in the setup-kubernetes playbook). This part of the playbook execution takes time because of docker image download, bundling the images into tar, placing them in {{role_path}} of k8s roles followed by the removal of these images in localhost.

- This enhancement addresses the above problem by looking for the presence of image tarfile for a given k8s version (which is now added as a global variable in all.yml) in the fixed {{role_path}}/files location before performing the above steps. This is achieved by grouping above tasks in a block with a when conditional for image tarfile

- Updated the k8s-master and k8s-hosts defaults/main.yml to refer the image tarfile with k8s/weave version

- The pre-requisites task yaml file for the crunchy-postgres test delegates the subversion package install step to kubeminion, but it is actually needed on the kubemaster (for the svn export of the crunchy postgres templates folder in openebs repo). Previous test runs had svn pre-installed on the master machine which caused tests to run. Fixing this issue as part of this PR