### PR TITLE
PR#104: K8s Box as VM for quick build and folder permission fixes.

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -1,13 +1,19 @@
+---
+
 #########################################
 # Kubernetes Deployment Specification   #
 #########################################
 
 #Kubernetes Version to be used for deployment
 #Accepted Entries (Valid Kubernetes Version): default:1.6.3
+#Accepted Entries (Valid Weave Version): default:1.9.4
 
 k8s_version: 1.6.3
 weave_version: 1.9.4
 
+#list of kubernetes versions released.
+#do not tamper the list unless you know
+#what you are doing...
 k8s_version_list:
   - 1.6.2
   - 1.6.3
@@ -15,6 +21,9 @@ k8s_version_list:
   - 1.6.5
   - 1.6.6
   - 1.7.0
+
+weave_version_list:
+  - 1.9.4 
 
 #########################################
 # OpenEBS Deployment Specifications     #

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -13,17 +13,19 @@
   meta: end_play
   when: "'FAILED' in result_status.stdout"
 
-- name: Load images from Archive
-  command: docker load --input "{{ k8s_images }}"
-  args:
-    chdir: "{{ k8s_images_path }}"
-  become: true
+- block:
+    - name: Load images from Archive
+      command: docker load --input "{{ k8s_images }}"
+      args:
+        chdir: "{{ k8s_images_path }}"
+      become: true
 
-- name: Install deb packages
-  apt:
-    deb: "{{ k8s_images_path }}/{{ item }}"
-  with_items: "{{ k8s_dpkg_packages }}"
-  become: true
+    - name: Install deb packages
+      apt:
+        deb: "{{ k8s_images_path }}/{{ item }}"
+      with_items: "{{ k8s_dpkg_packages }}"
+      become: true
+  when: build_type == "normal"
 
 - name: Get Token Name from Master
   shell: >

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -100,6 +100,12 @@
   retries: 3 
   with_items: "{{ k8s_master_scripts }}"
 
+- name: Change Kubernetes version in configure scripts
+  replace:
+    path: "{{ playbook_dir }}/roles/k8s-master/files/configure_k8s_master.sh"
+    regexp: "--kubernetes-version=v1.[0-9].[0-9]"
+    replace: "--kubernetes-version=v{{ k8s_version }}"
+
 - block: 
     - name: Fetch weave images from dockerhub
       docker_image:

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -1,14 +1,31 @@
 ---
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
 - name: Create Directory
   file:
     path: "{{ weave_images_path }}"
     state: directory
-
-- name: Copy TAR to remote
-  copy:
-    src: "{{ weave_depends[0] }}"
-    dest: "{{ weave_images_path }}"
   become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ weave_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ weave_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
 
 - name: Copy Pod YAML to remote
   copy:
@@ -21,24 +38,34 @@
     dest: "{{ k8s_images_path }}"
     mode: "u+rwx"
 
-- name: Load images from Archive
-  command: docker load --input "{{ k8s_images }}"
-  args:
-    chdir: "{{ k8s_images_path }}"
-  become: true
+- block:
 
-- name: Load images from Archive
-  command: docker load --input "{{ weave_depends[0] }}"
-  args:
-    chdir: "{{ weave_images_path }}"
-  become: true
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ weave_depends[0] }}"
+       dest: "{{ weave_images_path }}"
+     become: true
 
-- name: Install deb packages
-  apt:
-    deb: "{{ k8s_images_path }}/{{ item }}"
-  with_items: "{{ k8s_dpkg_packages }}"
-  become: true
+   - name: Load images from Archive
+     command: docker load --input "{{ k8s_images }}"
+     args:
+       chdir: "{{ k8s_images_path }}"
+     become: true
 
+   - name: Load images from Archive
+     command: docker load --input "{{ weave_depends[0] }}"
+     args:
+       chdir: "{{ weave_images_path }}"
+     become: true
+
+   - name: Install deb packages
+     apt:
+       deb: "{{ k8s_images_path }}/{{ item }}"
+     with_items: "{{ k8s_dpkg_packages }}"
+     become: true
+
+  when: build_type == "normal"
+ 
 - name: kubeadm reset before init
   command: kubeadm reset
   become: true

--- a/e2e/ansible/roles/kubernetes/tasks/main.yml
+++ b/e2e/ansible/roles/kubernetes/tasks/main.yml
@@ -28,10 +28,33 @@
   become: true
   with_items: "{{ k8s_deb_packages }}"
 
+- name: Get Current User
+  command: whoami
+  register: user
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
 - name: Create Directory
   file:
     path: "{{ k8s_images_path }}"
     state: directory
+  become: true
+  when: status.stat.isdir is not defined
+
+- stat:
+    path: "{{ k8s_images_path }}"
+  register: status
+
+- name: Change Folder Permissions
+  file:
+    path: "{{ k8s_images_path }}"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true
+  when: status.stat.isdir is defined and status.stat.isdir
 
 - name: Copy TAR to remote
   copy:

--- a/e2e/ansible/setup-env.yml
+++ b/e2e/ansible/setup-env.yml
@@ -15,6 +15,13 @@
          copy: 
            src: "{{ playbook_dir }}/templates/{{ ci_mode }}/Vagrantfile.{{ ci_mode }}"
            dest: "{{ playbook_dir }}/Vagrantfile"
+       
+       - name: For a build of type 'quick' change the box in Vagrantfile
+         lineinfile:
+           path: "{{ playbook_dir }}/Vagrantfile"
+           regexp: "config.vm.box =" 
+           line: "config.vm.box = \"openebs/k8s-1.7\""
+         when: build_type == "quick" 
 
        - name: Change OpenEBS mode in all.yml
          lineinfile: 
@@ -23,6 +30,21 @@
            line: "deployment_mode: {{ ci_mode }}"
            backup: yes
        
+       - name: Change the version of Kubernetes, if defined in the env
+         lineinfile:
+           path: "{{ inventory_dir }}/group_vars/all.yml"
+           regexp: "k8s_version:"
+           line: "k8s_version: {{lookup('env','K8S_VERSION')}}"
+         when: lookup('env','K8S_VERSION') in k8s_version_list
+
+       - name: Change the version of Weave, if defined in the env
+         lineinfile:
+           path: "{{ inventory_dir }}/group_vars/all.yml"
+           regexp: "weave_version:"
+           line: "k8s_version: {{lookup('env','WEAVE_VERSION')}}"
+           backup: yes
+         when: lookup('env','WEAVE_VERSION') in weave_version_list
+ 
      rescue:
        - debug: 
            msg: "Env setup failed, please pass a valid ci_mode as argument"

--- a/e2e/ansible/templates/dedicated/Vagrantfile.dedicated
+++ b/e2e/ansible/templates/dedicated/Vagrantfile.dedicated
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "openebs/test"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
   #
   #   # Customize the amount of memory on the VM:
   #   vb.memory = "1024"
-    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-test.log")]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "build-box.log")]
   end
   #
   # View the documentation for the provider you are using for more
@@ -78,30 +78,54 @@ Vagrant.configure("2") do |config|
   config.vm.define "maya-master" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.31"
     vmCfg.vm.hostname = "omm-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
   end
 
   config.vm.define "mayahost-01" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.32"
-    vmCfg.vm.hostname = "osh-01"        
+    vmCfg.vm.hostname = "osh-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true        
   end
 
   config.vm.define "mayahost-02" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.33"
-    vmCfg.vm.hostname = "osh-02"    
+    vmCfg.vm.hostname = "osh-02"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true    
   end
 
   config.vm.define "kubemaster" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.34"
     vmCfg.vm.hostname = "kubemaster-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
   end
 
   config.vm.define "kubeminion-01" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.35"
     vmCfg.vm.hostname = "kubeminion-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
   end
 
   config.vm.define "kubeminion-02" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.36"
     vmCfg.vm.hostname = "kubeminion-02"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
   end
 end

--- a/e2e/ansible/templates/hyperconverged/Vagrantfile.hyperconverged
+++ b/e2e/ansible/templates/hyperconverged/Vagrantfile.hyperconverged
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "openebs/test"
+  config.vm.box = "ubuntu/xenial64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -54,7 +54,7 @@ Vagrant.configure("2") do |config|
   #
   #   # Customize the amount of memory on the VM:
   #   vb.memory = "1024"
-    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-test.log")]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "build-box.log")]
   end
   #
   # View the documentation for the provider you are using for more
@@ -79,15 +79,27 @@ Vagrant.configure("2") do |config|
   config.vm.define "HCMaster" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.31"
     vmCfg.vm.hostname = "hcm-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true
   end
 
   config.vm.define "HCHost-01" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.32"
-    vmCfg.vm.hostname = "hch-01"        
+    vmCfg.vm.hostname = "hch-01"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true        
   end
 
   config.vm.define "HCHost-02" do |vmCfg|
     vmCfg.vm.network "private_network", ip: "172.28.128.33"
-    vmCfg.vm.hostname = "hch-02"    
+    vmCfg.vm.hostname = "hch-02"
+
+    vmCfg.vm.provision :shell,
+    inline: "sudo apt-get install -y python-minimal",
+    privileged: true    
   end
 end


### PR DESCRIPTION
New build type attributes 'quick' and 'normal'. Bug fixes for permission issues.

Code Changes:
-------------------
- The changes include addition of build type attributes called 'quick' and 'normal'.
- The 'quick' build uses the vagrant box having k8s preinstalled.
- The 'normal' build uses the version of the Kubernetes provided in the environment variable to install that specific version.
- If no Kubernetes version is provided, it defaults to 1.6.3.
- Fixed some permission issues during directory creation.
- Updated the Vagrantfile templates to install python-minimal for ansible.

Tested On:
-------------
OpenEBS ESXi Box - (Using Vagrant Boxes- Ubuntu)

Details of the fix:
--------------------
These fixes are part of the initial enhancements to reduce the time taken to run the CI tests.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>