### PR TITLE
PR#104 Added build_type as a CI specification param in global variabl…

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -14,6 +14,7 @@ weave_version: 1.9.4
 #list of kubernetes versions released.
 #do not tamper the list unless you know
 #what you are doing...
+
 k8s_version_list:
   - 1.6.2
   - 1.6.3
@@ -63,7 +64,13 @@ is_vagrant_vm: true
 
 run_demo: true
 
+#Option to setup Ansible Runtime Analysis playbook recorder
+#Accepted Entries(true, false): default:true
+
 ara_setup: true 
+
+#Option to enable slack notifications to specified channel
+#Accepted Entries(true, false): default:true
 
 slack_notify: true
 
@@ -75,3 +82,16 @@ slack_notify: true
 #Accepted Entries(true, false): default:true
 
 clean: true
+
+#########################################
+# OpenEBS CI Specifications             #
+#########################################
+
+#Option to select type of CI build
+#Accepted Entries(quick, normal): default:normal
+#quick build uses preconfigured VMs, 
+#normal builds upon vanilla VMs
+
+build_type: normal
+
+


### PR DESCRIPTION
…es file

Code Changes : 
-----------------

- Added a global variable to specify the CI build type. This variable is specific to vagrant environments that is used in the jenkins managed CI workflow that invokes the ansible playbooks during its job run

- 'quick' build deploys pre-configured vagrant VMs with kubernetes pre-installed

- 'normal' build configures vagrant VMs from scratch ans sets up all dependencies

- In non-jenkins-vagrant environments, the setup routines are executed for default build type 'normal'
