### PR TITLE
PR#104: Additional "blocks" added to reduce the time taken for quick build to complete.

### DIFF
--- a/e2e/ansible/roles/k8s-hosts/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/defaults/main.yml
@@ -2,9 +2,11 @@
 # Do not change the order of the scripts.
 # They have to been run in the order defined below.
 
+configure_scripts: configure_k8s_host.sh
+
 k8s_images: k8s_images_{{ k8s_version }}.tar
 
-k8s_images_path: "{{ ansible_env.HOME }}/setup/kubernetes"
+k8s_images_path: "{{ ansible_env.HOME }}/setup/k8s"
 
 k8s_dpkg_packages:
   - kubelet.deb

--- a/e2e/ansible/roles/k8s-hosts/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-hosts/tasks/main.yml
@@ -68,44 +68,68 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   delegate_facts: True
 
-- name: Get the openebs-iscsi flexvolume driver
-  get_url:
-    url: "{{ openebs_iscsi_driver }}"
-    dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
-    force: yes
-  register: result
-  until:  "'OK' in result.msg"
-  delay: 5
-  retries: 3
+- block:
+   - name: Get the openebs-iscsi flexvolume driver
+     get_url:
+       url: "{{ openebs_iscsi_driver }}"
+       dest: "{{ ansible_env.HOME}}/{{ flexvol_driver_alias }}"
+       force: yes
+     register: result
+     until:  "'OK' in result.msg"
+     delay: 5
+     retries: 3
 
-- name: Create flexvol driver destination
-  file:
-    path: "{{ flexvol_driver_path }}"
-    state: directory
-    mode: 0755
-  become: true
+   - name: Create flexvol driver destination
+     file:
+       path: "{{ flexvol_driver_path }}"
+       state: directory
+       mode: 0755
+     become: true
 
-- name: Copy script to flexvol driver location
-  copy:
-    src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
-    dest: "{{ flexvol_driver_path }}"
-    mode: "u+rwx"
-    force: yes
-    remote_src: yes
-  become: true
+   - name: Copy script to flexvol driver location
+     copy:
+       src: "{{ ansible_env.HOME }}/{{ flexvol_driver_alias }}"
+       dest: "{{ flexvol_driver_path }}"
+       mode: "u+rwx"
+       force: yes
+       remote_src: yes
+     become: true
           
-- name: Reset kubeadm
-  command: kubeadm reset
-  become: true
+   - name: Reset kubeadm
+     command: kubeadm reset
+     become: true
 
-- name: Setup k8s Hosts 
-  script: "configure_k8s_host.sh 
-          --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
-          --token={{result_token_name.stdout}}.{{result_token.stdout}} 
-          --clusterip={{result_cluster.stdout}}"
-  become: true
-  notify: 
-    - Reload systemd
-    - Restart kubelet
+   - name: Setup k8s Hosts 
+     script: "{{configure_scripts}} 
+             --masterip={{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}} 
+             --token={{result_token_name.stdout}}.{{result_token.stdout}} 
+             --clusterip={{result_cluster.stdout}}"
+     become: true  
+     notify: 
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "normal"
+
+- block:
+   - name: Change file mode
+     file:
+       path: "{{k8s_images_path}}/{{configure_scripts}}"
+       mode: "u+rwx"
+     become: true
+
+   - name: Setup k8s Hosts
+     shell: >
+       source ~/.profile;
+       "{{k8s_images_path}}/{{configure_scripts}}"
+       --masterip="{{hostvars[groups['kubernetes-kubemasters'][0]]['ansible_ssh_host']}}"
+       --token="{{result_token_name.stdout}}.{{result_token.stdout}}"
+       --clusterip="{{result_cluster.stdout}}"
+     args:
+       executable: /bin/bash
+     become: true
+     notify:
+       - Reload systemd
+       - Restart kubelet
+  when: build_type == "quick"
 
 - meta: flush_handlers 

--- a/e2e/ansible/roles/k8s-master/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-master/defaults/main.yml
@@ -14,7 +14,7 @@ k8s_images: k8s_images_{{ k8s_version }}.tar
 
 weave_images_path: "{{ ansible_env.HOME}}/setup/weave"
 
-k8s_images_path: "{{ ansible_env.HOME}}/setup/kubernetes"
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
 
 # Do not change the order of the packages
 # They have to be installed in the order defined below.

--- a/e2e/ansible/roles/k8s-master/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-master/tasks/main.yml
@@ -27,18 +27,17 @@
   become: true
   when: status.stat.isdir is defined and status.stat.isdir
 
-- name: Copy Pod YAML to remote
-  copy:
-    src: "{{ weave_depends[1] }}"
-    dest: "{{ weave_images_path }}"
-
-- name: Copy Script to remote
-  copy:
-    src: "{{ configure_scripts[1] }}"
-    dest: "{{ k8s_images_path }}"
-    mode: "u+rwx"
-
 - block:
+   - name: Copy Pod YAML to remote
+     copy:
+       src: "{{ weave_depends[1] }}"
+       dest: "{{ weave_images_path }}"
+
+   - name: Copy Script to remote
+     copy:
+       src: "{{ configure_scripts[1] }}"
+       dest: "{{ k8s_images_path }}"
+       mode: "u+rwx"
 
    - name: Copy TAR to remote
      copy:
@@ -63,16 +62,31 @@
        deb: "{{ k8s_images_path }}/{{ item }}"
      with_items: "{{ k8s_dpkg_packages }}"
      become: true
+ 
+   - name: kubeadm reset before init
+     command: kubeadm reset
+     become: true
+
+   - name: kubeadm init
+     script: "{{ configure_scripts[0] }}"
+     become: true
 
   when: build_type == "normal"
- 
-- name: kubeadm reset before init
-  command: kubeadm reset
-  become: true
 
-- name: kubeadm init
-  script: "{{ configure_scripts[0] }}"
-  become: true
+- block:
+   - name: Change file modes
+     file:
+       path: "{{k8s_images_path}}/{{item}}"
+       mode: "u+rwx"
+     become: true
+     with_items: "{{ configure_scripts}}"
+
+   - name: kubeadm init
+     shell: "{{ k8s_images_path }}/{{ configure_scripts[0] }}"
+     args:
+       executable: /bin/bash
+     become: true
+  when: build_type == "quick"
 
 - name: Get Current User
   command: whoami
@@ -103,3 +117,10 @@
   shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}" 
   args:
     executable: /bin/bash
+  when: build_type == "normal"
+
+- name: Patch kube-proxy for CNI Networks
+  shell: source ~/.profile; "{{ k8s_images_path }}/{{ configure_scripts[1] }}"
+  args:
+    executable: /bin/bash
+  when: build_type == "quick"

--- a/e2e/ansible/roles/kubernetes/defaults/main.yml
+++ b/e2e/ansible/roles/kubernetes/defaults/main.yml
@@ -9,7 +9,7 @@ k8s_deb_packages:
   - socat
   - ebtables
 
-k8s_images_path: "{{ ansible_env.HOME}}/setup/kubernetes"
+k8s_images_path: "{{ ansible_env.HOME}}/setup/k8s"
 
 k8s_images: k8s_images_{{ k8s_version }}.tar
 

--- a/e2e/ansible/roles/kubernetes/tasks/main.yml
+++ b/e2e/ansible/roles/kubernetes/tasks/main.yml
@@ -1,32 +1,35 @@
 ---
-- name: Get Package Updates
-  apt:
-    update_cache: yes
-  become: true
+- block:
+   - name: Get Package Updates
+     apt:
+       update_cache: yes
+     become: true
 
-- name: Add apt-key
-  apt_key:
-    url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
-    state: present
-  become: true
+   - name: Add apt-key
+     apt_key:
+       url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+       state: present
+     become: true
 
-- name: Add Kubernetes apt repository
-  apt_repository:
-    repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
-    state: present
-  become: true
+   - name: Add Kubernetes apt repository
+     apt_repository:
+       repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
+       state: present
+     become: true
 
-- name: Get Package Updates
-  apt:
-    update_cache: yes
-  become: true
+   - name: Get Package Updates
+     apt:
+       update_cache: yes
+     become: true
 
-- name: Install APT Packages
-  apt:
-    name: "{{ item }}" 
-    state: present
-  become: true
-  with_items: "{{ k8s_deb_packages }}"
+   - name: Install APT Packages
+     apt:
+       name: "{{ item }}" 
+       state: present
+     become: true
+     with_items: "{{ k8s_deb_packages }}"
+  
+  when: build_type == "normal"
 
 - name: Get Current User
   command: whoami
@@ -56,13 +59,16 @@
   become: true
   when: status.stat.isdir is defined and status.stat.isdir
 
-- name: Copy TAR to remote
-  copy:
-    src: "{{ k8s_images }}"
-    dest: "{{ k8s_images_path }}"
+- block:
+   - name: Copy TAR to remote
+     copy:
+       src: "{{ k8s_images }}"
+       dest: "{{ k8s_images_path }}"
 
-- name: Copy local deb files to K8s-Master and K8s-Minions
-  copy:
-   src: "{{ item }}"
-   dest: "{{ k8s_images_path }}"
-  with_items: "{{ k8s_dpkg_packages }}"
+   - name: Copy local deb files to K8s-Master and K8s-Minions
+     copy:
+       src: "{{ item }}"
+       dest: "{{ k8s_images_path }}"
+     with_items: "{{ k8s_dpkg_packages }}"
+
+  when: build_type == "normal"

--- a/e2e/ansible/setup-kubernetes.yml
+++ b/e2e/ansible/setup-kubernetes.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: localhost
-  roles: 
-    - k8s-localhost 
+  roles:
+    - {role: k8s-localhost, when: build_type == "normal"} 
 
 - hosts: kubernetes-kubemasters
   roles:


### PR DESCRIPTION
Additional "blocks" added to reduce the time taken for quick build to complete.

Changes:
-----------
- k8s-localhost to run only when the build_type is "normal".
- Use already available configure scripts from the k8s vagrant box.
- Skip tasks not required by build_type="quick"

Tested On:
-------------
Ubuntu 16.04 (OpenEBS ESX Machine)
Ubuntu 16.04 (Developer Laptop, Vagrant)

Details of fix:
---------------
Part of the enhancement to improve CI completion time. k8s-localhost tasks are run based on build_type. 

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>