### PR TITLE
PR#104 - Retry atleast 3 times to fetch the master status before exiting the playbook run.

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -20,6 +20,10 @@
   args:
     executable: /bin/bash
   register: result
+  until:  "'OK' in result.stdout"
+  delay: 20
+  retries: 3
+  ignore_errors: true  
 
 - name: 
   debug: 


### PR DESCRIPTION
Retry atleast 3 times to fetch the master status before exiting the playbook run.

Code Changes:
-------------------
- Retry 3 times to get the master status before exiting the play.

Tested On:
-------------

Ubuntu ESX VM (Vagrant VMs)

Details of the fix:
--------------------
During the k8s cluster formation the kubelet is restarted to load the changes in the configuration. Before the kubelet is up and running if the status of the master is requested it returns a status of 'Not Ready'. The intention of the fix is to retry and fetch the status again in case the kubelet is taking time to restart.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>