### PR TITLE
Create vdbench kubernetes job yaml for hyperconverged mode

### DIFF
--- a/k8s/demo/percona/tutorial-running-percona-pod-on-openebs.md
+++ b/k8s/demo/percona/tutorial-running-percona-pod-on-openebs.md
@@ -1,0 +1,1 @@
+# Running percona pod on OpenEBS

--- a/k8s/demo/vdbench/demo-vdbench-openebs.yaml
+++ b/k8s/demo/vdbench/demo-vdbench-openebs.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: batch/v1
+kind: Job 
+metadata:
+  name: vdbench
+spec: 
+  template: 
+    metadata:
+      name: vdbench 
+    spec: 
+      restartPolicy: Never
+      containers:
+      - name: perfrunner  
+        image: openebs/tests-vdbench
+        volumeMounts:
+        - mountPath: /datadir1
+          name: demo-vol1
+      volumes: 
+      - name: demo-vol1
+        persistentVolumeClaim:
+          claimName: demo-vol1-claim 
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-basic
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5G"
+ 
+    


### PR DESCRIPTION
Code Changes : 
-----------------
- The demo-vdbench-openebs.yml creates a k8s "Job" which runs a basic read-write workload on iSCSI target exposed by OpenEBS from an ubuntu-based vdbench container

- The job is created with restartPolicy "Never" and uses the storage class "openebs-basic"

Changes tested on : 
----------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts

