### PR TITLE
Tutorial for running percona pod on openebs storage in k8s

### DIFF
--- a/k8s/demo/percona/sql-loadgen.yaml
+++ b/k8s/demo/percona/sql-loadgen.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sql-loadgen
+spec:
+  template:
+    metadata:
+      name: sql-loadgen
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sql-loadgen
+        image: openebs/tests-mysql-client
+        command: ["/bin/bash"]
+        args: ["-c", "timelimit -t 300 sh MySQLLoadGenerate.sh 10.36.0.3 > /dev/null 2>&1; exit 0"]
+        tty: true 
+

--- a/k8s/demo/percona/tutorial-running-percona-pod-on-openebs.md
+++ b/k8s/demo/percona/tutorial-running-percona-pod-on-openebs.md
@@ -127,8 +127,8 @@ karthik@MayaMaster:~$ kubectl describe pod percona | grep IP
 IP:             10.44.0.3
 ``` 
 
-Edit the below line in sql load generation job yaml to pass the desired load duration and percona pod IP as arguments.
-In this example, the job runs for 300s
+Edit the below line in sql-loadgen job yaml to pass the desired load duration and percona pod IP as arguments.
+In this example, the job performs sql queries on pod with IP address 10.44.0.3 for 300s
 
 ```
 args: ["-c", "timelimit -t 300 sh MySQLLoadGenerate.sh 10.44.0.3 > /dev/null 2>&1; exit 0"]


### PR DESCRIPTION
Code Changes: 
----------------
- Created a tutorial to run percona mysql pod on openebs storage in k8s with steps for load generation (using client container) and stats monitoring (using mayactl)

- Added a kubernetes job yaml for performing sql load generation. The sql-loadgen.yaml is a batch job that generates R/W load on mysql database server through insert and select queries

- Duration of load and IP of database application pod are passed as arguments to the mysql-container run in the pod

Changes tested on:
---------------------
The steps were validated by running them on a local setup with k8s cluster configured on ubuntu 16.04 VMs