### PR TITLE
Fix for #198: Contains the code changes to generate a random unique name for AWS S3 bucket.

### DIFF
--- a/e2e/terraform/oebs-cloud.sh
+++ b/e2e/terraform/oebs-cloud.sh
@@ -3,6 +3,7 @@
 set -e
 
 master_dns_name=
+s3_bucket_name=
 
 function show_help() {
     cat << EOF
@@ -98,8 +99,12 @@ function create_terraform_file() {
     
     # Wait for AWS to refresh
     sleep 60
+
+    # Create unique S3 bucket name for each user
+    # Amazon S3 bucket names are universal
+    s3_bucket_name=`echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2`
     
-    aws s3api create-bucket --bucket openebs-k8s-local-state-store
+    aws s3api create-bucket --bucket openebs-k8s-`echo $s3_bucket_name`-local-state-store
 
     if [ -e ~/.ssh/id_rsa.pub ];then
         echo "Using Public Key for Passwordless SSH."

--- a/e2e/terraform/oebs-cloud.sh
+++ b/e2e/terraform/oebs-cloud.sh
@@ -122,7 +122,7 @@ function create_terraform_file() {
     --node-size=t2.micro \
     --zones=us-east-1a \
     --image=ami-2757f631 \
-    --state=s3://openebs-k8s-local-state-store \
+    --state=s3://openebs-k8s-`echo $s3_bucket_name`-local-state-store \
     --target=terraform \
     --out=. \
     --name=openebs.k8s.local


### PR DESCRIPTION
Generate unique S3 bucket names on AWS.

Code Changes:
-------------------

- Contains the fix to generate a random name for S3 bucket.
- Fix adheres to standard S3 bucket naming conventions.

Tested On:
-------------

ESX VM - (Ubuntu 16.04)

Details of the fix:
--------------------

The oebs-cloud.sh script used a standard name 'openebs-k8s-local-state-store' for creating a S3 bucket on AWS. But the S3 bucket names, seem to be universal and AWS does not allow the creation of the bucket with the same name for any other AWS user. So the name needs to be randomized so as  to avoid the duplicate name conflict.

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>