### PR TITLE
Make ara setup role more generic 

### DIFF
--- a/e2e/ansible/roles/ara/tasks/main.yml
+++ b/e2e/ansible/roles/ara/tasks/main.yml
@@ -18,6 +18,12 @@
   command: python -c "import os,ara; print(os.path.dirname(ara.__file__))"
   register: ara_location  
 
+- name: Create plugins folder in playbook directory if it doesn't exist
+  file:
+    path: "{{ playbook_dir }}/plugins/callback"
+    recurse: yes
+    state: directory
+
 - name: Copy ara callback plugin to openebs custom plugins location
   copy: 
     src: "{{ ara_location.stdout }}/plugins/callbacks/log_ara.py"  

--- a/e2e/ansible/roles/ara/tasks/main.yml
+++ b/e2e/ansible/roles/ara/tasks/main.yml
@@ -39,7 +39,7 @@
     src: "{{ ara_location.stdout }}/plugins/modules"
     dest: "{{ playbook_dir }}/plugins"
 
-- name: Update ansible.cfg with ara module library
+- name: Update ansible.cfg with ara module library path
   ini_file:
     path: "{{ playbook_dir }}/ansible.cfg"
     section: defaults
@@ -47,7 +47,14 @@
     value: "./plugins/modules"
     backup: yes
 
-- name: Update ansible.cfg with ara action plugins 
+- name: Update ansible.cfg with callback plugin path
+  ini_file:
+    path: "{{ playbook_dir }}/ansible.cfg"
+    section: defaults
+    option: callback_plugins
+    value: "./plugins/callback"
+
+- name: Update ansible.cfg with ara action plugins path
   ini_file:
     path: "{{ playbook_dir }}/ansible.cfg"
     section: defaults


### PR DESCRIPTION
Code changes: 
----------------
- Updated the ara role to make it more generic,i.e., added steps to create a custom plugin directory with "callbacks" folder if it is not already present, and also added step to edit ansible.cfg to point to custom callback plugin path

   (It is already available by default if the openebs/e2e/ansible is downloaded as is, but general ansible users may be using default plugins. With current changes, they can directly use the role in their environments)

Changes tested on: 
---------------------
Ubuntu 16.04 64 bit Baremetal boxes/ESX VMs as non-root user on test harness and target hosts