### PR TITLE
Setup kube-proxy in user-mode networking

### DIFF
--- a/k8s/lib/scripts/configure_k8s_weave.sh
+++ b/k8s/lib/scripts/configure_k8s_weave.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 
-function setup_k8s_weave() {
-    kubectl apply -n kube-system -f $HOME/setup/weave/weave-daemonset-k8s-1.6.yaml
+function patch_kube_proxy(){
+    kubectl -n kube-system get ds -l 'k8s-app=kube-proxy' -o json \
+    | jq '.items[0].spec.template.spec.containers[0].command |= .+ ["--proxy-mode=userspace"]' \
+    | kubectl apply -f - \
+    && kubectl -n kube-system delete pods -l 'k8s-app=kube-proxy'
 }
 
+function setup_k8s_weave() {
+    kubectl apply -f $HOME/setup/weave/weave-daemonset-k8s-1.6.yaml
+}
+
+
+#Patching kube-proxy to run with --proxy-mode=userspace
+echo Patching the kube-proxy for CNI Networks...
+patch_kube_proxy
 
 echo Configure Pod Network with Weave
 setup_k8s_weave

--- a/k8s/lib/vagrant/patch/Vagrantfile
+++ b/k8s/lib/vagrant/patch/Vagrantfile
@@ -1,0 +1,118 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+
+BOX_MODE_OPENEBS    = 1
+BOX_MODE_KUBERNETES = 2
+
+box_Mode=ENV['OPENEBS_BUILD_BOX'] || 2
+
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  if ((box_Mode.to_i < BOX_MODE_OPENEBS.to_i) || \
+      (box_Mode.to_i > BOX_MODE_KUBERNETES.to_i))
+        puts "Invalid value set for OPENEBS_BUILD_BOX."
+        puts "Usage: OPENEBS_BUILD_BOX=1 for OpenEBS."
+        puts "Usage: OPENEBS_BUILD_BOX=2 for Kubernetes."
+        puts "Defaulting to OpenEBS..." 
+        puts "Do you want to continue?(y/n):"
+
+        input = STDIN.gets.chomp
+        while 1 do
+           if(input == "n")
+             Kernel.exit!(0)
+           elsif(input == "y")
+             break
+           else
+             puts "Invalid input: type 'y' or 'n'"
+             input = STDIN.gets.chomp
+           end
+        end
+        box_Mode = 1
+    end
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "openebs/k8s-1.7.5"
+
+  # Needed for ubuntu/xenial64 packaged boxes
+  # The default user is ubuntu for those boxes
+  config.ssh.username = "ubuntu"
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "ubuntu:ubuntu" | sudo chpasswd
+  SHELL
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  if box_Mode.to_i == BOX_MODE_KUBERNETES.to_i
+    
+    config.vm.provision :shell, 
+    path: "patch_k8s.sh",
+    privileged: true
+
+  elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i
+
+    config.vm.provision :shell, 
+    path: "patch_openebs.sh",
+    privileged: true
+  end
+end

--- a/k8s/lib/vagrant/patch/patch_k8s.sh
+++ b/k8s/lib/vagrant/patch/patch_k8s.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Insert the patch instructions here
+
+# Patch 01 - Copy the latest configure_k8s_weave.sh 
+# Location of the k8s configure scripts
+scriptloc="/vagrant/workdir/scripts/k8s"
+cd /home/ubuntu/setup/k8s
+cp ${scriptloc}/configure_k8s_weave.sh .
+# END Patch 01
+
+
+# DONOT MODIFY BELOW THIS LINE
+# Cleaning up apt and bash history before packaing the box. 
+sudo mkdir -p /etc/systemd/system/apt-daily.timer.d/
+cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf > /dev/null
+[Timer]
+Persistent=false
+EOF
+
+sudo apt-get clean
+cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/patch/patch_openebs.sh
+++ b/k8s/lib/vagrant/patch/patch_openebs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Insert the patch instructions here
+
+
+# DONOT MODIFY BELOW THIS LINE
+# Cleaning up apt and bash history before packaing the box. 
+# Cleaning up apt and bash history before packaing the box.
+sudo mkdir -p /etc/systemd/system/apt-daily.timer.d/
+cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf > /dev/null
+[Timer]
+Persistent=false
+EOF
+
+sudo apt-get clean
+cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/patch/patch_vagrantbox.sh
+++ b/k8s/lib/vagrant/patch/patch_vagrantbox.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+kubeversion="1.7.5"
+
+function fetch_k8s_scripts(){
+    mkdir -p workdir/scripts/k8s/    
+    cp ../../scripts/configure_k8s_master.sh workdir/scripts/k8s/
+    cp ../../scripts/configure_k8s_host.sh workdir/scripts/k8s/
+    cp ../../scripts/configure_k8s_weave.sh workdir/scripts/k8s/
+    cp ../../scripts/configure_k8s_cred.sh workdir/scripts/k8s/
+    cp ../../scripts/configure_k8s_dashboard.sh workdir/scripts/k8s/
+}
+
+function fetch_specs(){
+    mkdir -p workdir/specs
+    cp ../../../demo/specs/demo-vdbench-openebs.yaml workdir/specs/
+    cp ../../../demo/specs/demo-fio-openebs.yaml workdir/specs/
+}
+
+function cleanup(){
+    rm -rf workdir
+}
+
+#echo Gathering all the K8s configure scripts to be package
+fetch_k8s_scripts
+
+#echo Gathering sample k8s specs
+fetch_specs
+
+#echo Launch VM
+vagrant up
+vagrant package --output workdir/kubernetes-${kubeversion}.box
+
+#echo Test the new box
+mkdir -p workdir/test 
+vagrant box add --name openebs/k8s-test-box --force workdir/kubernetes-${kubeversion}.box 
+currdir=`pwd`
+echo Launch Test VM
+cp ../test/k8s/Vagrantfile workdir/test/
+cd workdir/test; 
+vagrant up
+#vagrant destroy -f
+#vagrant box remove openebs/k8s-test-box
+#cd $currdir
+
+echo Destroy the default vm
+#vagrant destroy default
+
+echo Clear working directory
+#cleanup
+
+


### PR DESCRIPTION
Fixes #302

As part of the recent upgrades, the changes (PR #295) to set the
kube-proxy in user mode were reverted. As it turns out, the issue
of weave pods getting stuck in CrashLoopBackOff appears intermittently
and on restarts of the kubeminion nodes.

Reverting back the changes that removed setting kube-proxy in
user-mode