### PR TITLE
Remove Release Notes

### DIFF
--- a/documentation/source/getting_started/overview.rst
+++ b/documentation/source/getting_started/overview.rst
@@ -6,7 +6,7 @@ OpenEBS is a storage platform, written in GoLang, to deliver persistent block st
 **See Also:**
 
 Changelog_
-          .. _Changelog: http://openebs.readthedocs.io/en/latest/release_notes/releasenotes.html
+          .. _Changelog: https://github.com/openebs/openebs/releases
 
 
 .. <<TBD>> Include why OpenEBS/Benefits <<TBD>>

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -38,9 +38,9 @@ Contents:
    
 
 
-.. toctree::
+.. .. toctree::
    :maxdepth: 1
    :caption: Release Notes
    
 
-   Changelog <release_notes/releasenotes>
+..   Changelog <release_notes/releasenotes>


### PR DESCRIPTION
Removed Release Notes section on the left pane and added a link to GitHub in the Introducing OpenEBS section for Changelog. Fixes #320