### PR TITLE
Add prometheus to monitor openebs

### DIFF
--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -1,0 +1,148 @@
+# Define the Service Account
+# Define the RBAC rules for the Service Account
+# Launch the Prometheus ( deployment )
+# Launch the node-exporter ( deameon set )
+#
+# Create prometheus service account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: default
+---
+# Define Role that allows operations on K8s pods/deployments
+# in "default" namespace
+# TODO : change to new namespace, for isolated data network
+# TODO : the rules should be updated with required group/resources/verb
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+---
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default
+---
+# prometheus-deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: prometheus-server
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: prometheus
+          image: prom/prometheus:latest
+          args:
+            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            # Metrics are stored in an emptyDir volume which
+            # exists as long as the Pod is running on that Node.
+            # The data in an emptyDir volume is safe across container crashes.
+            - "-storage.local.path=/prometheus"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            # prometheus config file stored in the given mountpath
+            - name: prometheus-server-volume
+              mountPath: /etc/prometheus/conf
+            # metrics collected by prometheus will be stored at the given mountpath.
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
+      volumes:
+        - name: prometheus-server-volume
+          configMap:
+            name: prometheus-config
+        - name: prometheus-storage-volume
+          # containers in the Pod can all read and write the same files here.
+          emptyDir: {} 
+---
+# prometheus-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+spec:
+  selector: # exposes any pods with the following labels as a service
+    name: prometheus-server
+  type: NodePort
+  ports:
+    - port: 80 # this Service's port (cluster-internal IP clusterIP)
+      targetPort: 9090 # pods expose this port
+      # Kubernetes master will allocate a port from a flag-configured range (default: 30000-32767),
+      # or we can set a specific port number (in our case).
+      # Each node will proxy 32514 port (the same port number on every node) into this service.
+      # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:port
+      nodePort: 32514
+---
+# node-exporter will be launch as daemonset.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+      name: node-exporter
+    spec:
+      containers:
+      - image: prom/node-exporter:latest
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: scrape
+        volumeMounts:
+        # All the application data stored in data-disk
+        - name: data-disk
+          mountPath: /data-disk
+          readOnly: true
+        # Root disk is where OS(Node) is installed
+        - name: root-disk
+          mountPath: /root-disk
+          readOnly: true
+      # toleration  is particularly useful for situations where most pods in 
+      # the cluster should avoid scheduling onto the node. In our case we want
+      # node-exporter to run on master node also that's why tolerations added.
+      # if removed master's node metrics can't be scrapped by prometheus.
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      volumes:
+        - name: data-disk
+          hostPath:
+            path: /localdata
+        - name: root-disk
+          hostPath:
+            path: /
+      hostNetwork: true
+      hostPID: true

--- a/k8s/openebs-monitoring/prometheus.yaml
+++ b/k8s/openebs-monitoring/prometheus.yaml
@@ -1,0 +1,169 @@
+# ConfigMap is used to run prometheus with given configuration. It helps
+# if we want to change the configuration from time to time because our 
+# requirement changes so configurations also need to change accordingly.
+#
+# A scrape configuration for running Prometheus on a Kubernetes cluster.
+# This uses separate scrape configs for cluster components (i.e. API server, node)
+# and services to allow each to use different authentication configs.
+#
+# Kubernetes labels will be added as Prometheus labels on metrics via the
+# `labelmap` relabeling action.
+#
+# If you are using Kubernetes 1.7.2 or earlier, please take note of the comments
+# for the kubernetes-cadvisor job; you will need to edit or remove this job.
+
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+apiVersion: v1
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    
+    # scrape config for maya-apiserver pods
+    #
+    # The relabeling allows the actual pod scrape endpoint to be configured via the
+    # following annotations:
+    #
+    # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+    # pod's declared ports (default is a port-free target if none are declared).
+    scrape_configs:
+    - job_name: 'maya-apiserver'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: maya-apiserver
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name : 'kubelets'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /metrics 
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:10255'
+        target_label: __address__
+      
+      # Scrape config for API servers.
+      #
+      # Kubernetes exposes API servers as endpoints to the default/kubernetes
+      # service so this uses `endpoints` role and uses relabelling to only keep
+      # the endpoints associated with the default/kubernetes service using the
+      # default named port `https`. This works for single API server deployments as
+      # well as HA API server deployments.  
+    - job_name: 'kubernetes-apiservers'
+      kubernetes_sd_configs:
+      - role: endpoints
+      
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https
+      
+      # This TLS & bearer token file config is used to connect to the actual scrape
+      # endpoints for cluster components. This is separate to discovery auth
+      # configuration because discovery & scraping are two separate concerns in
+      # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+      # the cluster. Otherwise, more config options have to be provided within the
+      # <kubernetes_sd_config>.
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      
+      # If your node certificates are self-signed or use a different CA to the
+      # master CA, then disable certificate verification below. Note that
+      # certificate verification is an integral part of a secure infrastructure
+      # so this should only be disabled in a controlled environment. You can
+      # disable certificate verification by uncommenting the line below.
+      #
+      # insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      
+      # Keep only the default/kubernetes service endpoints for the https port. This
+      # will add targets for each API server which Kubernetes adds an endpoint to
+      # the default/kubernetes service.
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: default;kubernetes;https
+    
+      # Scrape config for Kubelet cAdvisor.
+      #
+      # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+      # (those whose names begin with 'container_') have been removed from the
+      # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+      # retrieve those metrics.
+      #
+      # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+      # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+      # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+      # the --cadvisor-port=0 Kubelet flag).
+      #
+      # This job is not necessary and should be removed in Kubernetes 1.6 and
+      # earlier versions, or it will cause the metrics to be scraped twice.
+    - job_name: 'kubernetes-cadvisor'
+      
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https 
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+    
+      # Scrap config for node-exporter.
+      #
+      # This is required to scrap the node metrics such as IO's, CPU and other metrics
+      # related to node. By default it scrap only from worker nodes if run as deployment
+      # but you can monitor master node also. To monitor node you need to run it as
+      # daemonset and add 'toleration' field in node-exporter.yaml file.For more details
+      # see 'taints and toleration' in Kubernetes documentation. 
+    - job_name: 'kubernetes-node-exporter'
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - source_labels: [__meta_kubernetes_role]
+        action: replace
+        target_label: kubernetes_role
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:9100'
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+        target_label: __instance__
+      - source_labels: [job]
+        regex: 'kubernetes-(.*)'
+        replacement: '${1}'
+        target_label: name


### PR DESCRIPTION
 **What this PR does / why we need it**:
* This PR refers issue #341 
* This PR adds prometheus-operator and config file to monitor openebs cluster.

**How this commit address the issue**:
* Prometheus now collects metrics from cadvisor, kubelet, node and pods.

**How to verify this change**
* After bringing up the openebs on vagrant, change directory `cd openebs-monitoring`
* Set up configmap by `kubectl create -f prometheus.yaml` and wait for few seconds to let it configured well
* Now run `kubectl create -f prometheus-operator.yaml`. It will launch prometheus pod, deployment, service and node exporter.
* Open new tab in terminal from outside the vagrant and do `ssh -NL <port>:<localhost>:32514 ubuntu@<ip_address_of_node>`. You can specify any valid port and `172.28.128.3` as your ip_address_of_node.
* Now open `localhost:port` on your browser and you will be able to see the expression browser of prometheus.

**Note**:
* PR [#106](https://github.com/openebs/mayaserver/pull/106) is dependent on this commit, So it will not show you custom metrics exposed by maya-apiserver.
* It does not monitor openebs-provisioner as it is not running as service.