### PR TITLE
Fix for #399: Ansible Playbook, now downloads the correct version kubernetes packages.

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -22,9 +22,13 @@ k8s_version_list:
   - 1.6.5
   - 1.6.6
   - 1.7.0
+  - 1.7.2
+  - 1.7.4
+  - 1.7.5
 
 weave_version_list:
-  - 1.9.4 
+  - 1.9.4
+  - 2.0.4 
 
 #########################################
 # OpenEBS Deployment Specifications     #

--- a/e2e/ansible/roles/k8s-localhost/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/defaults/main.yml
@@ -12,17 +12,12 @@ pip_local_packages:
 # Links for .deb packages that will be installed on all K8s boxes (masters, minions), i.e, 
 # these packages will be copied into kubernetes role's .files
 
-k8s_deb_packages:
-  - https://packages.cloud.google.com/apt/pool/kubeadm_{{ k8s_version }}-00_amd64_ff5e882c88a5db71803aab900c0b341eb63038558da73c51c3d351070b0c62af.deb
-  - https://packages.cloud.google.com/apt/pool/kubectl_{{ k8s_version }}-00_amd64_05d48fa118b6538ee2bc0b864aeb09f2cede83990fc8819875f698a5dece0c9b.deb
-  - https://packages.cloud.google.com/apt/pool/kubelet_{{ k8s_version }}-00_amd64_a94b0cfa5b26939d87097dfd45260474c1effcad879e35940eb6d36e7d953d6c.deb
-  - https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.5.1-00_amd64_08cbe5c42366ec3184cc91a4353f6e066f2d7325b4db1cb4f87c7dcc8c0eb620.deb
+k8s_cni_deb_package: https://packages.cloud.google.com/apt/pool/kubernetes-cni_0.5.1-00_amd64_08cbe5c42366ec3184cc91a4353f6e066f2d7325b4db1cb4f87c7dcc8c0eb620.deb
 
 k8s_deb_package_alias:
   - kubeadm.deb
   - kubectl.deb
   - kubelet.deb
-  - kubernetes-cni.deb
 
 # Container images that needs to be placed on all K8s boxes (masters, minions)
 # These images will be downloaded, tar'ed and pushed into the kubernetes role's .files

--- a/e2e/ansible/roles/k8s-localhost/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-localhost/tasks/main.yml
@@ -31,9 +31,13 @@
 
 ## kubernetes role preparation
 
+- name: Get .deb package details
+  shell: "curl -s https://packages.cloud.google.com/apt/dists/kubernetes-xenial/main/binary-amd64/Packages | grep _{{ k8s_version }} | awk '{print $2}' | cut -d '/' -f2"
+  register: k8s_deb_packages
+
 - name: Get .deb kubernetes packages google cloud 
   get_url: 
-    url: "{{ item.0 }}"
+    url: "https://packages.cloud.google.com/apt/pool/{{ item.0 }}"
     dest: "{{ playbook_dir }}/roles/kubernetes/files/{{item.1}}"
     force: yes
   register: result
@@ -41,8 +45,18 @@
   delay: 5
   retries: 3
   with_together: 
-    - "{{ k8s_deb_packages }}"
+    - "{{ k8s_deb_packages.stdout_lines }}"
     - "{{ k8s_deb_package_alias }}"
+
+- name: Get CNI .deb package from google cloud
+  get_url:
+    url: "{{k8s_cni_deb_package}}"
+    dest: "{{ playbook_dir }}/roles/kubernetes/files/kubernetes-cni.deb"
+    force: yes
+  register: result
+  until: "'OK' in result.msg"
+  delay: 5
+  retries: 3
 
 - name: Check whether deb packages and images are already downloaded
   stat: 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add missing versions of kubernetes and weave in all.yml.
- Add logic to get the desired version of kubeadm, kubelet and kubectl from google cloud packages.
- Addresses problems caused by kubeadm issue.(refer:https://github.com/kubernetes/kubeadm/issues/291)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #399
  
**Special notes for your reviewer**:

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>