### PR TITLE
Updates to test playbooks : Resolves postgres deploy failure & improves libiscsi-cleanup process

### DIFF
--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
@@ -6,7 +6,7 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name: Confirm the iSCSI target has been deleted
-  shell: source ~/.profile; kubectl get pods
+  shell: source ~/.profile; kubectl get pvc
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -56,6 +56,15 @@
            line: "              \"storage\": \"{{postgres_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Get the number of replicas from set.json
+         command: cat {{ result_kube_home.stdout }}/crunchy-postgres/set.json
+         register: jsonfile
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Register the replica variable 
+         set_fact:
+           replicas: "{{(jsonfile.stdout | from_json).spec.replicas}}"
+
        - name: Comment the cleanup step in the run.sh with 
          lineinfile:
            path: "{{ result_kube_home.stdout }}/crunchy-postgres/run.sh" 
@@ -73,12 +82,12 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Confirm the postgres statefulset is running 
-         shell: source ~/.profile; kubectl get pods | grep pgset
+         shell: source ~/.profile; kubectl get pods | grep pgset| grep Running | wc -l
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: setup
-         until: "'pgset-0' and 'Running' in setup.stdout_lines[0] and 'pgset-1' and 'Running' in setup.stdout_lines[1]"
+         until: "replicas in setup.stdout"
          delay: 300
          retries: 6
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -56,10 +56,14 @@
            line: "              \"storage\": \"{{postgres_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Get the number of replicas from set.json
+       - name: Get the number of statefulset details from set.json
          command: cat {{ result_kube_home.stdout }}/crunchy-postgres/set.json
          register: jsonfile
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       
+       - name: Register the app label
+         set_fact:
+           label: "{{(jsonfile.stdout | from_json).spec.template.metadata.labels.app}}"
 
        - name: Register the replica variable 
          set_fact:
@@ -82,7 +86,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Confirm the postgres statefulset is running 
-         shell: source ~/.profile; kubectl get pods | grep pgset| grep Running | wc -l
+         shell: source ~/.profile; kubectl get pods --selector=app={{ label }} | grep Running | wc -l
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Postgresql statefulset deployment failure : This was caused due to a timing issue where the pods
take more than a few sec to comeup, causing a a line in the playbook to fail on account of
using invalid variable (it is null until pod instantiation is done). Updated this line to avoid
the said error. Also, now the playbook verifies whether "all" the replicas (as mentioned in set.json
file from crunchy-data) are UP.

- libiscsi cleanup improvement : Added check whether all PVCs are deleted

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #425 
fixes #428 

**Special notes for your reviewer**:
