### PR TITLE
Setup Travis CI for documentation changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
-dist: trusty
-sudo: required
-install: true
+language: python
+
+python:
+  - "2.7"
+
+install: "pip install -q -r requirements.txt"
+
 script:
-  - make build
-notifications:
-  email:
-    recipients:
-      - kiran.mova@cloudbyte.com
+  - cd documentation; sphinx-build -nW -b html source build
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx==1.6.3
+sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
Fixes #443

.travis.yaml
 - adds sphinx build steps that converts warnings into errors
 - inspiration: https://coderwall.com/p/wws2uq/have-travis-ci-test-your-sphinx-docs

requirements.txt
 - sphinx related packages
