### PR TITLE
Partially Fixes the issue #477.

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -20,7 +20,7 @@
   args:
     executable: /bin/bash
   register: result
-  until:  "'Ready' in result.stdout"
+  until:  result.stdout == "Ready"
   delay: 60
   retries: 10
   ignore_errors: true  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
The condition to validate the state of the master node has been modified. This fix correctly validates the state and continues with the playbook execution.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes issue #477 , specific to validating the state of the Kubernetes Master.

**Special notes for your reviewer**:

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>
