### PR TITLE
Initial commit for MongoDB support in OpenEBS.

### DIFF
--- a/k8s/demo/mongodb/mongo-statefulset.yml
+++ b/k8s/demo/mongodb/mongo-statefulset.yml
@@ -1,0 +1,53 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+ name: mongo
+ labels:
+   name: mongo
+spec:
+ ports:
+ - port: 27017
+   targetPort: 27017
+ clusterIP: None
+ selector:
+   role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+ name: mongo
+spec:
+ serviceName: "mongo"
+ replicas: 3
+ template:
+   metadata:
+     labels:
+       role: mongo
+       environment: test
+   spec:
+     terminationGracePeriodSeconds: 10
+     containers:
+       - name: mongo
+         image: mongo
+         command:
+           - mongod
+           - "--replSet"
+           - rs0
+           - "--smallfiles"
+           - "--noprealloc"
+         ports:
+           - containerPort: 27017
+         volumeMounts:
+           - name: mongo-persistent-storage
+             mountPath: /data/db
+ volumeClaimTemplates:
+ - metadata:
+     name: mongo-persistent-storage
+   spec:
+     storageClassName: openebs-percona
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 5G

--- a/k8s/demo/mongodb/mongo-statefulset.yml
+++ b/k8s/demo/mongodb/mongo-statefulset.yml
@@ -45,7 +45,7 @@ spec:
  - metadata:
      name: mongo-persistent-storage
    spec:
-     storageClassName: openebs-percona
+     storageClassName: openebs-basic
      accessModes:
        - ReadWriteOnce
      resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Creates Headless Service for MongoDB.
- Creates StatefulSet for MongoDb with ReplicaSet set to 3.
- Uses OpenEBS Storage in volumeClaimTemplates.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fix for issue #353 

**Special notes for your reviewer**:

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>