### PR TITLE
Change the readthedocs theme's sidebar to orange colour.

### DIFF
--- a/documentation/source/_static/theme_overrides.css
+++ b/documentation/source/_static/theme_overrides.css
@@ -1,10 +1,13 @@
 /* override logo styling */
-.logo {
+/*.logo {
   display: block;
   width: 150px !important;
   margin: 5px;
   fill: #fff;
   background-color: #fb8225 !important;
   border-radius: 0 !important;
-}
+}*/
 
+.wy-side-nav-search {
+  background-color: #ee5a2b;
+}

--- a/documentation/source/_templates/layout.html
+++ b/documentation/source/_templates/layout.html
@@ -1,6 +1,8 @@
 
 {% extends "!layout.html" %}
 
+{% set css_files = css_files + ["_static/theme_overrides.css"] %}
+
 <div style="background-color: grey;">
 
 {% block rootrellink %}
@@ -22,5 +24,3 @@
 {% block sidebar2 %}
 </div>
 {% endblock %}
-
-


### PR DESCRIPTION
The sidebar colour in the [read the docs documentation](http://openebs.readthedocs.io/en/latest/) becomes orange (`#ee5a2b`) with this change.

This fixes #509.