### PR TITLE
Update the k8s-openebs-operator ansible role with improved deployment status check 

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -35,25 +35,14 @@
   when: result.stdout != "Ready"
 
 - name: Deploy the openebs operator yml
-  shell: source ~/.profile; kubectl apply -f {{ openebs_operator_alias }} 
+  shell: >
+    source ~/.profile; 
+    kubectl apply -f {{ openebs_operator_alias }} 
+    | grep deployment | awk '{print $2}'
+    | tr -d '"'
   args:
     executable: /bin/bash
-  register: op_out
-
-- name: Place stdout into temp file
-  shell: echo {{item}} >> {{ ansible_env.HOME }}/op_out.log
-  args:
-    executable: /bin/bash
-  with_items: "{{op_out.stdout_lines}}"
-
-- name: Get deployment label names 
-  shell: cat {{ ansible_env.HOME }}/op_out.log | grep deployment | awk '{print $2}'
-  register: labels 
-
-- name: Remove the temp file 
-  file: 
-    path: "{{ ansible_env.HOME }}/op_out.log"
-    state: absent
+  register: labels
 
 - name: Confirm provisioner & apiserver are running
   shell: source ~/.profile; kubectl get pods --selector=name={{item}} | grep Running |wc -l 

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -20,9 +20,9 @@
   args:
     executable: /bin/bash
   register: result
-  until:  result.stdout == "Ready"
+  until:  result.stdout == 'Ready'
   delay: 60
-  retries: 10
+  retries: 10 
   ignore_errors: true  
 
 - name: 
@@ -38,19 +38,42 @@
   shell: source ~/.profile; kubectl apply -f {{ openebs_operator_alias }} 
   args:
     executable: /bin/bash
+  register: op_out
 
-- name: Confirm maya-apiserver pod is running
-  shell: source ~/.profile; kubectl get pods
+- name: Place stdout into temp file
+  shell: echo {{item}} >> {{ ansible_env.HOME }}/op_out.log
+  args:
+    executable: /bin/bash
+  with_items: "{{op_out.stdout_lines}}"
+
+- name: Get deployment label names 
+  shell: cat {{ ansible_env.HOME }}/op_out.log | grep deployment | awk '{print $2}'
+  register: labels 
+
+- name: Remove the temp file 
+  file: 
+    path: "{{ ansible_env.HOME }}/op_out.log"
+    state: absent
+
+- name: Confirm provisioner & apiserver are running
+  shell: source ~/.profile; kubectl get pods --selector=name={{item}} | grep Running |wc -l 
   args:
     executable: /bin/bash
   register: result_pod
-  until: "'maya-apiserver' and 'Running' in result_pod.stdout_lines[1] and 'openebs-provisioner' and 'Running' in result_pod.stdout_lines[2]"
-  delay: 300
-  retries: 6
+  until: result_pod.stdout|int >= 1
+  delay: 120
+  retries: 15
+  with_items: "{{ labels.stdout_lines }}"
+
+- name: Get maya-apiserver pod name
+  shell: source ~/.profile; kubectl get pods --selector=name=maya-apiserver 
+  args:
+    executable: /bin/bash
+  register: result_name
 
 - name: Create fact for pod name
   set_fact: 
-    pod_name: "{{ result_pod.stdout_lines[1].split()[0] }}"
+    pod_name: "{{ result_name.stdout_lines[1].split()[0] }}"
 
 - name: Confirm that maya-cli is available in the maya-apiserver pod
   shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -- maya version


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Dynamically get the deployments we are performing as part of applying openebs-operator
  instead of hardcoding as maya-apiserver and openebs-provisioner

- Improved the way we perform the status check for openebs-operator deployments using pod
  labels

- Reduced the wait duration and increased number of retries in the polling task of the above status check. This is to ensure the wait window is smaller before moving on to the next step

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #477 

**Special notes for your reviewer**:
These changes are focused on Pt.2 of the issue #477 , with Pt.1 addressed by PR #481 