### PR TITLE
Deployment specification YAMLs for mysql-replication cluster

### DIFF
--- a/k8s/demo/mysql-replication-cluster/deployments/mysql-master.yaml
+++ b/k8s/demo/mysql-replication-cluster/deployments/mysql-master.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql-master
+  labels:
+    name: mysql-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-master
+  template:
+    metadata:
+      labels:
+        name: mysql-master
+    spec:
+      containers:
+        - name: master
+          image: openebs/tests-mysql-master
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: "test"
+            - name: MYSQL_REPLICATION_USER
+              value: 'demo'
+            - name: MYSQL_REPLICATION_PASSWORD
+              value: 'demo'
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-percona
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-master
+  labels:
+    name: mysql-master
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: mysql-master

--- a/k8s/demo/mysql-replication-cluster/deployments/mysql-slave.yaml
+++ b/k8s/demo/mysql-replication-cluster/deployments/mysql-slave.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: mysql-slave
+  labels:
+    name: mysql-slave
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-slave
+  template:
+    metadata:
+      labels:
+        name: mysql-slave
+    spec:
+      containers:
+        - name: slave
+          image: openebs/tests-mysql-slave
+          args: 
+            - "--ignore-db-dir"
+            - "lost+found"
+          ports:
+            - containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: "test"
+            - name: MYSQL_REPLICATION_USER
+              value: 'demo'
+            - name: MYSQL_REPLICATION_PASSWORD
+              value: 'demo'
+          volumeMounts: 
+            - mountPath: /var/lib/mysql
+              name: demo-vol2
+      volumes:
+        - name: demo-vol2     
+          persistentVolumeClaim:
+            claimName: demo-vol2-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol2-claim
+spec:
+  storageClassName: openebs-percona
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-slave
+  labels:
+    name: mysql-slave
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: mysql-slave


### PR DESCRIPTION
**What this PR does / why we need it**:

mysql replication cluster is an asynchronous replication-based cluster with slave taking _only_ replication writes.  This PR provides a couple of simple k8s deployment specification YAMLs to setup this mysql-cluster. Together, it constitutes : 

a) mysql-master & mysql-sql k8s services which expose the access to mysql-master & slave pods 
b) mysql-master & mysql-slave k8s deployments running the master and slave DB servers, which use the OpenEBS persistent volumes

The mysql-master and slave use their respective custom images - ```openebs/tests-mysql-master``` & ```openebs/tests-mysql-slave```

The steps to setup and test the mysql replication cluster are provided below : 

```
karthik@MayaMaster:~/mysql-replication$ kubectl apply -f mysql-master.yaml
deployment "mysql-master" created
persistentvolumeclaim "demo-vol1-claim" created
service "mysql-master" created

karthik@MayaMaster:~/mysql-replication$ kubectl apply -f mysql-slave.yaml
deployment "mysql-slave" created
persistentvolumeclaim "demo-vol2-claim" created
service "mysql-slave" created

karthik@MayaMaster:~/mysql-replication$ kubectl get pods
NAME                                                             READY     STATUS    RESTARTS   AGE
maya-apiserver-1089964587-sqr7w                                  1/1       Running   0          21h
mysql-master-617764837-d76bw                                     1/1       Running   0          4m
mysql-slave-3765196437-86ckb                                     1/1       Running   0          4m
openebs-provisioner-1149663462-3k8z5                             1/1       Running   0          21h
pvc-6a33e259-aa6c-11e7-b043-000c298ff5fc-ctrl-2249910151-nwm42   1/1       Running   0          4m
pvc-6a33e259-aa6c-11e7-b043-000c298ff5fc-rep-1734254689-47475    1/1       Running   0          4m
pvc-6a33e259-aa6c-11e7-b043-000c298ff5fc-rep-1734254689-dn0wx    1/1       Running   0          4m
pvc-6e36ba88-aa6c-11e7-b043-000c298ff5fc-ctrl-2465654818-d4rvx   1/1       Running   0          4m
pvc-6e36ba88-aa6c-11e7-b043-000c298ff5fc-rep-3253051697-q89tl    1/1       Running   0          4m
pvc-6e36ba88-aa6c-11e7-b043-000c298ff5fc-rep-3253051697-qdzrt    1/1       Running   0          4m

karthik@MayaMaster:~/mysql-replication$ kubectl exec -it mysql-master-617764837-d76bw /bin/bash
root@mysql-master-617764837-d76bw:/# mysql -uroot -ptest;
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 5
Server version: 5.7.19-log MySQL Community Server (GPL)

Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
+--------------------+
4 rows in set (0.00 sec)

mysql> create database testdb;
Query OK, 1 row affected (0.03 sec)

mysql> use testdb;
Database changed

mysql> CREATE TABLE Hardware (Name VARCHAR(20),HWtype VARCHAR(20),Model VARCHAR(20));
Query OK, 0 rows affected (0.15 sec)

mysql> INSERT INTO Hardware (Name,HWtype,Model) VALUES ('TestBox','Server','DellR820');
Query OK, 1 row affected (0.03 sec)

mysql> select * from Hardware;
+---------+--------+----------+
| Name    | HWtype | Model    |
+---------+--------+----------+
| TestBox | Server | DellR820 |
+---------+--------+----------+
1 row in set (0.00 sec)

mysql> exit
Bye
root@mysql-master-617764837-d76bw:/# exit
exit

karthik@MayaMaster:~/mysql-replication$ kubectl exec -it mysql-slave-3765196437-86ckb /bin/bash
root@mysql-slave-3765196437-86ckb:/# mysql -uroot -ptest;
mysql: [Warning] Using a password on the command line interface can be insecure.
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 5
Server version: 5.7.19-log MySQL Community Server (GPL)

Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show slave status\G;
*************************** 1. row ***************************
               Slave_IO_State: Waiting for master to send event
                  Master_Host: 10.98.131.65
                  Master_User: demo
                  Master_Port: 3306
                Connect_Retry: 60
              Master_Log_File: mysql-master-617764837-d76bw-bin.000003
          Read_Master_Log_Pos: 830
               Relay_Log_File: mysql-slave-3765196437-86ckb-relay-bin.000005
                Relay_Log_Pos: 1089
        Relay_Master_Log_File: mysql-master-617764837-d76bw-bin.000003
             Slave_IO_Running: Yes
            Slave_SQL_Running: Yes
              Replicate_Do_DB:
          Replicate_Ignore_DB:
           Replicate_Do_Table:
       Replicate_Ignore_Table:
      Replicate_Wild_Do_Table:
  Replicate_Wild_Ignore_Table:
                   Last_Errno: 0
                   Last_Error:
                 Skip_Counter: 0
          Exec_Master_Log_Pos: 830
              Relay_Log_Space: 3002273
              Until_Condition: None
               Until_Log_File:
                Until_Log_Pos: 0
           Master_SSL_Allowed: No
           Master_SSL_CA_File:
           Master_SSL_CA_Path:
              Master_SSL_Cert:
            Master_SSL_Cipher:
               Master_SSL_Key:
        Seconds_Behind_Master: 0
Master_SSL_Verify_Server_Cert: No
                Last_IO_Errno: 0
                Last_IO_Error:
               Last_SQL_Errno: 0
               Last_SQL_Error:
  Replicate_Ignore_Server_Ids:
             Master_Server_Id: 1
                  Master_UUID: 89c321ad-aa6c-11e7-af96-56ff7c178866
             Master_Info_File: /var/lib/mysql/master.info
                    SQL_Delay: 0
          SQL_Remaining_Delay: NULL
      Slave_SQL_Running_State: Slave has read all relay log; waiting for more updates
           Master_Retry_Count: 86400
                  Master_Bind:
      Last_IO_Error_Timestamp:
     Last_SQL_Error_Timestamp:
               Master_SSL_Crl:
           Master_SSL_Crlpath:
           Retrieved_Gtid_Set:
            Executed_Gtid_Set:
                Auto_Position: 0
         Replicate_Rewrite_DB:
                 Channel_Name:
           Master_TLS_Version:
1 row in set (0.00 sec)

ERROR:
No query specified

mysql> show databases;
+--------------------+
| Database           |
+--------------------+
| information_schema |
| mysql              |
| performance_schema |
| sys                |
| testdb             |
+--------------------+
5 rows in set (0.00 sec)

mysql> use testdb;
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Database changed

mysql> show tables;
+------------------+
| Tables_in_testdb |
+------------------+
| Hardware         |
+------------------+
1 row in set (0.00 sec)

mysql> select * from Hardware;
+---------+--------+----------+
| Name    | HWtype | Model    |
+---------+--------+----------+
| TestBox | Server | DellR820 |
+---------+--------+----------+
1 row in set (0.00 sec)

mysql> exit
Bye
root@mysql-slave-3765196437-86ckb:/#
root@mysql-slave-3765196437-86ckb:/# exit
exit
```
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #529 

**Special notes for your reviewer**:

The mysql-replication cluster can be built as a statefulset as well, and this is probably recommended, mainly for the following reason : 

- The pods are always created in order - and given an "ordinality"
- The DNS names of the pods will be constant across clusters, 
- PVs won't be deleted after deleting the statefulset, aiding backup/recovery etc..,
- Services for replication

However, with the traditional mysql-based asynchronous replication, unlike with other statefulsets like, say, postgresql or mongodb the containers need to have different mysql configuration in them, which means we need to create the master and replica w/ different conf inside at the time of spawning it, which in turn may need use of init-containers & config-maps to load appropriate configuration. This is slightly more complex to construct and deploy. Creation of statefulset YAMLs for mysql-replication will be tracked by a different issue : #544 

The current set of files use different container images for mysql-master & replica, with come pre-configured with the respective configurations, and are created as simple deployments with scope for scaling the number of replicas as well.