### PR TITLE
demo: adding redis standalone & cluster

### DIFF
--- a/k8s/demo/redis/redis-cluster.yml
+++ b/k8s/demo/redis/redis-cluster.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: redis-master
 spec:
+  clusterIP: None
   ports:
     - port: 6379
   selector:
@@ -18,6 +19,7 @@ metadata:
   labels:
     app: redis-replica
 spec:
+  clusterIP: None
   ports:
     - port: 6379
   selector:

--- a/k8s/demo/redis/redis-cluster.yml
+++ b/k8s/demo/redis/redis-cluster.yml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis-master
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: redis-master
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-replica
+  labels:
+    app: redis-replica
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: redis-replica
+
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: redis-master
+spec:
+  serviceName: redis-master
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-master
+  template:
+    metadata:
+      name: redis-master
+      labels:
+        app: redis-master
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        args: [ "--appendonly","yes" ]
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: openebs-redis
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5G
+
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: redis-replica
+spec:
+  serviceName: redis-replica
+  replicas: 3
+  selector:
+    matchLabels:
+      app: redis-replica
+  template:
+    metadata:
+      name: redis-replica
+      labels:
+        app: redis-replica
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        args: [
+          "--appendonly","yes" ,
+          "--slaveof", "redis-master", "6379"
+          ]
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: openebs-redis
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5G

--- a/k8s/demo/redis/redis-standalone.yml
+++ b/k8s/demo/redis/redis-standalone.yml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: redis-standalone
 spec:
+  clusterIP: None
   ports:
     - port: 6379
   selector:

--- a/k8s/demo/redis/redis-standalone.yml
+++ b/k8s/demo/redis/redis-standalone.yml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-standalone
+  labels:
+    app: redis-standalone
+spec:
+  ports:
+    - port: 6379
+  selector:
+    app: redis-standalone
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: redis-standalone
+spec:
+  serviceName: redis-standalone
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-standalone
+  template:
+    metadata:
+      name: redis-standalone
+      labels:
+        app: redis-standalone
+    spec:
+      containers:
+      - name: redis
+        image: redis:latest
+        args: [ "--appendonly", "yes" ]
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+      annotations:
+        volume.beta.kubernetes.io/storage-class: openebs-redis
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 5G

--- a/k8s/openebs-storageclasses.yaml
+++ b/k8s/openebs-storageclasses.yaml
@@ -48,4 +48,14 @@ parameters:
   pool: hostdir-var
   replica: "2"
   size: 5G
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-redis
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G
 


### PR DESCRIPTION
Provides 2 deployment flavours:

**standalone**
single server, with [AOF](https://redis.io/topics/persistence)
redis endpoint: `redis-standalone:6379`

**cluster**
a master with multiple (3x) replicas.
redis endpoints:
- master: `redis-master:6379`
- any of the replicas: `redis-replica:6379`

This PR fixes #536 