### PR TITLE
OpenEBS provisioner HA

### DIFF
--- a/contribute/design/openebs-provisioner-high-availibility.md
+++ b/contribute/design/openebs-provisioner-high-availibility.md
@@ -1,0 +1,77 @@
+# High Availability for OpenEBS Volume Provisioner
+
+## Problems addressed:
+
+- `openebs-provisioner` should always be available.
+- `openebs-provisioner` should always be running on the specified/labeled nodes. 
+- If any node in cluster goes down in that scenario the pod should be assigned to other node in the cluster.
+ 
+## Solutions for above problems: 
+
+
+- Increase the `replicas` to 2 or >2 in `openebs-operator.yaml` for `openebs-provisioner`. 
+
+
+- We need to make sure that each node is running at least one  `openebs-provisioner` pod.  
+  We need to label nodes to assign the pods on those. 
+
+  To do that execute: 
+
+```
+kubectl label nodes kubeminion-01  node=minion01  # For node kubeminion-01
+kubectl label nodes kubeminion-02  node=minion02   # For node kubeminion-02
+```
+
+To make sure that nodes are labeled: 
+
+```
+ubuntu@kubemaster-01:~/openebs/k8s$ kubectl get nodes --show-labels
+
+NAME            STATUS    AGE       VERSION   LABELS
+kubemaster-01   Ready     4h        v1.6.3    beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=kubemaster-01,node-role.kubernetes.io/master=
+kubeminion-01   Ready     4h        v1.6.3    beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=kubeminion-01,node=minion01
+kubeminion-02   Ready     4h        v1.6.3    beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/hostname=kubeminion-02,node=minion02
+
+
+```
+
+
+Once, we labeled the nodes we can specify these labels in the `affinity` of `openebs-provisioner` spec in `openebs-operator.yaml`
+
+```yaml
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: default
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              matchExpressions:
+                key: node			  # <-- Key of label of the node. 	
+                operator: Equal
+                values: ["minion01","minion02"]   # <-- Add the labels of the nodes as a value.
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner
+        imagePullPolicy: Always
+        image: openebs/openebs-k8s-provisioner:0.4.0
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+
+```
+
+After this, kubernetes scheduler will take care of assigning pods to the specific nodes and it will make sure that pods are always available on specified nodes. 
+
+

--- a/contribute/design/openebs-provisioner-high-availibility.md
+++ b/contribute/design/openebs-provisioner-high-availibility.md
@@ -3,16 +3,13 @@
 ## Problems addressed:
 
 - `openebs-provisioner` should always be available.
-- `openebs-provisioner` should always be running on the specified/labeled pods. 
+- 2 `openebs-provisioner` pods should always be running in the cluster. 
 - If any node in cluster goes down in that scenario the pod should be assigned to other node in the cluster.
 ---
 ## Solutions for above problems: 
 
 
-- Increase the `replicas` to 2 or >2 in `openebs-operator.yaml` for `openebs-provisioner` deployment. 
-
-
-- Each node should always be running the specified/labeled openebs-provisioner pods on each node provided that replica count is equal to the number of nodes.
+- Increase the `replicas` count to 2 or >2 in `openebs-operator.yaml` for `openebs-provisioner` deployment.
 
 
 Sample Deployment spec for `openebs-provisioner` looks like: 
@@ -57,7 +54,7 @@ spec:
 
 ```
 
-## Pod Anti Affinity 
+## Pod Anti Affinity
 Pod anti-affinity can prevent the scheduler from locating a new pod on the same node as pods with the same labels if the label selector on the new pod matches the label on the current pod. 
 
 

--- a/contribute/design/openebs-provisioner-high-availibility.md
+++ b/contribute/design/openebs-provisioner-high-availibility.md
@@ -12,7 +12,8 @@
 - Increase the `replicas` to 2 or >2 in `openebs-operator.yaml` for `openebs-provisioner` deployment. 
 
 
-- We need to make sure that each node is running at least one  `openebs-provisioner` pod. In order to do that, we're using `podAntiAffinity` method for scheduling `openebs-provisioner` pods. We have added label `name:provisioner` as a default label. 
+- Each node should always be running the specified/labeled openebs-provisioner pods on each node provided that replica count is equal to the number of nodes.
+
 
 Sample Deployment spec for `openebs-provisioner` looks like: 
 
@@ -26,17 +27,18 @@ spec:
   replicas: 2
   template:
     spec:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:   # <-- Affinity Selector 
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                    - openebs-provisioner
-              topologyKey: "kubernetes.io/hostname"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:   # <-- Affinity Selector 
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                      - openebs-provisioner
+                topologyKey: "kubernetes.io/hostname"
   template:
     metadata:
       labels:
@@ -55,6 +57,9 @@ spec:
 
 ```
 
+## Pod Anti Affinity 
+Pod anti-affinity can prevent the scheduler from locating a new pod on the same node as pods with the same labels if the label selector on the new pod matches the label on the current pod. 
+
 
 You can change affinity selector in the Deployment spec.
 
@@ -64,6 +69,7 @@ You can change affinity selector in the Deployment spec.
 |`requiredDuringSchedulingIgnoredDuringExecution`  | Runs | Fails | Keeps Running |
 |`preferredDuringSchedulingIgnoredDuringExecution` |	Runs |	Runs |	Keeps Running|
 |`requiredDuringSchedulingRequiredDuringExecution` (Not recommanded) |	Runs |	Fails | Fails|
+
 
 ---
 

--- a/contribute/design/openebs-provisioner-high-availibility.md
+++ b/contribute/design/openebs-provisioner-high-availibility.md
@@ -79,7 +79,6 @@ spec:
 
 ```
 
-After this, kubernetes scheduler will take care of assigning pods to the specific nodes and it will make sure that specific/labeled pods are always available.
 You can change affinity selector in the Deployment spec.
 
 
@@ -88,4 +87,12 @@ You can change affinity selector in the Deployment spec.
 |`requiredDuringSchedulingIgnoredDuringExecution`  | Runs | Fails | Keeps Running |
 |`preferredDuringSchedulingIgnoredDuringExecution` |	Runs |	Runs |	Keeps Running|
 |`requiredDuringSchedulingRequiredDuringExecution` (Not recommanded) |	Runs |	Fails | Fails|
+
+---
+
+### How `openebs-provisioner` will be Highly Available?
+ 
+	- Kubernetes scheduler will make sure that each node has atleast one pod of `openebs-provisioner`
+	- On descreasing replicas count from n (>2) to 2 will retain pods having label P1 and P2. P1 and P2 will be isolated and protected to make sure that P1 and P2 are always running. 
+
 

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -96,12 +96,20 @@ metadata:
   name: openebs-provisioner
   namespace: default
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:
         name: openebs-provisioner
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              matchExpressions:
+                key: node
+                operator: Equal
+                values: ["minion01","minion02"]
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -99,14 +99,18 @@ spec:
   replicas: 2
   template:
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              matchExpressions:
-                key: node
-                operator: Equal
-                values: ["minion01","minion02"]
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: provisioner
+                    operator: In
+                    values:
+                    - P1
+                    - P2
+              topologyKey: "kubernetes.io/hostname"
   template:
     metadata:
       labels:
@@ -122,5 +126,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+
+
 
 

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -126,7 +126,3 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-
-
-
-

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -99,17 +99,18 @@ spec:
   replicas: 2
   template:
     spec:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: name
-                    operator: In
-                    values:
-                    - openebs-provisioner
-              topologyKey: "kubernetes.io/hostname"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: name
+                      operator: In
+                      values:
+                      - openebs-provisioner
+                topologyKey: "kubernetes.io/hostname"
   template:
     metadata:
       labels:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -98,9 +98,6 @@ metadata:
 spec:
   replicas: 2
   template:
-    metadata:
-      labels:
-        name: openebs-provisioner
     spec:
       affinity:
         nodeAffinity:
@@ -110,6 +107,11 @@ spec:
                 key: node
                 operator: Equal
                 values: ["minion01","minion02"]
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+    spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -3,7 +3,7 @@
 # Launch the maya-apiserver ( deployment )
 # Launch the maya-storagemanager ( deameon set )
 
-# Create Maya Service Account 
+# Create Maya Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -105,11 +105,10 @@ spec:
             podAffinityTerm:
               labelSelector:
                 matchExpressions:
-                  - key: provisioner
+                  - key: name
                     operator: In
                     values:
-                    - P1
-                    - P2
+                    - openebs-provisioner
               topologyKey: "kubernetes.io/hostname"
   template:
     metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
    `openebs-provisioner` should be available all the time even if any node goes down.

**What is changed?**
    This will increase the `replicas` count and will add `affinity` to the pod spec.

**Which issue this PR fixes**:
fixes #267 
