### PR TITLE
PEP8 error (Unused import) corrected

### DIFF
--- a/e2e/ansible/roles/inventory/files/generate-inventory.py
+++ b/e2e/ansible/roles/inventory/files/generate-inventory.py
@@ -28,7 +28,7 @@
 
 import os
 import sys
-from utils import sshToOtherClient, executeCmd
+from utils import executeCmd
 from passwordless import setupSSH
 import logging
 import argparse


### PR DESCRIPTION
Signed-off-by: debojitkakoti <debojkakoti88@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: flake8 has been integrated into .travis.yml . It is throwing error of unused module, this has been corrected on this PR

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # #607 

**Special notes for your reviewer**:
This is regarding #607 