### PR TITLE
Fixes for issues #618 and #619 

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -21,16 +21,10 @@
          args: 
            executable: /bin/bash
          register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
-
-       - name: 
-         debug: 
-           msg: "Ending play, maya-apiserver is not running"
-         when: "'Running' not in result.stdout"
-
-       - name: 
-         meta: end_play
-         when: "'Running' not in result.stdout"
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 120
+         retries: 5 
 
        - name: Replace 'tree/master' with 'trunk' in the crunchy-postgres link
          debug:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
@@ -30,17 +30,11 @@
          args: 
            executable: /bin/bash
          register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 120
+         retries: 5
 
-       - name: 
-         debug: 
-           msg: "Ending play, maya-apiserver is not running"
-         when: "'Running' not in result.stdout"
-
-       - name: 
-         meta: end_play
-         when: "'Running' not in result.stdout"
-    
        - name: Replace volume size in plugin YAML
          lineinfile:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -31,17 +31,11 @@
          args: 
            executable: /bin/bash
          register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"     
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 120
+         retries: 5
 
-       - name: 
-         debug: 
-           msg: "Ending play, maya-apiserver is not running"
-         when: "'Running' not in result.stdout"
-
-       - name: 
-         meta: end_play
-         when: "'Running' not in result.stdout"
-    
        - name: Replace volume size in plugin YAML
          lineinfile:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
@@ -62,7 +56,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: result
          until: "'percona' and 'Running' in result.stdout"
-         delay: 300 
+         delay: 300
          retries: 6
      
        - name: Get $HOME of K8s minion for kubernetes user
@@ -90,20 +84,18 @@
          with_items: "{{ files }}"
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-       - name: Build the mysql-client image
+       - name: Pull the mysql-client image
          docker_image:
-           name: mysql-client
+           name: openebs/tests-mysql-client
            state: present
-           path: "{{ result_kube_home.stdout }}"
-           rm: true
-           timeout: 600
+           timeout: 120
          become: true
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
        - name: mysql-client docker instantiate
          docker_container:
            name: client
-           image: mysql-client
+           image: openebs/tests-mysql-client
            network_mode: host
            command: timelimit -t {{ mysql_load_duration }} sh MySQLLoadGenerate.sh {{ pod_ip }} > /dev/null 2>&1
            state: started


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Added retry mechanism to verify maya-apiserver is in "Running" state before deploying test applications 

- Modified steps in percona test playbook to pull mysql-client image instead of building it on the kubernetes
  node

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #618 
fixes #619 
