### PR TITLE
Replace apt module with apt-get shell command in test pre-requisites playbook

### DIFF
--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml
@@ -1,8 +1,12 @@
 ---
+- name: Run apt-get update via shell
+  shell: apt-get update
+  become: true
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  ignore_errors: true
+
 - name: Install libiscsi on K8S-minion
-  apt:
-    name: "{{ item }}"
-    state: present
+  shell: apt-get install -y {{ item }}
+  become: true
   with_items: "{{ deb_packages }}"
-  become: true 
   delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-prerequisites.yml
@@ -1,9 +1,12 @@
-- name: Install subversion on K8S-master
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ deb_packages }}"
-  become: true 
+- name: Run apt-get update via shell
+  command: apt-get update
+  become: true
   delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  ignore_errors: true
 
+- name: Install subversion on K8S-master
+  shell: apt-get install -y {{ item }}
+  become: true
+  with_items: "{{ deb_packages }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
       

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,10 +1,14 @@
 ---
+- name: Run apt-get update via shell
+  shell: apt-get update
+  become: true
+  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  ignore_errors: true
+
 - name: Install python-pip on K8S-minion
-  apt:
-    name: "{{ item }}"
-    state: present
-  with_items: "{{ deb_packages }}"
+  shell: apt-get install -y {{ item }}
   become: true 
+  with_items: "{{ deb_packages }}"
   delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
 - name: Install PIP packages on K8s-minion


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The ansible apt module executes the apt-get update command as part of package installation,
which randomly fails due to failed update of one or more packages (Hash sum mismatch)

- This change replaces the package installation into two separate steps, executed with the
  shell module to : a) perform update by ignoring errors b) Install package

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #628 

**Special notes for your reviewer**:
Some of the other hacks for this issue included clearing the /var/lib/apt/lists folder and repeating the update, but were found to be unreliable. 
