### PR TITLE
Include pod election logic for mongodb statefulset - Fixes issue #654

### DIFF
--- a/k8s/demo/mongodb/mongo-statefulset.yml
+++ b/k8s/demo/mongodb/mongo-statefulset.yml
@@ -41,6 +41,11 @@ spec:
          volumeMounts:
            - name: mongo-persistent-storage
              mountPath: /data/db
+       - name: mongo-sidecar
+         image: cvallance/mongo-k8s-sidecar
+         env: 
+           - name: MONGO_SIDECAR_POD_LABELS
+             value: "role=mongo,environment=test"
  volumeClaimTemplates:
  - metadata:
      name: mongo-persistent-storage


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- A kubernetes sidecar associated with the mongodb containers is used to implement the pod election logic and generally manage the replicaset.

- Needed to ensure that we have a functional mongodb replication cluster 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #654 

Mongo-shell output with updated statefulset specification YAML: 

```
mongodb@MayaHost01:/$ mongo --host 10.44.0.3 --port 27017

rs0:PRIMARY> show dbs
admin  0.000GB
local  0.000GB
rs0:PRIMARY>

rs0:PRIMARY> db.isMaster()
{
        "hosts" : [
                "10.44.0.3:27017",
                "10.36.0.6:27017"
        ],
        "setName" : "rs0",
        "setVersion" : 4,
        "ismaster" : true,
        "secondary" : false,
        "primary" : "10.44.0.3:27017",
        "me" : "10.44.0.3:27017",
        "electionId" : ObjectId("7fffffff0000000000000001"),
        "lastWrite" : {
                "opTime" : {
                        "ts" : Timestamp(1508322407, 1),
                        "t" : NumberLong(1)
                },
                "lastWriteDate" : ISODate("2017-10-18T10:26:47Z")
        },
        "maxBsonObjectSize" : 16777216,
        "maxMessageSizeBytes" : 48000000,
        "maxWriteBatchSize" : 1000,
        "localTime" : ISODate("2017-10-18T10:26:57.282Z"),
        "maxWireVersion" : 5,
        "minWireVersion" : 0,
        "readOnly" : false,
        "ok" : 1
```

```
mongodb@MayaHost01:/$ mongo --host 10.36.0.6 --port 27017

rs0:SECONDARY>
rs0:SECONDARY>
rs0:SECONDARY> db.isMaster()
{
        "hosts" : [
                "10.44.0.3:27017",
                "10.36.0.6:27017"
        ],
        "setName" : "rs0",
        "setVersion" : 4,
        "ismaster" : false,
        "secondary" : true,
        "primary" : "10.44.0.3:27017",
        "me" : "10.36.0.6:27017",
        "lastWrite" : {
                "opTime" : {
                        "ts" : Timestamp(1508322707, 1),
                        "t" : NumberLong(1)
                },
                "lastWriteDate" : ISODate("2017-10-18T10:31:47Z")
        },
        "maxBsonObjectSize" : 16777216,
        "maxMessageSizeBytes" : 48000000,
        "maxWriteBatchSize" : 1000,
        "localTime" : ISODate("2017-10-18T10:31:54.736Z"),
        "maxWireVersion" : 5,
        "minWireVersion" : 0,
        "readOnly" : false,
        "ok" : 1
}
```

**Special notes for your reviewer**:

The mongodb-k8s-sidecar (https://github.com/cvallance/mongo-k8s-sidecar) is a PoC which is under further improvement.
