### PR TITLE
convert the openebs-operator and sc yaml files to chart

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+version: 0.0.1
+name: openebs
+appVersion: 0.4.0
+description: Containerized Storage for Containers
+icon: https://github.com/openebs/chitrakala/blob/master/logo/png/logo-01.png
+home: http://www.openebs.io/
+keywords:
+  - cloud-native-storage
+  - block-storage
+  - iSCSI
+  - storage
+sources:
+  - https://github.com/openebs/openebs

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -1,0 +1,18 @@
+
+# Prerequisites
+- Kubernetes 1.7.5+ with RBAC enabled
+- iSCSI PV support in the underlying infrastructure
+
+
+# Installing OpenEBS from Chart codebase
+```
+git clone https://github.com/openebs/openebs.git
+cd openebs/k8s/charts/openebs/
+helm install --name openebs .
+```
+
+# Unistalling OpenEBS from Chart codebase
+```
+helm ls --all
+helm del --purge openebs
+```

--- a/k8s/charts/openebs/templates/NOTES.txt
+++ b/k8s/charts/openebs/templates/NOTES.txt
@@ -1,0 +1,6 @@
+The OpenEBS has been installed. Check its status by running:
+  kubectl get pods -l "name=maya-apiserver"
+
+To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
+Please visit http://openebs.readthedocs.io/en/latest/getting_started/quick_install.html for instructions
+

--- a/k8s/charts/openebs/templates/_helpers.tpl
+++ b/k8s/charts/openebs/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbacEnable }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  namespace: default
+  name: openebs-maya-operator
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+rules:
+- apiGroups: ["*"]
+  resources: ["services","pods","deployments", "events"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["persistentvolumes","persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["*"]
+{{- end }}

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbacEnable }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  namespace: default
+  name: openebs-maya-operator
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openebs-maya-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: default
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: maya-apiserver
+  namespace: default
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-apiserver
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: maya-apiserver
+        image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports: 
+        - containerPort: 5656
+        env:
+        - name: DEFAULT_CONTROLLER_IMAGE
+          value: {{ .Values.jiva.image }}
+        - name: DEFAULT_REPLICA_IMAGE
+          value: {{ .Values.jiva.image }}
+        - name: DEFAULT_REPLICA_COUNT
+          value: "{{ .Values.jiva.replicas }}"

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-provisioner
+  namespace: default
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-provisioner
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: openebs-provisioner
+        image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        - name: NODE_NAME
+          valueFrom: 
+            fieldRef:
+              fieldPath: spec.nodeName

--- a/k8s/charts/openebs/templates/sc-openebs-standard.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standard.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-standard
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: maya-apiserver-service
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  ports:
+  - name: api
+    port: 5656
+    protocol: TCP
+    targetPort: 5656
+  selector:
+    name: maya-apiserver
+  sessionAffinity: None

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: default
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -1,0 +1,21 @@
+# Default values for OpenEBS
+
+## If true, create & use RBAC resources
+##
+rbacEnable: true
+
+image:
+  pullPolicy: IfNotPresent
+
+apiserver:
+  image: "openebs/m-apiserver"
+  tag: "0.4.0"
+
+provisioner:
+  image: "openebs/openebs-k8s-provisioner"
+  tag: "0.4.0"
+
+jiva:
+  image: "openebs/jiva:0.4.0"
+  replicas: 2
+


### PR DESCRIPTION
Initial commit for #560. 

This PR only converts to chart format and provides developer option to install. The next step would be to create a helm repo that can host the openebs chart and install from that publicly available repo. 

The following is the output from installing openebs via helm chart:
```
vagrant@minikube-dev:~$ git clone https://github.com/kmova/openebs.git
Cloning into 'openebs'...
remote: Counting objects: 5794, done.
remote: Compressing objects: 100% (49/49), done.
remote: Total 5794 (delta 23), reused 40 (delta 9), pack-reused 5735
Receiving objects: 100% (5794/5794), 5.75 MiB | 520.00 KiB/s, done.
Resolving deltas: 100% (3124/3124), done.
Checking connectivity... done.

vagrant@minikube-dev:~$ cd openebs/
vagrant@minikube-dev:~/openebs$ git checkout add-openebs-helm-chart-#560
Branch add-openebs-helm-chart-#560 set up to track remote branch add-openebs-helm-chart-#560 from origin.
Switched to a new branch 'add-openebs-helm-chart-#560'

vagrant@minikube-dev:~/openebs$ cd k8s/charts/openebs/    

vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ kubectl get pods
No resources found.
vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ kubectl get sc  
NAME                 PROVISIONER
standard (default)   k8s.io/minikube-hostpath


vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ helm install --name openebs .
NAME:   openebs
LAST DEPLOYED: Wed Oct 18 17:52:32 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ServiceAccount
NAME                   SECRETS  AGE
openebs-maya-operator  1        1s

==> v1beta1/ClusterRole
NAME                   AGE
openebs-maya-operator  1s

==> v1beta1/ClusterRoleBinding
NAME                   AGE
openebs-maya-operator  1s

==> v1/Service
NAME                    CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
maya-apiserver-service  10.0.0.103  <none>       5656/TCP  1s

==> v1beta1/Deployment
NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
maya-apiserver       1        1        1           0          1s
openebs-provisioner  1        1        1           0          1s

==> v1/StorageClass
NAME              TYPE
openebs-standard  openebs.io/provisioner-iscsi  


NOTES:
The OpenEBS has been installed. Check its status by running:
  kubectl get pods -l "name=maya-apiserver"

To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
Please visit http://openebs.readthedocs.io/en/latest/getting_started/quick_install.html for instructions


vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ kubectl get sc
NAME                 PROVISIONER
openebs-standard     openebs.io/provisioner-iscsi
standard (default)   k8s.io/minikube-hostpath

vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ kubectl get pods
NAME                                   READY     STATUS    RESTARTS   AGE
maya-apiserver-927297988-c95v5         1/1       Running   0          1m
openebs-provisioner-2139922117-tfdw7   1/1       Running   0          1m
vagrant@minikube-dev:~/openebs/k8s/charts/openebs$ 

```