### PR TITLE
Update instruction to install from openebs charts repo. 

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.0.1
+version: 0.4.0
 name: openebs
 appVersion: 0.4.0
 description: Containerized Storage for Containers

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -3,6 +3,12 @@
 - Kubernetes 1.7.5+ with RBAC enabled
 - iSCSI PV support in the underlying infrastructure
 
+# Installing OpenEBS 
+```
+helm repo add openebs-charts https://openebs.github.io/charts/
+helm repo update
+helm install openebs-charts/openebs
+```
 
 # Installing OpenEBS from Chart codebase
 ```
@@ -14,5 +20,6 @@ helm install --name openebs .
 # Unistalling OpenEBS from Chart codebase
 ```
 helm ls --all
-helm del --purge openebs
+# Note the openebs-chart-name from above command
+helm del --purge <openebs-chart-name>
 ```


### PR DESCRIPTION
Fixes #560 

The charts repo is hosted by github pages at https://openebs.github.io/charts
(The code is at : https://github.com/openebs/charts)

Also updated the chart version to reflect current openebs release:

```
vagrant@minikube-dev:~/charts$ helm repo add openebs-charts https://openebs.github.io/charts/
"openebs-charts" has been added to your repositories
vagrant@minikube-dev:~/charts$ helm repo update
Hang tight while we grab the latest from your chart repositories...
...Skip local chart repository
...Successfully got an update from the "openebs-charts" chart repository
...Successfully got an update from the "stable" chart repository
Update Complete. ⎈ Happy Helming!⎈ 
vagrant@minikube-dev:~/charts$ helm install openebs-charts/openebs
NAME:   nonexistent-billygoat
LAST DEPLOYED: Thu Oct 19 13:08:02 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/ServiceAccount
NAME                   SECRETS  AGE
openebs-maya-operator  1        1s

==> v1beta1/ClusterRole
NAME                   AGE
openebs-maya-operator  1s

==> v1beta1/ClusterRoleBinding
NAME                   AGE
openebs-maya-operator  1s

==> v1/Service
NAME                    CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
maya-apiserver-service  10.0.0.243  <none>       5656/TCP  1s

==> v1beta1/Deployment
NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
maya-apiserver       1        1        1           0          1s
openebs-provisioner  1        1        1           0          1s

==> v1/StorageClass
NAME              TYPE
openebs-standard  openebs.io/provisioner-iscsi  


NOTES:
The OpenEBS has been installed. Check its status by running:
  kubectl get pods -l "name=maya-apiserver"

To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
Please visit http://openebs.readthedocs.io/en/latest/getting_started/quick_install.html for instructions


vagrant@minikube-dev:~/charts$ kubectl get pods
NAME                                  READY     STATUS    RESTARTS   AGE
maya-apiserver-757497993-028np        1/1       Running   0          1m
openebs-provisioner-416704200-xvlbj   1/1       Running   0          1m
vagrant@minikube-dev:~/charts$ 
