### PR TITLE
Add openebs-exporter to monitor openebs volumes

### DIFF
--- a/k8s/vagrant/1.7.5/openebs-monitoring/openebs-exporter.yaml
+++ b/k8s/vagrant/1.7.5/openebs-monitoring/openebs-exporter.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-exporter
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-exporter
+    spec:
+      serviceAccountName: prometheus
+      containers:
+        - name: openebs-exporter
+          image: utkarshmani1997/openebs-exporter:test-11
+          args:
+            # This is the flag provided to exporter at run time
+            # replace it with your controller's service IP
+            # For exp : Do kubectl get svc | grep volname-ctrl-svc
+            # to get the IP.
+            - --controller.addr=http://10.101.141.121:9501
+          ports:
+            - containerPort: 9500
+---
+# openebs-exporter-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-exporter-service
+spec:
+  selector: # exposes any pods with the following labels as a service
+    name: openebs-exporter
+  ports:
+    - port: 80 # this Service's port (cluster-internal IP clusterIP)
+      targetPort: 9500 # pods expose this port

--- a/k8s/vagrant/1.7.5/openebs-monitoring/prometheus.yaml
+++ b/k8s/vagrant/1.7.5/openebs-monitoring/prometheus.yaml
@@ -1,0 +1,232 @@
+# ConfigMap is used to run prometheus with given configuration. It helps
+# if we want to change the configuration from time to time because our 
+# requirement changes so configurations also need to change accordingly.
+# You need to restart the pods to apply these changes.
+#
+# A scrape (Collect metrics) configuration for running Prometheus on a 
+# Kubernetes cluster is given below. This uses separate scrape configs 
+# for cluster components  (i.e. API server, node) and services to allow 
+# each to use different authentication configs.
+#
+# Kubernetes labels will be added as Prometheus labels on metrics via the
+# `labelmap` relabeling action.
+# labelmap: Match regex against all label names. Then copy the values of 
+# the matching labels to label names given by replacement with match group
+# references (${1}, ${2}, ...) in replacement substituted by their value.
+#
+# If you are using Kubernetes 1.7.2 or earlier, please take note of the comments
+# for the kubernetes-cadvisor job; you will need to edit or remove this job.
+
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+apiVersion: v1
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    
+    # scrape config for maya-apiserver pods
+    #
+    # The relabeling allows the actual pod scrape endpoint to be configured via the
+    # following annotations:
+    #
+    # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+    # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+    # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+    # pod's declared ports (default is a port-free target if none are declared).
+    scrape_configs:
+    - job_name: 'prometheus'
+      static_configs:
+      # Please change this IP to the IP of your node (VM)
+      # Because prometheus-service is running as Type NodePort
+      # So it's accessible outside the cluster.
+      - targets: ['172.28.128.12:32514']
+    - job_name: 'maya-apiserver'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: maya-apiserver
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'openebs-jiva-controller'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_openebs_controller]
+        regex: jiva-controller
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)3260'
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'openebs-jiva-replica'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_openebs_replica]
+        regex: jiva-replica
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9503'
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9504'
+    - job_name : 'kubelets'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /metrics 
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:10255'
+        target_label: __address__
+      
+      # Scrape config for API servers.
+      #
+      # Kubernetes exposes API servers as endpoints to the default/kubernetes
+      # service so this uses `endpoints` role and uses relabelling to only keep
+      # the endpoints associated with the default/kubernetes service using the
+      # default named port `https`. This works for single API server deployments as
+      # well as HA API server deployments.  
+    - job_name: 'kubernetes-apiservers'
+      kubernetes_sd_configs:
+      - role: endpoints
+      
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https
+      
+      # This TLS & bearer token file config is used to connect to the actual scrape
+      # endpoints for cluster components. This is separate to discovery auth
+      # configuration because discovery & scraping are two separate concerns in
+      # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+      # the cluster. Otherwise, more config options have to be provided within the
+      # <kubernetes_sd_config>.
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      
+      # If your node certificates are self-signed or use a different CA to the
+      # master CA, then disable certificate verification below. Note that
+      # certificate verification is an integral part of a secure infrastructure
+      # so this should only be disabled in a controlled environment. You can
+      # disable certificate verification by uncommenting the line below.
+      #
+      # insecure_skip_verify: true
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      
+      # Keep only the default/kubernetes service endpoints for the https port. This
+      # will add targets for each API server which Kubernetes adds an endpoint to
+      # the default/kubernetes service.
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+        action: keep
+        regex: default;kubernetes;https
+    
+      # Scrape config for Kubelet cAdvisor.
+      #
+      # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+      # (those whose names begin with 'container_') have been removed from the
+      # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+      # retrieve those metrics.
+      #
+      # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+      # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+      # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+      # the --cadvisor-port=0 Kubelet flag).
+      #
+      # This job is not necessary and should be removed in Kubernetes 1.6 and
+      # earlier versions, or it will cause the metrics to be scraped twice.
+    - job_name: 'kubernetes-cadvisor'
+      
+      # Default to scraping over https. If required, just disable this or change to
+      # `http`.
+      scheme: https 
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+    
+      # Scrap config for node-exporter.
+      #
+      # This is required to scrap the node metrics such as IO's, CPU and other metrics
+      # related to node. By default it scrap only from worker nodes if run as deployment
+      # but you can monitor master node also. To monitor node you need to run it as
+      # daemonset and add 'toleration' field in node-exporter.yaml file.For more details
+      # see 'taints and toleration' in Kubernetes documentation. 
+    - job_name: 'kubernetes-node-exporter'
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      - source_labels: [__meta_kubernetes_role]
+        action: replace
+        target_label: kubernetes_role
+      - source_labels: [__address__]
+        regex: '(.*):10250'
+        replacement: '${1}:9100'
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+        target_label: __instance__
+      - source_labels: [job]
+        regex: 'kubernetes-(.*)'
+        replacement: '${1}'
+        target_label: name
+    - job_name: 'openebs-exporter'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: openebs-exporter
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+


### PR DESCRIPTION
**What this PR does / why we need it**:

* This PR refers issue #392, #264, #266, #272
* This PR adds openebs-exporter to monitor OpenEBS volume stats

**How this commit address the issue**:

* Prometheus now collects metrics from openebs-exporter
* Updated the config file of prometheus to see the latest changes

**How to verify this change**
* After bringing up the openebs on vagrant, change directory `cd
  /vagrant/openebs-monitoring`
* Set up configmap by `kubectl create -f prometheus.yaml` and wait for
  few seconds to let it configured well
* Now run `kubectl create -f prometheus-operator.yaml`. It will launch
  prometheus pod, deployment, service and node exporter.
* Now you can directly access prometheus expression browser on your browser
  at the NodeIP:32514. (Do ifconfig in kubemaster-01 and it will be like
  enp0s8)

**Note**:
* openebs-exporter is depend on [my repo](https://github.com/utkarshmani1997)

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
