### PR TITLE
Add retention-period and Qos policy in prometheus deployment

### DIFF
--- a/k8s/openebs-monitoring/prometheus-env.yaml
+++ b/k8s/openebs-monitoring/prometheus-env.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-env
+data:
+  storage-retention: 120h

--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -102,8 +102,29 @@ spec:
             # exists as long as the Pod is running on that Node.
             # The data in an emptyDir volume is safe across container crashes.
             - "-storage.local.path=/prometheus"
+            # How long to retain samples in the local storage. 
+            - "-storage.local.retention=$(STORAGE_RETENTION)" 
           ports:
             - containerPort: 9090
+          env:
+            # environment vars are stored in prometheus-env configmap. 
+            - name: STORAGE_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: prometheus-env
+                  key: storage-retention
+          resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
           volumeMounts:
             # prometheus config file stored in the given mountpath
             - name: prometheus-server-volume
@@ -160,6 +181,18 @@ spec:
         - containerPort: 9100
           hostPort: 9100
           name: scrape
+        resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
         volumeMounts:
         # All the application data stored in data-disk
         - name: data-disk
@@ -169,7 +202,7 @@ spec:
         - name: root-disk
           mountPath: /root-disk
           readOnly: true
-      # The Kubernetes scheduler’s default behavior works well for most cases 
+      # The Kubernetes scheduler’s default behavior works well for most cases
       # -- for example, it ensures that pods are only placed on nodes that have 
       # sufficient free resources, it ties to spread pods from the same set 
       # (ReplicaSet, StatefulSet, etc.) across nodes, it tries to balance out 
@@ -193,6 +226,11 @@ spec:
       - effect: NoSchedule
         operator: Exists
       volumes:
+        # A hostPath volume mounts a file or directory from the host node’s 
+        # filesystem.For example, some uses for a hostPath are:
+        # running a container that needs access to Docker internals; use a hostPath 
+        # of /var/lib/docker
+        # running cAdvisor in a container; use a hostPath of /dev/cgroups
         - name: data-disk
           hostPath:
             path: /localdata

--- a/k8s/openebs-monitoring/prometheus.yaml
+++ b/k8s/openebs-monitoring/prometheus.yaml
@@ -37,6 +37,12 @@ data:
     # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
     # pod's declared ports (default is a port-free target if none are declared).
     scrape_configs:
+    - job_name: 'prometheus'
+      static_configs:
+      # Please change this IP to the IP of your node (VM)
+      # Because prometheus-service is running as Type NodePort
+      # So it's accessible outside the cluster.
+      - targets: ['172.28.128.3:32514']
     - job_name: 'maya-apiserver'
       scheme: http
       tls_config:
@@ -209,3 +215,18 @@ data:
         regex: 'kubernetes-(.*)'
         replacement: '${1}'
         target_label: name
+    - job_name: 'maya-agent'
+      scheme: http
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: maya-agent
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+


### PR DESCRIPTION
**What this PR does** :

* This PR add Qos policies and retention period for metrics
  collection in prometheus.
* Fixes #387
* Fixes #393

**why we need it** :

* It's good practice to have Qos defined for the pods that limits
  the use of resource.
* This further opens scope for implementing alertmanager (issue #326)

**Special notes for your reviewer** :

* Please allocate minimum 2GB RAM per node.

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
