### PR TITLE
Replace release tags for m-apiserver to "ci" on openebs-operator.yml before deployment

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -7,4 +7,4 @@ openebs_storageclasses_link: https://raw.githubusercontent.com/openebs/openebs/m
 
 openebs_storageclasses_alias: openebs-storageclasses.yaml
 
-
+test_tag: ci

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Change m-apiserver image to desired tag in operator YAML
   replace:
     path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}" 
-    regexp: "m-apiserver:[\\w_.-][\\w.-][\\w.-][\\w.-][\\w.-]"
+    regexp: "m-apiserver:[\\w.-]+"
     replace: "m-apiserver:{{ test_tag }}"
 
 - name: Get kubernetes master name

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -9,6 +9,12 @@
   delay: 5
   retries: 3
 
+- name: Change m-apiserver image to desired tag in operator YAML
+  replace:
+    path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}" 
+    regexp: "m-apiserver:[\\w_.-][\\w.-][\\w.-][\\w.-][\\w.-]"
+    replace: "m-apiserver:{{ test_tag }}"
+
 - name: Get kubernetes master name
   shell: hostname
   args:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

The m-apiserver image with latest code changes is pushed into dockerhub with tag "CI". The ansible-based CI needs to use this image in the integration test suite. The suite currently downloads the latest
openebs-operator.yml from openebs/openebs repo and deploys it. This PR ensures that the release tags
on the YAML are changed to "CI" before deployment and test. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: partially fixes #616 (there are other images like jiva and provisioner that also need to undergo this change. Currently they do not have regular CI images being pushed) 

**Special notes for your reviewer**:

Used a regex that will cover most characters used in tags <A-Z, a-z, 0-9, -, _, .> even if the current format is changed to include alphabets/hyphen etc., 