### PR TITLE
Optimizations to reduce the CI run duration (Prepull images) 

### DIFF
--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -5,8 +5,10 @@
 
 - include: setup-openebs.yml
 
-- include: run-dedicated-tests.yml
-  when: deployment_mode == "dedicated"
+- include: load-images.yml
+
+#- include: run-dedicated-tests.yml
+#  when: deployment_mode == "dedicated"
 
 - include: run-hyperconverged-tests.yml
   when: deployment_mode == "hyperconverged"

--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -8,8 +8,8 @@
 #Accepted Entries (Valid Kubernetes Version): default:1.6.3
 #Accepted Entries (Valid Weave Version): default:1.9.4
 
-k8s_version: 1.6.3
-weave_version: 1.9.4
+k8s_version: 1.7.7 
+weave_version: 2.0.4
 
 #list of kubernetes versions released.
 #do not tamper the list unless you know
@@ -25,6 +25,7 @@ k8s_version_list:
   - 1.7.2
   - 1.7.4
   - 1.7.5
+  - 1.7.7
 
 weave_version_list:
   - 1.9.4

--- a/e2e/ansible/load-images.yml
+++ b/e2e/ansible/load-images.yml
@@ -1,0 +1,16 @@
+---
+- hosts: kubernetes-kubeminions
+  
+  tasks:
+    - name: Check for presence of tarfiles
+      shell: ls *.tar
+      args:
+        chdir: "{{ playbook_dir }}/roles/load-test-images/files" 
+      register: tar 
+      delegate_to: 127.0.0.1 
+
+    - name: Execute load-test-images role if tarfile exists
+      include_role:
+        name: load-test-images
+      when: tar.stdout != ""
+

--- a/e2e/ansible/roles/load-test-images/defaults/main.yml
+++ b/e2e/ansible/roles/load-test-images/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+
+tarfile_path: "{{ ansible_env.HOME}}"
+
+test_images:
+# keys -> label:image:tag
+  - {label: percona, image: percona, tag: latest}
+  - {label: jupyter, image: satyamz/docker-jupyter, tag: v0.4}
+  - {label: postgres, image: crunchydata/crunchy-postgres, tag: centos7-9.6-1.4.0}
+  - {label: mysqlclient, image: openebs/tests-mysql-client, tag: latest}
+

--- a/e2e/ansible/roles/load-test-images/tasks/main.yml
+++ b/e2e/ansible/roles/load-test-images/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- block: 
+
+    - name: Load test images from Archive
+      command: docker load --input "{{item.label}}_{{item.tag}}.tar"
+      args:
+        chdir: "/vagrant/roles/load-test-images/files"
+      become: true
+      with_items: "{{test_images}}"
+ 
+  when: is_vagrant_vm  
+
+- block: 
+
+    - name: Copy test image tarfile to kubernetes hosts
+      copy:
+        src: "{{item.label}}_{{item.tag}}.tar"
+        dest: "{{ tarfile_path }}"
+      become: true
+      with_items: "{{test_images}}"
+
+    - name: Load test images from Archive
+      command: docker load --input "{{item.label}}_{{item.tag}}.tar"
+      args:
+        chdir: "{{ tarfile_path }}"
+      become: true
+      with_items: "{{test_images}}"
+ 
+  when: not is_vagrant_vm  
+

--- a/e2e/ansible/roles/setup-test-images/defaults/main.yml
+++ b/e2e/ansible/roles/setup-test-images/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+deb_local_packages:
+  - docker.io
+
+pip_local_packages:
+  - 'docker-py==1.9.0'
+
+test_images:
+# keys -> label:image:tag
+  - {label: percona, image: percona, tag: latest}
+  - {label: jupyter, image: satyamz/docker-jupyter, tag: v0.4}
+  - {label: postgres, image: crunchydata/crunchy-postgres, tag: centos7-9.6-1.4.0}
+  - {label: mysqlclient, image: openebs/tests-mysql-client, tag: latest}

--- a/e2e/ansible/roles/setup-test-images/tasks/main.yml
+++ b/e2e/ansible/roles/setup-test-images/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Install APT Packages
+  apt:
+    name: "{{item}}"
+    state: present
+  with_items: "{{deb_local_packages}}"
+  become: true
+  delegate_to: 127.0.0.1
+
+- name: Install PIP Packages
+  pip:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ pip_local_packages }}"
+  delegate_to: 127.0.0.1
+  become: true
+
+- name: Create files directory in load-test-images role if not present
+  file:
+    path: "{{ playbook_dir }}/roles/load-test-images/files"
+    state: directory
+    mode: 0755
+
+- name: Check for available image tarballs 
+  shell: ls *.tar
+  args:
+    chdir: "{{ playbook_dir }}/roles/load-test-images/files"
+  register: tar
+  delegate_to: 127.0.0.1
+
+- name: Fetch test images from dockerhub 
+  docker_image: 
+    name: "{{item.image}}:{{item.tag}}"
+    state: present
+    pull: true
+    force: yes
+  register: result
+  until: "'Pulled image' and item.image in result.actions[0]"
+  delay: 60
+  retries: 3  
+  when: "item.label ~ '_' ~ item.tag ~ '.tar' not in tar.stdout_lines"
+  with_items: "{{ test_images }}"
+  become: true
+
+- name: Create TAR files for test images
+  shell: >
+    docker save {{item.image}}:{{item.tag}}
+    -o {{item.label}}_{{item.tag}}.tar
+  args:
+    chdir: "{{playbook_dir}}/roles/load-test-images/files"
+    creates: "{{item.label}}_{{item.tag}}.tar"
+  become: true
+  with_items: "{{ test_images }}"
+
+- name: Get current user details
+  command: whoami
+  register: user
+
+- name: Change permissions of tarfile 
+  file:
+    path: "{{playbook_dir}}/roles/load-test-images/files"
+    owner: "{{ user.stdout }}"
+    group: "{{ user.stdout }}"
+    recurse: true
+  become: true 
+
+- name: Remove test images from localhost
+  docker_image:
+    name: "{{item.image}}:{{item.tag}}" 
+    state: absent
+  with_items: "{{ test_images }}"
+  become: true
+  
+
+

--- a/e2e/ansible/setup-images.yml
+++ b/e2e/ansible/setup-images.yml
@@ -1,0 +1,7 @@
+---
+- hosts: localhost
+  roles:
+      - {role: setup-test-images}
+
+
+

--- a/e2e/jenkins/cron-file.txt
+++ b/e2e/jenkins/cron-file.txt
@@ -23,4 +23,9 @@
 # For more information see the manual pages of crontab(5) and cron(8)
 # 
 # m h  dom mon dow   command
+
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
+
 00 06 * * * cd ~/openebs && ./git_monitor.sh 
+00 23 * * * cd ~/openebs && ./tar_images.sh

--- a/e2e/jenkins/tar_images.sh
+++ b/e2e/jenkins/tar_images.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#############################################################################
+# This is a script that will be run periodically as part of a cronjob on the 
+# Jenkins master (build machine) to create docker image tarballs for the e2e
+# test images. The script checks for presence of the versioned image tarballs
+# and if the desired version is not present, fetches the image and creates the 
+# tarball. It uses the setup-test-images ansible role to perform these tasks.
+#
+# These tarfiles are used by the load-test-images ansible role to load the 
+# images into the test VMs created as part of the CI test run.
+#############################################################################
+
+source ~/.profile
+
+# file touched by the jenkins job to indicate run in progress
+file=ci.running
+
+# log file path
+log=~/openebs/tar_status.log
+
+# message definitions
+no_run_msg="##### CI RUN IN PROGRESS, WON'T ATTEMPT TEST IMAGE UPDATES #####"
+run_msg="##### RUNNING PLAYBOOK TO PEROFRM IMAGE CHECK #####"
+error_msg="##### ERRORS DURING PLAYBOOK RUN, CHECK ARA LOGS #####"
+success_msg="##### PLAYBOOK COMPLETED SUCCESSFULLY #####"
+
+# look for file indicating ongoing CI job, exit if present
+if [ -f "$file" ]; then
+    echo $no_run_msg | awk '{ print strftime("%c:"),$0; fflush();}' >> $log
+    exit
+fi
+
+# invoke the setup-images.yml playbook
+echo $run_msg | awk '{ print strftime("%c:"),$0; fflush();}' >> $log
+cd ~/openebs/e2e/ansible && ansible-playbook setup-images.yml 2>&1 >> $log 
+
+# log failed playbook runs
+retcode=$?
+
+if [ $retcode -ne 0 ]
+then
+    echo $error_msg | awk '{ print strftime("%c:"),$0; fflush();}' >> $log
+    echo $retcode >> $log
+else 
+    echo $success_msg | awk '{ print strftime("%c:"),$0; fflush();}' >> $log
+fi


### PR DESCRIPTION
The CI integration suite is ever expanding and we need to make the run as efficient as possible.
Currently, we are running 3-4 applications and the run is seen to take around ~80 min.

Some ways to approach this are provided below :

- Increase the number of retries and decreasing poll interval while waiting on pod status changes
  post creation/deletion etc., during the testcase (#626)
- Use test images wherever possible instead of building the image during the course of a testcase (#623)
- Increasing the resources on the vagrant VMs being used in the kubernetes cluster (#636)
- PrePull test images into test harness and load into kubernetes nodes upon bringup

Together, these changes have been observed to reduce the CI run time to ~45 min.

This commit provides the code changes needed to perform the PrePull test images. Changes include :

- Ansible role and playbook to pull test images specified by a list (maintains images as versioned tarballs)
- Ansible role and playbook to load this into test k8s nodes (vagrantVM /baremetal)
- Updates to ci.yml to include load images step
- Bash script that will run on test/jenkins harness to invoke the pull image role
- Updates to jenkins cron file to include the bash script run

Further optimizations will be taken up as in subsequent releases

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #463 

**Special notes for your reviewer**:
