### PR TITLE
Add alertmanager and grafana for openebs-monitoring

### DIFF
--- a/k8s/openebs-monitoring/alertmanager.yaml
+++ b/k8s/openebs-monitoring/alertmanager.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: alertmanager
-        image: prom/alertmanager:latest
+        image: prom/alertmanager:v0.9.1
         args:
           - '-config.file=/etc/alertmanager/config.yml'
           - '-storage.path=/alertmanager'

--- a/k8s/openebs-monitoring/alertmanager.yaml
+++ b/k8s/openebs-monitoring/alertmanager.yaml
@@ -1,0 +1,61 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alertmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      name: alertmanager
+      labels:
+        app: alertmanager
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:latest
+        args:
+          - '-config.file=/etc/alertmanager/config.yml'
+          - '-storage.path=/alertmanager'
+        ports:
+        - name: alertmanager
+          containerPort: 9093
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/alertmanager
+        - name: templates-volume
+          mountPath: /alertmanager/template/
+        - name: alertmanager
+          mountPath: /alertmanager
+      volumes:
+      - name: config-volume
+        configMap:
+          name: alertmanager-config
+      - name: templates-volume
+        configMap:
+          name: alertmanager-templates
+      - name: alertmanager
+        emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/alertmanager/metrics'
+  labels:
+    name: alertmanager
+  name: alertmanager
+spec:
+  selector:
+    app: alertmanager
+  type: NodePort
+  ports:
+  - name: alertmanager
+    protocol: TCP
+    port: 9093
+    targetPort: 9093

--- a/k8s/openebs-monitoring/configs/alertmanager-config.yaml
+++ b/k8s/openebs-monitoring/configs/alertmanager-config.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+data:
+  config.yml: |-
+    global:
+      
+      # ResolveTimeout is the time after which an alert is declared resolved
+      # if it has not been updated.
+      resolve_timeout: 5m
+      # Replace the given api url by your slack webhook url.        
+      slack_api_url: 'https://hooks.slack.com/services/Token'
+
+    # The directory from which notification templates are read.
+    templates:
+    - '/alertmanager/templates/slack.tmpl'
+    
+    # The root route on which each incoming alert enters.
+    route:
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+      group_by: ['alertname', 'cluster', 'service']
+      
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+      group_wait: 10s
+      
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      
+      group_interval: 1m
+      
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 1m
+      
+      receiver: slack_general
+      
+      routes:
+      - match:
+          severity: 'warning'
+        receiver: slack_general
+
+    receivers:
+    - name: slack_general
+      slack_configs:
+      # channel name where webhook integrated       
+      - channel: '#alert'
+        text: "<!here>{{ range .Alerts }}\nInstance: {{ .Labels.instance }}\n {{ end }}"
+        

--- a/k8s/openebs-monitoring/configs/alertmanager-templates.yaml
+++ b/k8s/openebs-monitoring/configs/alertmanager-templates.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: alertmanager-templates 
+data:
+  slack.tmpl: |-
+    # TODO
+    # Create templates to customize alerts
+    {{ define "slack.alert.text" }}{{ end }}

--- a/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
@@ -1,0 +1,76 @@
+kind: ConfigMap
+metadata:
+  name: prometheus-alert-rules
+apiVersion: v1
+data:
+  alert.rules: |-
+    ## alert.rules ##
+    #
+    # CPU Alerts
+    #
+    # alerts when cpu usage exceeds the given limit within the 
+    # interval of 5 min
+    # The given expression below are the queries (PromQL) to
+    # get the details.
+    ALERT NodeCPUUsage
+      IF (100 - (avg by (instance) (irate(node_cpu{name="node-exporter",mode="idle"}[5m])) * 100)) > 75
+      FOR 2m
+      LABELS { severity="warning" }  
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High CPU usage detected",
+        DESCRIPTION = "{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})"
+      }
+  
+    #
+    # Disk Alerts
+    # 
+    ALERT NodeLowRootDisk
+      IF ((node_filesystem_size{mountpoint="/root-disk"} - node_filesystem_free{mountpoint="/root-disk"} ) / node_filesystem_size{mountpoint="/root-disk"} * 100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: Low root disk space",
+        DESCRIPTION = "{{$labels.instance}}: Root disk usage is above 75% (current value is: {{ $value }})"
+      }
+
+    ALERT NodeLowDataDisk
+      IF ((node_filesystem_size{mountpoint="/data-disk"} - node_filesystem_free{mountpoint="/data-disk"} ) / node_filesystem_size{mountpoint="/data-disk"} * 100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: Low data disk space",
+        DESCRIPTION = "{{$labels.instance}}: Data disk usage is above 75% (current value is: {{ $value }})"
+      }
+ 
+    #
+    # Node Load Alerts (5m)
+    # alerts when Load on node exceeds the given limit with in 5 min
+    ALERT NodeLoadAverage
+      IF ((node_load5 / count without (cpu, mode) (node_cpu{mode="system"})) > 1)
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High Node Load average(5m) detected",
+        DESCRIPTION = "{{$labels.instance}}: LA is high"
+      }
+
+    #
+    # RAM Alerts
+    #
+    ALERT NodeSwapUsage
+      IF (((node_memory_SwapTotal-node_memory_SwapFree)/node_memory_SwapTotal)*100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High Swap usage detected",
+        DESCRIPTION = "{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})"
+      }
+
+    ALERT NodeMemoryUsage
+      IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High memory usage detected",
+        DESCRIPTION = "{{$labels.instance}}: Memory usage is above 75% (current value is: {{ $value }})"
+      }  

--- a/k8s/openebs-monitoring/configs/prometheus-config.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-config.yaml
@@ -26,11 +26,13 @@ data:
     global:
       scrape_interval: 5s
       evaluation_interval: 5s
-    
+    rule_files: 
+    # alert rules passed as argument in prometheus-deployment at given path     
+    - '/etc/prometheus-rules/alert.rules' 
     # scrape config for maya-apiserver pods
     #
-    # The relabeling allows the actual pod scrape endpoint to be configured via the
-    # following annotations:
+    # The relabeling allows the actual pod scrape endpoint to be configured via 
+    # the following annotations:
     #
     # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
     # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.

--- a/k8s/openebs-monitoring/configs/prometheus-env.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-env.yaml
@@ -1,0 +1,11 @@
+# All the run time arguments required in prometheus should
+# be defined in this configmap
+# TODO:
+# Add arg to limit heap usage to overcome high RAM usage
+# Add remote storage address
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-env
+data:
+  storage-retention: 120h

--- a/k8s/openebs-monitoring/grafana-operator.yaml
+++ b/k8s/openebs-monitoring/grafana-operator.yaml
@@ -7,7 +7,7 @@ spec:
   ports:
   - port: 3000
     targetPort: 3000
-    nodePort: 32525
+    nodePort: 32515
   selector:
     app: grafana
 ---

--- a/k8s/openebs-monitoring/grafana-operator.yaml
+++ b/k8s/openebs-monitoring/grafana-operator.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  type: NodePort
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 32525
+  selector:
+    app: grafana
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: grafana
+  name: grafana
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - image: grafana/grafana:4.5.2
+        name: grafana
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        env:
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 30
+          timeoutSeconds: 1

--- a/k8s/openebs-monitoring/prometheus-env.yaml
+++ b/k8s/openebs-monitoring/prometheus-env.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: prometheus-env
-data:
-  storage-retention: 120h

--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -57,7 +57,7 @@ rules:
   verbs: ["get", "list", "watch"]
   # nonResourceURLs are endpoints that don’t map to a traditional resource. 
   # Things like /ui/ or /apis or /swagger.json that are used for redirects
-  # Prometheus by default look for /metrics endpoint for the different IP's.
+  # Prometheus by default look for /metrics endpoint for the differnet IP's.
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
@@ -103,7 +103,8 @@ spec:
             # The data in an emptyDir volume is safe across container crashes.
             - "-storage.local.path=/prometheus"
             # How long to retain samples in the local storage. 
-            - "-storage.local.retention=$(STORAGE_RETENTION)" 
+            - "-storage.local.retention=$(STORAGE_RETENTION)"
+            - "-alertmanager.url=http://alertmanager:9093" 
           ports:
             - containerPort: 9090
           env:
@@ -125,6 +126,7 @@ spec:
             limits:
               memory: "700M"
               cpu: "500m"
+          
           volumeMounts:
             # prometheus config file stored in the given mountpath
             - name: prometheus-server-volume
@@ -132,6 +134,9 @@ spec:
             # metrics collected by prometheus will be stored at the given mountpath.
             - name: prometheus-storage-volume
               mountPath: /prometheus
+            # alerting rules defined will be stored at given mountpath
+            - name: rules-volume
+              mountPath: /etc/prometheus-rules
       volumes:
         # Prometheus Config file will be stored in this volume 
         - name: prometheus-server-volume
@@ -141,6 +146,11 @@ spec:
         - name: prometheus-storage-volume
           # containers in the Pod can all read and write the same files here.
           emptyDir: {} 
+        # Rules defined in configmap will be stored in this volume
+        - name: rules-volume
+          configMap:
+            name: prometheus-alert-rules
+
 ---
 # prometheus-service
 apiVersion: v1

--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -95,7 +95,7 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: prom/prometheus:latest
+          image: prom/prometheus:v1.7.2
           args:
             - "-config.file=/etc/prometheus/conf/prometheus.yml"
             # Metrics are stored in an emptyDir volume which


### PR DESCRIPTION
1. Why is this change necessary ?
- To add support for alertmanager and grafana
- To isolate run time requirements like env variables in separate configmap

2. How does this change address the issue ?
- Add configuration and deployment files for alertmanager and grafana
- Some rules are defined for alerting purpose for various resource usage

3. How to verify this change ?
- Run `kubectl create -f openebs-monitoring/configs`
- Run `kubectl create -f openebs-monitoring/alertmanager.yaml`
- Run `kubectl create -f openebs-monitoring/prometheus-operator.yaml`
- Run `kubectl create -f openebs-monitoring/grafana-operator.yaml`
- After running the above commands successfully  you will be able to see the
  created deployments and services.
- Run `kubectl get svc` and note down the forwarded ports for the
  prometheus, grafana and alertmanager.
- Run `kubectl cluster-info` to get the node IP
- Now launch NodeIP:NodePort (the Ports for the services) in your
  browser and you will be able to see the UI for the respective services
  at the different ports.

4. What side effects does this change have ?
- your node may crash, if you have exhausted the resources, to avoid
  this situation, increase the  size of RAM  and underlying storage.

5. Other details
fix: #326, #736

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
