### PR TITLE
Include the sc used by demo apps to helm chart

### DIFF
--- a/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cassandra
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-es-data-sc
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-jupyter
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-kafka
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-mongodb
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-percona.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-percona.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-percona
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-redis.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-redis.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-redis
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-standalone
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "1"
+  size: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-zk.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-zk.yaml
@@ -1,0 +1,12 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-zk
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  pool: hostdir-var
+  replica: "2"
+  size: 5G


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
The sample application available in the openebs/k8s/demo - use different openebs-storage classes. Most of these classes in current form look similar, but the intention of having them seperate is to annotate them with storage policies that suit the application - in terms of operations and performance. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #712 

**Special notes for your reviewer**:

Output from running the new chart looks like this:
```
vagrant@minikube-dev:~$ helm install openebs-charts/openebs
NAME:   loopy-fox
LAST DEPLOYED: Tue Oct 31 11:43:43 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/Deployment
NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
maya-apiserver       1        1        1           0          1s
openebs-provisioner  1        1        1           0          1s

==> v1/StorageClass
NAME                TYPE
openebs-cassandra   openebs.io/provisioner-iscsi  
openebs-es-data-sc  openebs.io/provisioner-iscsi  
openebs-jupyter     openebs.io/provisioner-iscsi  
openebs-kafka       openebs.io/provisioner-iscsi  
openebs-mongodb     openebs.io/provisioner-iscsi  
openebs-percona     openebs.io/provisioner-iscsi  
openebs-redis       openebs.io/provisioner-iscsi  
openebs-standalone  openebs.io/provisioner-iscsi  
openebs-standard    openebs.io/provisioner-iscsi  
openebs-zk          openebs.io/provisioner-iscsi  

==> v1/ServiceAccount
NAME                   SECRETS  AGE
openebs-maya-operator  1        1s

==> v1beta1/ClusterRole
NAME                   AGE
openebs-maya-operator  1s

==> v1beta1/ClusterRoleBinding
NAME                   AGE
openebs-maya-operator  1s

==> v1/Service
NAME                    CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
maya-apiserver-service  10.0.0.233  <none>       5656/TCP  1s


NOTES:
The OpenEBS has been installed. Check its status by running:
  kubectl get pods -l "name=maya-apiserver"

To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
Please visit http://openebs.readthedocs.io/en/latest/getting_started/quick_install.html for instructions


vagrant@minikube-dev:~$ 
```