### PR TITLE
add openebs brand color in mobile view and justify content

### DIFF
--- a/documentation/source/_static/theme_overrides.css
+++ b/documentation/source/_static/theme_overrides.css
@@ -1,4 +1,6 @@
 /* override logo styling */
+
+
 /*.logo {
   display: block;
   width: 150px !important;
@@ -9,5 +11,13 @@
 }*/
 
 .wy-side-nav-search {
-  background-color: #ee5a2b;
+    background-color: #ee5a2b;
+}
+
+.wy-nav-top {
+    background-color: #ee5a2b;
+}
+
+.wy-nav-content {
+    text-align: justify;
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you -->
** it will change the navigation bar color in mobile view and fix text alignment " justfied"  **

**older mobile view**

![screencapture-openebs-readthedocs-io-en-latest-getting_started-overview-html-1509972929793 2](https://user-images.githubusercontent.com/20504600/32442360-253780b4-c321-11e7-9658-a3a6fcf53da1.png)


** New mobile view** 

![screencapture-inyeetest-readthedocs-io-en-latest-getting_started-overview-html-1509973320439 1](https://user-images.githubusercontent.com/20504600/32442384-415c9b3a-c321-11e7-9114-8e04fc07122e.png)

** you can check output here http://inyeetest.readthedocs.io/en/latest/getting_started/overview.html**:
