### PR TITLE
Include feature test to verify basic high-availability workflow 

### DIFF
--- a/e2e/ansible/playbooks/feature/ha/ha-cleanup.yml
+++ b/e2e/ansible/playbooks/feature/ha/ha-cleanup.yml
@@ -1,0 +1,19 @@
+---
+- name: Delete percona mysql pod
+  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 120
+  retries: 6
+
+
+

--- a/e2e/ansible/playbooks/feature/ha/ha-prerequisites.yml
+++ b/e2e/ansible/playbooks/feature/ha/ha-prerequisites.yml
@@ -1,0 +1,14 @@
+---
+- name: Run apt-get update via shell
+  shell: apt-get update
+  become: true
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  ignore_errors: true
+
+- name: Install mysql-client on K8S-master 
+  shell: apt-get install -y {{ item }}
+  become: true 
+  with_items: "{{ deb_packages }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+      

--- a/e2e/ansible/playbooks/feature/ha/ha-vars.yml
+++ b/e2e/ansible/playbooks/feature/ha/ha-vars.yml
@@ -1,0 +1,14 @@
+---
+test_name: ha_pod_reschedule
+
+percona_mysql_plugin_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml
+
+pod_yaml_alias: demo-percona-mysql-pvc.yaml
+
+deb_packages:
+  - mysql-client
+
+
+
+
+

--- a/e2e/ansible/playbooks/feature/ha/ha.yml
+++ b/e2e/ansible/playbooks/feature/ha/ha.yml
@@ -1,0 +1,206 @@
+---
+- hosts: localhost
+
+  vars_files: 
+    - ha-vars.yml
+
+  tasks:
+   - block:
+
+       #################################################
+       # PREPARE TEST ENV FOR THE HA TEST              #
+       # (Includes installing packages, deploying apps)#
+       #################################################
+
+       - include: ha-prerequisites.yml 
+
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Download YAML for percona mysql plugin
+         get_url:
+           url: "{{ percona_mysql_plugin_link }}"
+           dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           force: yes
+         register: result
+         until:  "'OK' in result.msg"
+         delay: 5
+         retries: 3
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check whether maya-apiserver pod is deployed
+         shell: >
+           source ~/.profile; 
+           kubectl get pods -l name=maya-apiserver --no-headers
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 60
+         retries: 10
+
+       - name: Deploy percona mysql pod         
+         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Confirm pod status is running
+         shell: >
+           source ~/.profile; 
+           kubectl get pods -l name=percona --no-headers
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 120
+         retries: 15
+
+       ###################################################################
+       # PREPARE FOR FAULT-INJECTION                                     #
+       # (Includes identifying objects to fail, simulating infra changes)#
+       ###################################################################
+
+       - name: Get storage ctrl pod name
+         shell: >
+           source ~/.profile; 
+           kubectl get pods -l openebs/controller=jiva-controller
+           --no-headers
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Set ctrl pod name to variable
+         set_fact:
+           ctrl_pod_name: "{{ result.stdout.split()[0] }}"  
+
+       - name: Get node on which the pod is scheduled
+         shell: >
+           source ~/.profile; 
+           kubectl describe pod {{ctrl_pod_name}} | grep -w 'Node:'
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+      
+       - name: Store the ctrl pod node name in a variable 
+         set_fact:
+           ctrl_node: "{{ result.stdout.split('/')[0].split('\t')[2]}}"
+
+       - name: Make the current ctrl node unschedulable  
+         shell: source ~/.profile; kubectl cordon {{ctrl_node}}
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      
+       - name: Confirm ctrl node is unschedulable 
+         shell: source ~/.profile; kubectl get nodes | grep {{ctrl_node}}
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         failed_when: "'SchedulingDisabled' not in result.stdout"
+
+       ########################################################
+       # INJECT FAULT                                         #
+       # (Includes using tools, commands etc.,)               #
+       ########################################################
+ 
+       - name: Delete the ctrl pod to force reschedule 
+         shell: source ~/.profile; kubectl delete pod {{ctrl_pod_name}}
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         failed_when: "ctrl_pod_name and 'deleted' not in result.stdout"
+
+       #########################################################
+       # VERIFY RECOVERY                                       #
+       # (Includes checking desired fault-tolerance behaviour) #
+       #########################################################
+ 
+       - name: Check if ctrl pod is restarted within 30s 
+         shell: >
+           source ~/.profile; 
+           kubectl get pods -l openebs/controller=jiva-controller
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'Running' in result.stdout_lines[1]"
+         delay: 5
+         retries: 6
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       #######################################################
+       # POST RECOVERY HEALTH-CHECK                          #
+       # (Includes application status etc.,)                 #
+       #######################################################   
+
+       - name: Get percona pod details post ha
+         shell: >
+           source ~/.profile; 
+           kubectl get pods -l name=percona -o wide
+           --no-headers
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Set pod variables to facts 
+         set_fact:
+           pod_status: "{{ result.stdout.split()[2] }}"
+           pod_restarts: "{{ result.stdout.split()[3] }}" 
+           pod_ip: "{{ result.stdout.split()[5] }}"
+
+       - name: Verify percona is running w/o restarts
+         debug: 
+           msg: "Percona pod health-check is successful"
+         failed_when: "pod_status != 'Running' and pod_restarts != '0'"
+
+       - name: Create a test db on percona to confirm health
+         shell: mysql -uroot -pk8sDem0 -h {{pod_ip}} -e "CREATE DATABASE Inventory;"
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result 
+         failed_when: "result.rc != 0"
+
+       ########################################################
+       # REVERT FAULTS AND CLEANUP                            #
+       # (Includes commands, delete applications etc.,)       #
+       ########################################################     
+
+       - name: Uncordon the K8S node as part of cleanup
+         shell: source ~/.profile; kubectl uncordon {{ctrl_node}}
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   
+       - include: ha-cleanup.yml
+
+       - set_fact: 
+           flag: "Pass"
+
+     rescue:  
+       - set_fact: 
+           flag: "Fail"
+ 
+     always: 
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN') 
+
+           
+         
+       


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

HA is a critical feature of the OpenEBS storage solution. This commit adds the ansible playbook and task files necessary to execute a basic ha testcase that causes the ctrl pod reschedule from one node to another

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #531  

**Special notes for your reviewer**:

2. How does this change address the issue?

Typically, fault-injection is used to test resiliency (here in the context of HA). Fault-injection tests generally include the following steps:

- Test bed/env creation
- Pre-fault health checks/prepare for fault-injection
- Fault injection
- Verify system's fault-tolerance/Recovery capabilities
- Post recovery health-checks
- Revert fault
- Cleanup

The included test playbook attempts to create a "HA/Resiliency test template" that can be followed in the future while building test playbooks in future. It uses "kubectl cordon" and "kubectl delete pod" commands to modify the infrastructure, inject fault and generally simulate HA.

The application used is percona, which is checked for "Running" status and "zero" restarts during HA as part of verifying the tolerance and health-check. Also, some sample db query is performed after ctrl pod reschedule.

Files in this PR include : 

- ha-vars.yml - Holds test variables
- ha-prerequisites.yml - Set of tasks to be performed before starting test (packages etc.,)
- ha-cleanup.yml - Cleanup routines
- ha.yml - Main test playbook (above three are statically included into this yaml)

**Note**: Under ideal circumstances we can have live-load on the db while performing this test, something that is ideally achievable by the ansible "async" module. However, due  to some open issues in it, we have not included it in the playbook. Instead, we have included logic to check status/restart count of pod and perform db writes post ha to check sanity. 

Resiliency tests in future are expected to make use of tools like [pumba](https://github.com/gaia-adm/pumba) and stronger verification procedures. 