### PR TITLE
Update the Crunchy-Postgres statefulset specs to successfully deploy replication cluster

### DIFF
--- a/k8s/demo/crunchy-postgres/README.md
+++ b/k8s/demo/crunchy-postgres/README.md
@@ -1,12 +1,12 @@
 # Running Crunchy-Postgres with OpenEBS
 
-This tutorial provides detailed instructions to run a PostgreSQL Statefulset with OpenEBS storage and perform 
+This tutorial provides detailed instructions to run a PostgreSQL StatefulSet with OpenEBS storage and perform 
 simple database operations to verify successful deployment. 
 
 ## Crunchy-Postgres 
 
-The postgres container used in the Statefulset is sourced from (CrunchyData)[https://github.com/CrunchyData/crunchy-containers]. CrunchyData provides cloud agnostic PostgreSQL container technology that is designed for production 
-workloads with cloud native HA, DR, and monitoring.  
+The postgres container used in the StatefulSet is sourced from (CrunchyData)[https://github.com/CrunchyData/crunchy-containers]. CrunchyData provides cloud agnostic PostgreSQL container technology that is designed for production 
+workloads with cloud native High Availability, Disaster Recovery, and monitoring.  
 
 ## Prerequisite
 
@@ -20,11 +20,11 @@ maya-apiserver-2245240594-ktfs2                                  1/1       Runni
 openebs-provisioner-4230626287-t8pn9                             1/1       Running   0          3h
 ```
 
-## Deploy the Crunchy-Postgres Statefulset with OpenEBS storage
+## Deploy the Crunchy-Postgres StatefulSet with OpenEBS Storage
 
-The Statefulset specification JSONs are available at OpenEBS/k8s/demo/crunchy-postgres. 
+The StatefulSet specification JSONs are available at OpenEBS/k8s/demo/crunchy-postgres. 
 
-The number of replicas in the Statefulset can be modified in the *set.json* file. This example uses 2 replicas, 
+The number of replicas in the StatefulSet can be modified in the *set.json* file. This example uses 2 replicas, 
 which includes one master and one slave. The Postgres pods are configured as primary/master or as replica/slave by 
 a startup script which decides the role based on ordinality assigned to the pod.
 
@@ -84,7 +84,7 @@ service "pgset-replica" created
 statefulset "pgset" created
 ```
 
-Verify that all the OpenEBS persistent volumes are created, the Crunchy-Postgres services and pods are running. 
+Verify that all the OpenEBS persistent volumes are created and the Crunchy-Postgres services and pods are running. 
 
 ```
 test@Master:~/crunchy-postgres$ kubectl get statefulsets
@@ -130,9 +130,9 @@ dependent on the network speed.
 The verification procedure can be carried out using the following steps: 
 
 - Check cluster replication status between the Postgres primary and replica
-- Create a table in the default database as a Postgres user on the primary
-- Check data synchronization on the replica for created table
-- Verify table creation is restricted on the replica
+- Create a table in the default database as Postgres user "testuser" on the primary
+- Check data synchronization on the replica for table you have created
+- Verify that table is not created on the replica
 
 ### Step-1: Install the PostgreSQL-Client
 
@@ -176,8 +176,8 @@ INSERT 0 1
 
 ### Step-4: Verify Data Synchronization on Replica
 
-Identify the IP address of the replica (pgset-1) pod or the service (pgset-replica) and execute the following
-query: 
+Identify the IP Address of the replica (pgset-1) pod or the service (pgset-replica) and execute the following
+command: 
 
 ```
 test@Master:~$ psql -h 10.44.0.6 -U testuser postgres -c 'table foo'
@@ -188,11 +188,11 @@ Password for user testuser:
 (1 row)
 ```
 
-Verify that the table content is replicated successfully
+Verify that the table content is replicated successfully.
 
 ### Step-5: Verify Database Write Restricted on Replica
 
-Attempt creation of a new table on the replica and verify the operation is unsuccessful.
+Attempt to create a new table on the replica, and verify that the creation is unsuccessful.
 
 ```
 test@Master:~$ psql -h 10.44.0.6 -U testuser postgres -c 'create table bar(id int)'

--- a/k8s/demo/crunchy-postgres/README.md
+++ b/k8s/demo/crunchy-postgres/README.md
@@ -1,35 +1,203 @@
-This is place-holder for providing the steps to run clustered postgresql on K8s+OpenEBS. We hope to merge these files back to https://github.com/CrunchyData/crunchy-containers/blob/master/examples/kube/
+# Running Crunchy-Postgres with OpenEBS
 
+This tutorial provides detailed instructions to run a PostgreSQL Statefulset with OpenEBS storage and perform 
+simple database operations to verify successful deployment. 
 
+## Crunchy-Postgres 
 
-## Usage
+The postgres container used in the Statefulset is sourced from (CrunchyData)[https://github.com/CrunchyData/crunchy-containers]. CrunchyData provides cloud agnostic PostgreSQL container technology that is designed for production 
+workloads with cloud native HA, DR, and monitoring.  
 
-Once you have OpenEBS enabled on your K8s Cluster, you can use the following simple steps to launch a clustered postgresql service with one master and one replica. 
+## Prerequisite
 
-### Step 1: Download the files to your host, which has access to kubectl 
+A fully configured (preferably, multi-node) Kubernetes cluster configured with the OpenEBS operator and OpenEBS
+storage classes.
+
 ```
-cd $HOME
-git clone https://github.com/openebs/openebs.git
-cd openebs/k8s/demo/crunchy-postgres
-```
-
-### Step 2: Run the StatefulSet. 
-The files are make available with default images and credentails (set.json)
-```
-./run.sh
-```
-
-The above step will automatically create the OpenEBS volumes required for master and replica postgresql containers. The volume details can be inspected using the standard kubectl commands like:
-```
-kubectl get pvc
-kubectl get pv
+test@Master:~/crunchy-postgres$ kubectl get pods
+NAME                                                             READY     STATUS    RESTARTS   AGE
+maya-apiserver-2245240594-ktfs2                                  1/1       Running   0          3h
+openebs-provisioner-4230626287-t8pn9                             1/1       Running   0          3h
 ```
 
+## Deploy the Crunchy-Postgres Statefulset with OpenEBS storage
 
-## Motivation
+The Statefulset specification JSONs are available at OpenEBS/k8s/demo/crunchy-postgres. 
 
-The k8s spec files are based on the files provided by [CrunchyData StatefulSet with Dynamic Provisioner](https://github.com/CrunchyData/crunchy-containers/tree/master/examples/kube/statefulset-dyn)
+The number of replicas in the Statefulset can be modified in the *set.json* file. This example uses 2 replicas, 
+which includes one master and one slave. The Postgres pods are configured as primary/master or as replica/slave by 
+a startup script which decides the role based on ordinality assigned to the pod.
 
-Kubernetes Blog for running [Clustered PostgreSQL using StatefulSet](http://blog.kubernetes.io/2017/02/postgresql-clusters-kubernetes-statefulsets.html)
+```
+{
+  "apiVersion": "apps/v1beta1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "name": "pgset"
+  },
+  "spec": {
+    "serviceName": "pgset",
+    "replicas": 2,
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "pgset"
+        }
+      },
+:
+```
+
+Execute the following commands: 
+
+```
+test@Master:~$ cd openebs/k8s/demo/crunchy-postgres/
+
+test@Master:~/openebs/k8s/demo/crunchy-postgres$  ls -ltr
+total 32
+-rw-rw-r-- 1 test test  300 Nov 14 16:27 set-service.json
+-rw-rw-r-- 1 test test   97 Nov 14 16:27 set-sa.json
+-rw-rw-r-- 1 test test  558 Nov 14 16:27 set-replica-service.json
+-rw-rw-r-- 1 test test  555 Nov 14 16:27 set-master-service.json
+-rw-rw-r-- 1 test test 1879 Nov 14 16:27 set.json
+-rwxrwxr-x 1 test test 1403 Nov 14 16:27 run.sh
+-rw-rw-r-- 1 test test 1292 Nov 14 16:27 README.md
+-rwxrwxr-x 1 test test  799 Nov 14 16:27 cleanup.sh
+```
+
+```
+test@Master:~/crunchy-postgres$ ./run.sh
++++ dirname ./run.sh
+++ cd .
+++ pwd
++ DIR=/home/test/openebs/k8s/demo/crunchy-postgres
++ kubectl create -f /home/test/openebs/k8s/demo/crunchy-postgres/set-sa.json
+serviceaccount "pgset-sa" created
++ kubectl create clusterrolebinding permissive-binding --clusterrole=cluster-admin --user=admin --user=kubelet --group=system:serviceaccounts
+clusterrolebinding "permissive-binding" created
++ kubectl create -f /home/test/openebs/k8s/demo/crunchy-postgres/set-service.json
+service "pgset" created
++ kubectl create -f /home/test/openebs/k8s/demo/crunchy-postgres/set-primary-service.json
+service "pgset-primary" created
++ kubectl create -f /home/test/openebs/k8s/demo/crunchy-postgres/set-replica-service.json
+service "pgset-replica" created
++ kubectl create -f /home/test/openebs/k8s/demo/crunchy-postgres/set.json
+statefulset "pgset" created
+```
+
+Verify that all the OpenEBS persistent volumes are created, the Crunchy-Postgres services and pods are running. 
+
+```
+test@Master:~/crunchy-postgres$ kubectl get statefulsets
+NAME      DESIRED   CURRENT   AGE
+pgset     2         2         15m
+
+test@Master:~/crunchy-postgres$ kubectl get pods
+NAME                                                             READY     STATUS    RESTARTS   AGE
+maya-apiserver-2245240594-ktfs2                                  1/1       Running   0          3h
+openebs-provisioner-4230626287-t8pn9                             1/1       Running   0          3h
+pgset-0                                                          1/1       Running   0          3m
+pgset-1                                                          1/1       Running   0          3m
+pvc-17e21bd3-c948-11e7-a157-000c298ff5fc-ctrl-3572426415-n8ctb   1/1       Running   0          3m
+pvc-17e21bd3-c948-11e7-a157-000c298ff5fc-rep-3113668378-9437w    1/1       Running   0          3m
+pvc-17e21bd3-c948-11e7-a157-000c298ff5fc-rep-3113668378-xnt12    1/1       Running   0          3m
+pvc-1e96a86b-c948-11e7-a157-000c298ff5fc-ctrl-2773298268-x3dlb   1/1       Running   0          3m
+pvc-1e96a86b-c948-11e7-a157-000c298ff5fc-rep-723453814-hpkw3     1/1       Running   0          3m
+pvc-1e96a86b-c948-11e7-a157-000c298ff5fc-rep-723453814-tpjqm     1/1       Running   0          3m
+
+test@Master:~/crunchy-postgres$ kubectl get svc
+NAME                                                CLUSTER-IP       EXTERNAL-IP   PORT(S)             AGE
+kubernetes                                          10.96.0.1        <none>        443/TCP             4h
+maya-apiserver-service                              10.98.249.191    <none>        5656/TCP            3h
+pgset                                               None             <none>        5432/TCP            14m
+pgset-primary                                       10.104.32.113    <none>        5432/TCP            14m
+pgset-replica                                       10.99.40.69      <none>        5432/TCP            14m
+pvc-17e21bd3-c948-11e7-a157-000c298ff5fc-ctrl-svc   10.111.243.121   <none>        3260/TCP,9501/TCP   14m
+pvc-1e96a86b-c948-11e7-a157-000c298ff5fc-ctrl-svc   10.102.138.94    <none>        3260/TCP,9501/TCP   13m
+
+
+test@Master:~/crunchy-postgres$ kubectl get clusterrolebinding permissive-binding
+NAME                 AGE
+permissive-binding   15m
+test@Master:~/crunchy-postgres$
+```
+
+Note: It may take some time for the pods to start as the images must be pulled and instantiated. This is also
+dependent on the network speed.
+
+
+## Verify Successful Crunchy-Postgres Deployment
+
+The verification procedure can be carried out using the following steps: 
+
+- Check cluster replication status between the Postgres primary and replica
+- Create a table in the default database as a Postgres user on the primary
+- Check data synchronization on the replica for created table
+- Verify table creation is restricted on the replica
+
+### Step-1: Install the PostgreSQL-Client
+
+Install the PostgreSQL CLient Utility (psql) on any of the Kubernetes machines to perform database operations 
+from command line. 
+
+```
+sudo apt-get install postgresql-client
+```
+
+### Step-2: Verify Cluster Replication Status on Crunchy-Postgres Cluster
+
+Identify the IP address of the primary (pgset-0) pod or the service (pgset-primary) and execute the following
+query:
+
+```
+test@Master:~$ psql -h 10.47.0.3 -U testuser postgres -c 'select * from pg_stat_replication'
+
+ pid | usesysid |   usename   | application_name | client_addr | client_hostname | client_port |         backend_start         | backend_xmin |   state   | sent_lsn  | write_lsn | flush_lsn | replay_lsn | write_lag | flush_lag | replay_lag | sync_priority | sync_state
+-----+----------+-------------+------------------+-------------+-----------------+-------------+-------------------------------+--------------+-----------+-----------+-----------+-----------+------------+-----------+-----------+------------+---------------+------------
+  94 |    16391 | primaryuser | pgset-1          | 10.44.0.0   |                 |       60460 | 2017-11-14 09:29:21.990782-05 |              | streaming | 0/3014278 | 0/3014278 | 0/3014278 | 0/3014278  |           |           |            |             0 | async
+(1 row)
+```
+
+The replica should be registered for "asynchronous" replication. 
+
+### Step-3: Create a Table with Test Content on the Default Database 
+
+These queries should be executed on the primary.
+
+```
+test@Master:~$ psql -h 10.47.0.3 -U testuser postgres -c 'create table foo(id int)'
+Password for user testuser:
+CREATE TABLE
+```
+```
+test@Master:~/crunchy-postgres$ psql -h 10.47.0.3 -U testuser postgres -c 'insert into foo values (1)'
+Password for user testuser:
+INSERT 0 1
+```
+
+### Step-4: Verify Data Synchronization on Replica
+
+Identify the IP address of the replica (pgset-1) pod or the service (pgset-replica) and execute the following
+query: 
+
+```
+test@Master:~$ psql -h 10.44.0.6 -U testuser postgres -c 'table foo'
+Password for user testuser:
+ id
+----
+  1
+(1 row)
+```
+
+Verify that the table content is replicated successfully
+
+### Step-5: Verify Database Write Restricted on Replica
+
+Attempt creation of a new table on the replica and verify the operation is unsuccessful.
+
+```
+test@Master:~$ psql -h 10.44.0.6 -U testuser postgres -c 'create table bar(id int)'
+Password for user testuser:
+ERROR:  cannot execute CREATE TABLE in a read-only transaction
+```
 
 

--- a/k8s/demo/crunchy-postgres/README.md
+++ b/k8s/demo/crunchy-postgres/README.md
@@ -131,13 +131,13 @@ The verification procedure can be carried out using the following steps:
 
 - Check cluster replication status between the Postgres primary and replica
 - Create a table in the default database as Postgres user "testuser" on the primary
-- Check data synchronization on the replica for table you have created
+- Check data synchronization on the replica for the table you have created
 - Verify that table is not created on the replica
 
 ### Step-1: Install the PostgreSQL-Client
 
 Install the PostgreSQL CLient Utility (psql) on any of the Kubernetes machines to perform database operations 
-from command line. 
+from the command line. 
 
 ```
 sudo apt-get install postgresql-client
@@ -145,7 +145,7 @@ sudo apt-get install postgresql-client
 
 ### Step-2: Verify Cluster Replication Status on Crunchy-Postgres Cluster
 
-Identify the IP address of the primary (pgset-0) pod or the service (pgset-primary) and execute the following
+Identify the IP Address of the primary (pgset-0) pod or the service (pgset-primary) and execute the following
 query:
 
 ```

--- a/k8s/demo/crunchy-postgres/cleanup.sh
+++ b/k8s/demo/crunchy-postgres/cleanup.sh
@@ -14,6 +14,7 @@
 
 kubectl delete statefulset pgset
 kubectl delete sa pgset-sa
-kubectl delete service pgset pgset-master pgset-replica
+kubectl delete service pgset pgset-primary pgset-replica
 kubectl delete pod pgset-0 pgset-1
 kubectl delete pvc pgdata-pgset-0 pgdata-pgset-1
+kubectl delete clusterrolebinding permissive-binding

--- a/k8s/demo/crunchy-postgres/run.sh
+++ b/k8s/demo/crunchy-postgres/run.sh
@@ -24,8 +24,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 kubectl create -f $DIR/set-sa.json
 
 # For version Kube 1.6, we must allow the service account to perform
-# a label command. For this example, OpenEBS open up wide permissions
-# for all service accounts, this is NOT for production!
+# a label command. For this example, OpenEBS opens up wide permissions
+# for all service accounts. This is NOT for production!
 kubectl create clusterrolebinding permissive-binding \
   --clusterrole=cluster-admin \
   --user=admin \

--- a/k8s/demo/crunchy-postgres/run.sh
+++ b/k8s/demo/crunchy-postgres/run.sh
@@ -18,7 +18,7 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-$DIR/cleanup.sh
+#$DIR/cleanup.sh
 
 # create the service account used in the containers
 kubectl create -f $DIR/set-sa.json
@@ -26,14 +26,14 @@ kubectl create -f $DIR/set-sa.json
 # as of Kube 1.6, we need to allow the service account to perform
 # a label command, for this example, we open up wide permissions
 # for all serviceaccounts, this is NOT for production!
-#kubectl create clusterrolebinding permissive-binding \
-#  --clusterrole=cluster-admin \
-#  --user=admin \
-#  --user=kubelet \
-#  --group=system:serviceaccounts
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --group=system:serviceaccounts
 
 # create the services for the example
 kubectl create -f $DIR/set-service.json
-kubectl create -f $DIR/set-master-service.json
+kubectl create -f $DIR/set-primary-service.json
 kubectl create -f $DIR/set-replica-service.json
 kubectl create -f $DIR/set.json

--- a/k8s/demo/crunchy-postgres/run.sh
+++ b/k8s/demo/crunchy-postgres/run.sh
@@ -23,9 +23,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # create the service account used in the containers
 kubectl create -f $DIR/set-sa.json
 
-# as of Kube 1.6, we need to allow the service account to perform
-# a label command, for this example, we open up wide permissions
-# for all serviceaccounts, this is NOT for production!
+# For version Kube 1.6, we must allow the service account to perform
+# a label command. For this example, OpenEBS open up wide permissions
+# for all service accounts, this is NOT for production!
 kubectl create clusterrolebinding permissive-binding \
   --clusterrole=cluster-admin \
   --user=admin \

--- a/k8s/demo/crunchy-postgres/set-primary-service.json
+++ b/k8s/demo/crunchy-postgres/set-primary-service.json
@@ -2,9 +2,9 @@
         "kind": "Service",
         "apiVersion": "v1",
         "metadata": {
-            "name": "pgset-master",
+            "name": "pgset-primary",
             "labels": {
-                "name": "pgset-master"
+                "name": "pgset-primary"
             }
         },
         "spec": {
@@ -15,7 +15,7 @@
                 "nodePort": 0
             }],
             "selector": {
-                "name": "pgset-master"
+                "name": "pgset-primary"
             },
             "type": "ClusterIP",
             "sessionAffinity": "None"

--- a/k8s/demo/crunchy-postgres/set.json
+++ b/k8s/demo/crunchy-postgres/set.json
@@ -14,10 +14,14 @@
         }
       },
       "spec": {
+        "securityContext": 
+          {
+            "fsGroup": 26
+          },
         "containers": [
           {
             "name": "pgset",
-            "image": "crunchydata/crunchy-postgres:centos7-9.6-1.4.0",
+            "image": "crunchydata/crunchy-postgres:centos7-10.0-1.6.0",
             "ports": [
               {
                 "containerPort": 5432,
@@ -25,16 +29,16 @@
               }
             ],
             "env": [{
-                "name": "PG_MASTER_USER",
-                "value": "master"
+                "name": "PG_PRIMARY_USER",
+                "value": "primaryuser"
             }, {
                 "name": "PGHOST",
                 "value": "/tmp"
             }, {
                 "name": "PG_MODE",
-                "value": "master"
+                "value": "set"
             }, {
-                "name": "PG_MASTER_PASSWORD",
+                "name": "PG_PRIMARY_PASSWORD",
                 "value": "password"
             }, {
                 "name": "PG_USER",
@@ -48,6 +52,12 @@
             }, {
                 "name": "PG_ROOT_PASSWORD",
                 "value": "password"
+            }, {
+                "name": "PG_PRIMARY_PORT",
+                "value": "5432"
+            }, {
+                "name": "PG_PRIMARY_HOST",
+                "value": "pgset-primary"
             }],
             "volumeMounts": [
               {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

 The current JSON specs for Crunchy-Postgres statefulset fail to bring up the database cluster. Following changes have been made to enable this: 

- Changed the PG_MODE env variable in the spec from "Master" to "Set". Latter is needed by the startup scripts to decide on instance role based on ordinality

- Included Security Context for the pods to allow a user generated on the container to access and manage the mounted volume

- Included PG_PRIMARY_PORT env variable for successful port registration

- Included PG_PRIMARY_HOST env variable. This is needed by the slave/replica to sync with the primary/master

- Updated Crunchy-Postgres image version to latest stable release 1.6.0

- Updated semantics changes as needed by 1.6.0 (master->primary)

- Updated README with deployment, usage and verification instructions

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #461 

**Special notes for your reviewer**:

Refer https://github.com/CrunchyData/crunchy-containers/issues/287
