### PR TITLE
Replace release tags for all openebs images on openebs-operator before deployment

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -7,4 +7,6 @@ openebs_storageclasses_link: https://raw.githubusercontent.com/openebs/openebs/m
 
 openebs_storageclasses_alias: openebs-storageclasses.yaml
 
-test_tag: ci
+# Image tag for openebs containers
+# Accepted entries (ci, latest): Default: latest
+test_tag: latest

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -12,8 +12,12 @@
 - name: Change m-apiserver image to desired tag in operator YAML
   replace:
     path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}" 
-    regexp: "m-apiserver:[\\w.-]+"
-    replace: "m-apiserver:{{ test_tag }}"
+    regexp: "{{item}}:[\\w.-]+"
+    replace: "{{item}}:{{ test_tag }}"
+  with_items: 
+    - m-apiserver
+    - jiva
+    - openebs-k8s-provisioner
 
 - name: Get kubernetes master name
   shell: hostname


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

CI needs to run tests on the latest unit-tested openebs images. 

This commit basically extends #739 . Tagging images with "ci" is ideal and the best practice 
(should consist of unit-tested/stable versions for e2e). However, included "latest" as not all openebs images are being tagged with "ci" at this point.

- Two test tags: "ci" & "latest" are defined for openebs images. With "latest" as default
- The k8s-openebs-operator role will change the tags on all images in the openebs-operator yaml
  before deploying it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #616 

**Special notes for your reviewer**:
