### PR TITLE
Add deployment/configs for alertmanager (federation) and m-exporter

### DIFF
--- a/k8s/openebs-monitoring/README.md
+++ b/k8s/openebs-monitoring/README.md
@@ -7,9 +7,20 @@
 │   ├── configs
 │   │   ├── alertmanager-config.yaml
 │   │   ├── alertmanager-templates.yaml
+│   │   ├── openebs-dashboard.json
 │   │   ├── prometheus-alert-rules.yaml
 │   │   ├── prometheus-config.yaml
 │   │   └── prometheus-env.yaml
+│   ├── federation
+│   │   ├── configs
+│   │   │   ├── alertmanager-config.yaml
+│   │   │   ├── alertmanager-templates.yaml
+│   │   │   ├── openebs-dashboard.json
+│   │   │   ├── prometheus-alert-rules.yaml
+│   │   │   ├── prometheus-config-master.yaml
+│   │   │   └── prometheus-env.yaml
+│   │   ├── grafana-operator.yaml
+│   │   └── prometheus-operator-master.yaml
 │   ├── grafana-operator.yaml
 │   ├── prometheus-operator.yaml
 │   └── README.md
@@ -60,6 +71,11 @@ kubectl create -f prometheus-operator.yaml
 kubectl create -f alertmanager.yaml
 kubectl create -f grafana-operator.yaml
 ```
+
+- **Note** : For setting up the cluster on gcloud change the type of service
+    from NodePort to LoadBalancer, ClusterIP based on your requirement. Choosing
+    NodePort over LoadBalancer and ClusterIP doesn't gives you external IP
+    rather exposed srvices can be accesible on the NodeIP:NodePort.
 ## Verify
 After successfully running the above commands, the output displayed is similar to the following :
 ```
@@ -90,3 +106,10 @@ deployment "grafana" created
 * To launch Grafana open NodeIP:NodePort  (NodePort of grafana service) in your browser.
 ## Launch Alertmanager UI
 * To launch alertmanager open NodeIP:NodePort (NodePort of alertmanager service)
+
+## Federation
+Federation is used for scaling prometheus and ensuring its reliability. In this configuration there are two or more than two Prometheus running instances one is known as global which is used for collecting the metrics from others, known as slaves.
+## Setup Federation
+* All the setups and steps are very similar to previous one, one and only change is to be made in prometheus-master-config.yaml.
+* Just replace the IP given in targets field of job `master-federation` with your slave prometheus and also add the job name which you want to collect in the match field.
+* After configuring your global prometheus just repeat the steps given above in setup prometheus.

--- a/k8s/openebs-monitoring/federation/alertmanager.yaml
+++ b/k8s/openebs-monitoring/federation/alertmanager.yaml
@@ -1,0 +1,61 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: alertmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      name: alertmanager
+      labels:
+        app: alertmanager
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: alertmanager
+        image: prom/alertmanager:v0.9.1
+        args:
+          - '-config.file=/etc/alertmanager/config.yml'
+          - '-storage.path=/alertmanager'
+        ports:
+        - name: alertmanager
+          containerPort: 9093
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/alertmanager
+        - name: templates-volume
+          mountPath: /alertmanager/template/
+        - name: alertmanager
+          mountPath: /alertmanager
+      volumes:
+      - name: config-volume
+        configMap:
+          name: alertmanager-config
+      - name: templates-volume
+        configMap:
+          name: alertmanager-templates
+      - name: alertmanager
+        emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/path: '/alertmanager/metrics'
+  labels:
+    name: alertmanager
+  name: alertmanager
+spec:
+  selector:
+    app: alertmanager
+  type: NodePort
+  ports:
+  - name: alertmanager
+    protocol: TCP
+    port: 9093
+    targetPort: 9093

--- a/k8s/openebs-monitoring/federation/configs/alertmanager-config.yaml
+++ b/k8s/openebs-monitoring/federation/configs/alertmanager-config.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-config
+data:
+  config.yml: |-
+    global:
+      
+      # ResolveTimeout is the time after which an alert is declared resolved
+      # if it has not been updated.
+      resolve_timeout: 5m
+      # Replace the given api url by your slack webhook url.        
+      slack_api_url: 'https://hooks.slack.com/services/Token'
+
+    # The directory from which notification templates are read.
+    templates:
+    - '/alertmanager/templates/slack.tmpl'
+    
+    # The root route on which each incoming alert enters.
+    route:
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+      group_by: ['alertname', 'cluster', 'service']
+      
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+      group_wait: 10s
+      
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      
+      group_interval: 1m
+      
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 1m
+      
+      receiver: slack_general
+      
+      routes:
+      - match:
+          severity: 'warning'
+        receiver: slack_general
+
+    receivers:
+    - name: slack_general
+      slack_configs:
+      # channel name where webhook integrated       
+      - channel: '#alert'
+        text: "<!here>{{ range .Alerts }}\nInstance: {{ .Labels.instance }}\n {{ end }}"
+        

--- a/k8s/openebs-monitoring/federation/configs/alertmanager-templates.yaml
+++ b/k8s/openebs-monitoring/federation/configs/alertmanager-templates.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: alertmanager-templates 
+data:
+  slack.tmpl: |-
+    # TODO
+    # Create templates to customize alerts
+    {{ define "slack.alert.text" }}{{ end }}

--- a/k8s/openebs-monitoring/federation/configs/prometheus-alert-rules.yaml
+++ b/k8s/openebs-monitoring/federation/configs/prometheus-alert-rules.yaml
@@ -1,0 +1,76 @@
+kind: ConfigMap
+metadata:
+  name: prometheus-alert-rules
+apiVersion: v1
+data:
+  alert.rules: |-
+    ## alert.rules ##
+    #
+    # CPU Alerts
+    #
+    # alerts when cpu usage exceeds the given limit within the 
+    # interval of 5 min
+    # The given expression below are the queries (PromQL) to
+    # get the details.
+    ALERT NodeCPUUsage
+      IF (100 - (avg by (instance) (irate(node_cpu{name="node-exporter",mode="idle"}[5m])) * 100)) > 75
+      FOR 2m
+      LABELS { severity="warning" }  
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High CPU usage detected",
+        DESCRIPTION = "{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})"
+      }
+  
+    #
+    # Disk Alerts
+    # 
+    ALERT NodeLowRootDisk
+      IF ((node_filesystem_size{mountpoint="/root-disk"} - node_filesystem_free{mountpoint="/root-disk"} ) / node_filesystem_size{mountpoint="/root-disk"} * 100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: Low root disk space",
+        DESCRIPTION = "{{$labels.instance}}: Root disk usage is above 75% (current value is: {{ $value }})"
+      }
+
+    ALERT NodeLowDataDisk
+      IF ((node_filesystem_size{mountpoint="/data-disk"} - node_filesystem_free{mountpoint="/data-disk"} ) / node_filesystem_size{mountpoint="/data-disk"} * 100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: Low data disk space",
+        DESCRIPTION = "{{$labels.instance}}: Data disk usage is above 75% (current value is: {{ $value }})"
+      }
+ 
+    #
+    # Node Load Alerts (5m)
+    # alerts when Load on node exceeds the given limit with in 5 min
+    ALERT NodeLoadAverage
+      IF ((node_load5 / count without (cpu, mode) (node_cpu{mode="system"})) > 1)
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High Node Load average(5m) detected",
+        DESCRIPTION = "{{$labels.instance}}: LA is high"
+      }
+
+    #
+    # RAM Alerts
+    #
+    ALERT NodeSwapUsage
+      IF (((node_memory_SwapTotal-node_memory_SwapFree)/node_memory_SwapTotal)*100) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High Swap usage detected",
+        DESCRIPTION = "{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})"
+      }
+
+    ALERT NodeMemoryUsage
+      IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
+      FOR 2m
+      LABELS { severity="warning" }
+      ANNOTATIONS {
+        SUMMARY = "{{$labels.instance}}: High memory usage detected",
+        DESCRIPTION = "{{$labels.instance}}: Memory usage is above 75% (current value is: {{ $value }})"
+      }  

--- a/k8s/openebs-monitoring/federation/configs/prometheus-config-master.yaml
+++ b/k8s/openebs-monitoring/federation/configs/prometheus-config-master.yaml
@@ -25,7 +25,7 @@ data:
   prometheus.yml: |-
     global:
       external_labels:
-        slave: slave1
+        master: global
       scrape_interval: 5s
       evaluation_interval: 5s
     rule_files:
@@ -41,12 +41,33 @@ data:
     # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
     # pod's declared ports (default is a port-free target if none are declared).
     scrape_configs:
+    - job_name: 'master-federation'
+      honor_labels: true
+      metrics_path: /federate
+      params:
+        match[]:
+          # specify the jobs to scrap from the follower(slave) prometheus.
+          - '{job="prometheus"}'
+          - '{job="kubelets"}'
+          - '{job="kubernetes_apiservers"}'
+          - '{job="kubernetes_cadvisor"}'
+          - '{job="kubernetes_node_exporter"}'
+          - '{job="maya-agent"}'
+          - '{job="maya-apiserver"}'
+          - '{job="openebs-jiva-controller"}'
+          - '{job="openebs-jiva-replica"}'
+          - '{__name__=~"^slave:.*"}'
+      static_configs:
+        # replace the ip given below with the prometheus slave's IP and you can add
+        # others slave's IP also.
+        - targets:
+          - 100.100.100.100
     - job_name: 'prometheus'
       static_configs:
       # Please change this IP to the IP of your node (VM)
       # Because prometheus-service is running as Type NodePort
       # So it's accessible outside the cluster.
-        - targets: ['localhost:9090']
+      - targets: ['localhost:9090']
     - job_name: 'maya-apiserver'
       scheme: http
       tls_config:

--- a/k8s/openebs-monitoring/federation/configs/prometheus-env.yaml
+++ b/k8s/openebs-monitoring/federation/configs/prometheus-env.yaml
@@ -1,0 +1,11 @@
+# All the run time arguments required in prometheus should
+# be defined in this configmap
+# TODO:
+# Add arg to limit heap usage to overcome high RAM usage
+# Add remote storage address
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-env
+data:
+  storage-retention: 120h

--- a/k8s/openebs-monitoring/m-exporter.yaml
+++ b/k8s/openebs-monitoring/m-exporter.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: maya-volume-exporter
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: maya-volume-exporter
+    spec:
+      # serviceAccountName: prometheus
+      containers:
+        - name: maya-volume-exporter
+          image: openebs/m-exporter:ci
+          command: ["maya-volume-exporter"]
+          args:
+            # This is the flag provided to exporter at run time
+            # replace it with your controller's service IP
+            # For exp : Do kubectl get svc | grep volname-ctrl-svc
+            # to get the IP.
+            - "-c=volname-ctrl-svc:9501"
+          ports:
+          - containerPort: 9500


### PR DESCRIPTION
1. Why is this change necessary ?
- Deployment/configs is not there for alertmanager.
- Deployment file for m-exporter is not there.

2. How does this change address the issue ?
- Added deployment/configs for alertmanager and m-exporter respectively.

3. How to verify this change ?
- All the steps are similar to previous setup, only changes has to be
  made in `prometheus-config-master.yaml`. You need to add IP's of
  slaves in the target field of job `master-federation`.

4. What side effects does this change have ?
- None

5. Other details
fixes #914

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
