### PR TITLE
Update openebs/k8s with 0.5 features / container tags

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -20,6 +20,16 @@ kubectl apply -f openebs-config.yaml
 kubectl apply -f openebs-storageclasses.yaml
 ```
 
+### (Optional) Run customized kubernetes dashboard
+
+This step is required till a newer version of kubernetes dashboard is released, that contains fixes from openebs team to PV/PVC links. 
+
+Delete the older version of the kubernetes dashboard. If you are running in minikube, you can say - minikube addons disable dashboard. 
+
+```
+kubectl apply -f openebs-kubernetes-dashboard.yaml
+```
+
 ### (Optional) Enable monitoring using prometheus and grafana
 
 Use this step if you don't already have monitoring services installed

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -2,28 +2,31 @@
 
 This folder contains the software components (plugins, scripts, drivers etc.,), usage instructions and application examples of using OpenEBS with K8s. 
 
-OpenEBS can be deployed along-side Kubernetes master and minions (hyper-converged) or can be deployed in dedicated mode, connecting via the K8s FlexVolume plugins. 
-
 If this is your first time to Kubernetes, please go through these introductory tutorials: 
 - https://www.udacity.com/course/scalable-microservices-with-kubernetes--ud615
 - https://kubernetes.io/docs/tutorials/kubernetes-basics/
 
 
-The content here is organised as follows:
+## Usage
+
+### Enable OpenEBS on K8s
+```
+kubectl apply -f openebs-operator.yaml
+```
+
+### Customize OpenEBS
+```
+kubectl apply -f openebs-config.yaml
+kubectl apply -f openebs-storageclasses.yaml
+```
+
+### (Optional) Enable monitoring using prometheus and grafana
+
+Use this step if you don't already have monitoring services installed
+on your k8s cluster. 
 
 ```
-|---dedicated  ( install/setup instructions and usage examples )
-|
-|---hyperconverged ( install/setup instructions and usage examples )
-|
-|---demo ( scripts, providers for vagrant, terraform, ansible etc., used either in dedicated/hypercoverged mode )
-|
-|---flexvolume (K8s volume drivers used either in dedicated/hypercoverged mode)
-|  |--- openebs-iscsi
-|  |--- openebs-tcmu
-|  |--- openebs-localdisks
-|  
-|---tests (e2e tests using the usage examples under dedicated and hypercoverged mode)
-|
-|  
+kubectl apply -f openebs-monitoring-pg.yaml
 ```
+
+This folder also contains a sample openebs volume monitoring dashboard (openebs-pg-dashboard.json) that can be imported into your grafana. 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -24,11 +24,12 @@ kubectl apply -f openebs-storageclasses.yaml
 
 This step is required till a newer version of kubernetes dashboard is released, that contains fixes from openebs team to PV/PVC links. 
 
-Delete the older version of the kubernetes dashboard. If you are running in minikube, you can say - minikube addons disable dashboard. 
-
 ```
 kubectl apply -f openebs-kubernetes-dashboard.yaml
 ```
+
+If you running in minikube, you can access the openebs-dashboard via the proxy url:
+http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/https:openebs-kubernetes-dashboard:/proxy/#!/persistentvolume?namespace=default
 
 ### (Optional) Enable monitoring using prometheus and grafana
 

--- a/k8s/demo/pvc.yaml
+++ b/k8s/demo/pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-standalone
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/demo/specs/demo-fio-openebs.yaml
+++ b/k8s/demo/specs/demo-fio-openebs.yaml
@@ -28,10 +28,10 @@ apiVersion: v1
 metadata:
   name: demo-vol1-claim
 spec:
-  storageClassName: openebs-standard
+  storageClassName: openebs-standalone
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: "5G"
+      storage: "2G"
  

--- a/k8s/openebs-config.yaml
+++ b/k8s/openebs-config.yaml
@@ -47,6 +47,28 @@
 #  - a directory on host-os, 
 #  - a directory on mounted-disk, 
 #
+# Define a storage pool for launching the replicas using
+#  local directory or mounted directory on kubernetes nodes
+#  
+# The following is an example of how a storagepool can be 
+# confgured with any other directory to be used for persisting 
+# the storage. 
+#
+# Note: OpenEBS uses /var/openebs as default directory, even if 
+# the following default storagepool is not added to the k8s cluster.
+#
+apiVersion: openebs.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: default
+  type: hostdir
+spec:
+  path: "/var/openebs" 
+  nodes: [ "all" ]
+  #maxVolSize: 10G #Max Volume Size
+  #maxAllocatedSize: 100G #Max Total Space allocated from this directory/mount
+---
+#TODO - Yet to review the below lines and convert them into valid CRs
 # StorageBackendClaim : Provides information about types of storage
 #  pools that can be created using the storage pool and provided as 
 #  persistent storage backends to openebs volumes. The storage pool types
@@ -58,113 +80,52 @@
 #  - partition/full disk from a StoragePool(disk) 
 #
 # Custom Resource Definitions
-# =============================
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: storagepoolclaims.openebs.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Cluster
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: storagepoolclaims
-    # singular name to be used as an alias on the CLI and for display
-    singular: storagepoolclaim
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: StoragePoolClaim
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - spc
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: storagepools.openebs.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Cluster
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: storagepools
-    # singular name to be used as an alias on the CLI and for display
-    singular: storagepool
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: StoragePool
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - sp
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: storagebackendclaims.openebs.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Cluster
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: storagebackendclaims
-    # singular name to be used as an alias on the CLI and for display
-    singular: storagebackendclaim
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: StorageBackendClaim
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - sbc
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: storagebackends.openebs.io
-spec:
-  # group name to use for REST API: /apis/<group>/<version>
-  group: openebs.io
-  # version name to use for REST API: /apis/<group>/<version>
-  version: v1alpha1
-  # either Namespaced or Cluster
-  scope: Cluster
-  names:
-    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
-    plural: storagebackends
-    # singular name to be used as an alias on the CLI and for display
-    singular: storagebackend
-    # kind is normally the CamelCased singular type. Your resource manifests use this.
-    kind: StorageBackend
-    # shortNames allow shorter string to match your resource on the CLI
-    shortNames:
-    - sb
----
-# Define a storage pool for launching the replicas using
-#  local directory or mounted directory from the minion nodes
-#  
-apiVersion: openebs.io/v1alpha1
-kind: StoragePool
-metadata:
-  name: sp-hostdir
-  type: hostdir
-spec:
-  path: "/var/openebs" 
-  maxVolSize: 10G #Max Volume Size
-  maxAllocatedSize: 100G #Max Total Space allocated from this directory/mount
-  nodes: [ "all" ]
-#TODO - Yet to review the below lines and convert them into valid CRs
+# Note: The following CRDs will move into openebs-operator.yaml
+# =============================================================
+#apiVersion: apiextensions.k8s.io/v1beta1
+#kind: CustomResourceDefinition
+#metadata:
+#  # name must match the spec fields below, and be in the form: <plural>.<group>
+#  name: storagebackendclaims.openebs.io
+#spec:
+#  # group name to use for REST API: /apis/<group>/<version>
+#  group: openebs.io
+#  # version name to use for REST API: /apis/<group>/<version>
+#  version: v1alpha1
+#  # either Namespaced or Cluster
+#  scope: Cluster
+#  names:
+#    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+#    plural: storagebackendclaims
+#    # singular name to be used as an alias on the CLI and for display
+#    singular: storagebackendclaim
+#    # kind is normally the CamelCased singular type. Your resource manifests use this.
+#    kind: StorageBackendClaim
+#    # shortNames allow shorter string to match your resource on the CLI
+#    shortNames:
+#    - sbc
+#apiVersion: apiextensions.k8s.io/v1beta1
+#kind: CustomResourceDefinition
+#metadata:
+#  # name must match the spec fields below, and be in the form: <plural>.<group>
+#  name: storagebackends.openebs.io
+#spec:
+#  # group name to use for REST API: /apis/<group>/<version>
+#  group: openebs.io
+#  # version name to use for REST API: /apis/<group>/<version>
+#  version: v1alpha1
+#  # either Namespaced or Cluster
+#  scope: Cluster
+#  names:
+#    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+#    plural: storagebackends
+#    # singular name to be used as an alias on the CLI and for display
+#    singular: storagebackend
+#    # kind is normally the CamelCased singular type. Your resource manifests use this.
+#    kind: StorageBackend
+#    # shortNames allow shorter string to match your resource on the CLI
+#    shortNames:
+#    - sb
 #---  
 #apiVersion: openebs.io/v1alpha1
 #kind: Pool

--- a/k8s/openebs-kubernetes-dashboard.yaml
+++ b/k8s/openebs-kubernetes-dashboard.yaml
@@ -1,0 +1,176 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration to deploy release version of the Dashboard UI compatible with
+# Kubernetes 1.7.
+#
+# Example usage: kubectl create -f <this_file>
+
+# ------------------- Dashboard Secret ------------------- #
+
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard-certs
+  namespace: kube-system
+type: Opaque
+
+---
+# ------------------- Dashboard Service Account ------------------- #
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+
+---
+# ------------------- Dashboard Role & Role Binding ------------------- #
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+rules:
+  # Allow Dashboard to create and watch for changes of 'kubernetes-dashboard-key-holder' secret.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "watch"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  # Allow Dashboard to get, update and delete 'kubernetes-dashboard-key-holder' secret.
+  resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
+  verbs: ["get", "update", "delete"]
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  labels:
+    k8s-app: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+# ------------------- Dashboard Deployment ------------------- #
+
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      k8s-app: kubernetes-dashboard
+  template:
+    metadata:
+      labels:
+        k8s-app: kubernetes-dashboard
+    spec:
+      initContainers:
+      - name: kubernetes-dashboard-init
+        image: gcr.io/google_containers/kubernetes-dashboard-init-amd64:v1.0.1
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+      containers:
+      - name: kubernetes-dashboard
+        image: openebs/kubernetes-dashboard-amd64:latest
+        ports:
+        - containerPort: 8443
+          protocol: TCP
+        args:
+          - --tls-key-file=/certs/dashboard.key
+          - --tls-cert-file=/certs/dashboard.crt
+          # Uncomment the following line to manually specify Kubernetes API server Host
+          # If not specified, Dashboard will attempt to auto discover the API server and connect
+          # to it. Uncomment only if the default does not work.
+          # - --apiserver-host=http://my-address:port
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+          readOnly: true
+          # Create on-disk volume to store exec logs
+        - mountPath: /tmp
+          name: tmp-volume
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /
+            port: 8443
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
+      # Comment the following tolerations if Dashboard must not be deployed on master
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+
+---
+# ------------------- Dashboard Service ------------------- #
+
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+  name: kubernetes-dashboard
+  namespace: kube-system
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    k8s-app: kubernetes-dashboard

--- a/k8s/openebs-kubernetes-dashboard.yaml
+++ b/k8s/openebs-kubernetes-dashboard.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    k8s-app: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard
   name: kubernetes-dashboard-certs
   namespace: kube-system
 type: Opaque
@@ -35,8 +35,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   namespace: kube-system
 
 ---
@@ -45,7 +45,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: openebs-kubernetes-dashboard-minimal
   namespace: kube-system
 rules:
   # Allow Dashboard to create and watch for changes of 'kubernetes-dashboard-key-holder' secret.
@@ -67,30 +67,30 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: kubernetes-dashboard-minimal
+  name: openebs-kubernetes-dashboard-minimal
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kubernetes-dashboard-minimal
+  name: openebs-kubernetes-dashboard-minimal
 subjects:
 - kind: ServiceAccount
-  name: kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   namespace: kube-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   labels:
-    k8s-app: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   namespace: kube-system
 ---
 # ------------------- Dashboard Deployment ------------------- #
@@ -99,28 +99,28 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   namespace: kube-system
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      k8s-app: kubernetes-dashboard
+      k8s-app: openebs-kubernetes-dashboard
   template:
     metadata:
       labels:
-        k8s-app: kubernetes-dashboard
+        k8s-app: openebs-kubernetes-dashboard
     spec:
       initContainers:
-      - name: kubernetes-dashboard-init
+      - name: openebs-kubernetes-dashboard-init
         image: gcr.io/google_containers/kubernetes-dashboard-init-amd64:v1.0.1
         volumeMounts:
-        - name: kubernetes-dashboard-certs
+        - name: openebs-kubernetes-dashboard-certs
           mountPath: /certs
       containers:
-      - name: kubernetes-dashboard
+      - name: openebs-kubernetes-dashboard
         image: openebs/kubernetes-dashboard-amd64:latest
         ports:
         - containerPort: 8443
@@ -133,7 +133,7 @@ spec:
           # to it. Uncomment only if the default does not work.
           # - --apiserver-host=http://my-address:port
         volumeMounts:
-        - name: kubernetes-dashboard-certs
+        - name: openebs-kubernetes-dashboard-certs
           mountPath: /certs
           readOnly: true
           # Create on-disk volume to store exec logs
@@ -147,12 +147,12 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 30
       volumes:
-      - name: kubernetes-dashboard-certs
+      - name: openebs-kubernetes-dashboard-certs
         secret:
           secretName: kubernetes-dashboard-certs
       - name: tmp-volume
         emptyDir: {}
-      serviceAccountName: kubernetes-dashboard
+      serviceAccountName: openebs-kubernetes-dashboard
       # Comment the following tolerations if Dashboard must not be deployed on master
       tolerations:
       - key: node-role.kubernetes.io/master
@@ -165,12 +165,12 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard
+  name: openebs-kubernetes-dashboard
   namespace: kube-system
 spec:
   ports:
     - port: 443
       targetPort: 8443
   selector:
-    k8s-app: kubernetes-dashboard
+    k8s-app: openebs-kubernetes-dashboard

--- a/k8s/openebs-kubernetes-dashboard.yaml
+++ b/k8s/openebs-kubernetes-dashboard.yaml
@@ -121,7 +121,7 @@ spec:
           mountPath: /certs
       containers:
       - name: openebs-kubernetes-dashboard
-        image: openebs/kubernetes-dashboard-amd64:latest
+        image: openebs/kubernetes-dashboard-amd64:v0.5.0-2017110901
         ports:
         - containerPort: 8443
           protocol: TCP

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -1,0 +1,180 @@
+# The following file is intended for deployments that are not already
+# configured with prometheus. This is a minified version of the config
+# from the files present under ./openebs-monitoring/
+# 
+# Prometheus tunables
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-tunables
+data:
+  storage-retention: 24h
+---
+# Define the openebs prometheus jobs
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-config
+apiVersion: v1
+data:
+  prometheus.yml: |-
+    global:
+      external_labels:
+        slave: slave1
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    #- job_name: 'prometheus'
+      #static_configs:
+      # Added this to allow for federation collection
+      # Replace localhost with the nodeIP
+      #  - targets: ['localhost:32514']
+    - job_name: 'openebs-prometheus-server'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: openebs-prometheus-server
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'openebs-volumes'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_monitoring]
+        regex: volume_exporter_prometheus
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9501'
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)3260'
+---
+# prometheus-deployment
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-prometheus
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-prometheus-server
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v1.7.2
+          args:
+            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            # Metrics are stored in an emptyDir volume which
+            # exists as long as the Pod is running on that Node.
+            # The data in an emptyDir volume is safe across container crashes.
+            - "-storage.local.path=/prometheus"
+            # How long to retain samples in the local storage. 
+            - "-storage.local.retention=$(STORAGE_RETENTION)"
+          ports:
+            - containerPort: 9090
+          env:
+            # environment vars are stored in prometheus-env configmap. 
+            - name: STORAGE_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: openebs-prometheus-tunables
+                  key: storage-retention
+          resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
+          
+          volumeMounts:
+            # prometheus config file stored in the given mountpath
+            - name: prometheus-server-volume
+              mountPath: /etc/prometheus/conf
+            # metrics collected by prometheus will be stored at the given mountpath.
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
+      volumes:
+        # Prometheus Config file will be stored in this volume 
+        - name: prometheus-server-volume
+          configMap:
+            name: openebs-prometheus-config
+        # All the time series stored in this volume in form of .db file.
+        - name: prometheus-storage-volume
+          # containers in the Pod can all read and write the same files here.
+          emptyDir: {} 
+---
+# prometheus-service
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-prometheus-service
+spec:
+  selector: 
+    name: openebs-prometheus-server
+  type: NodePort
+  ports:
+    - port: 80 # this Service's port (cluster-internal IP clusterIP)
+      targetPort: 9090 # pods expose this port
+      nodePort: 32514
+      # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbs-grafana
+spec:
+  type: NodePort
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 32515
+  selector:
+    app: openbs-grafana
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openbs-grafana
+  name: openbs-grafana
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: openbs-grafana
+    spec:
+      containers:
+      - image: grafana/grafana:4.5.2
+        name: grafana
+        ports:
+        - containerPort: 3000
+        env:
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 30
+          timeoutSeconds: 1

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -70,14 +70,14 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:ci
+        image: openebs/m-apiserver:0.5.0-RC1
         ports:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:latest"
+          value: "openebs/jiva:0.5.0-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:latest"
+          value: "openebs/jiva:0.5.0-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "2"
 ---
@@ -111,7 +111,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:latest
+        image: openebs/openebs-k8s-provisioner:0.5.0-RC1
         env:
         - name: NODE_NAME
           valueFrom:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -21,7 +21,10 @@ metadata:
   name: openebs-maya-operator
 rules:
 - apiGroups: ["*"]
-  resources: ["services","pods","deployments", "events"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["services","pods","deployments", "events", "endpoints"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["persistentvolumes","persistentvolumeclaims"]
@@ -29,6 +32,8 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["*"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
 ---
 # Bind the Service Account with the Role Privileges.
 # TODO: Check if default account also needs to be there
@@ -65,15 +70,15 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.4.0
+        image: openebs/m-apiserver:ci
         ports:
         - containerPort: 5656
         env:
-        - name: DEFAULT_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.4.0"
-        - name: DEFAULT_REPLICA_IMAGE
-          value: "openebs/jiva:0.4.0"
-        - name: DEFAULT_REPLICA_COUNT
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "openebs/jiva:latest"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "openebs/jiva:latest"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "2"
 ---
 apiVersion: v1
@@ -106,11 +111,55 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.4.0
+        image: openebs/openebs-k8s-provisioner:latest
         env:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-
-
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -117,6 +117,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: OPENEBS_MONITOR_URL
+          value: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
+        - name: MAYA_PORTAL_URL
+          value: "https://mayaonline.io/"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -123,7 +123,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/60",
+              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/60",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -201,7 +201,7 @@
           "tableColumn": "__name__",
           "targets": [
             {
-              "expr": "OpenEBS_actual_used{instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_actual_used{kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -279,7 +279,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "OpenEBS_actual_used{instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_actual_used{kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A",
@@ -291,6 +291,7 @@
           "timeShift": null,
           "title": "Storage Usage",
           "type": "singlestat",
+	  "hideTimeOverride": true,
           "valueFontSize": "80%",
           "valueMaps": [
             {
@@ -360,7 +361,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -369,7 +370,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{Write IOPS}}",
@@ -459,7 +460,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/(1024*1024)",
+              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/(1024*1024)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -468,7 +469,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/(1024*1024)",
+              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/(1024*1024)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -559,7 +560,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -568,7 +569,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -637,7 +638,7 @@
         "multi": false,
         "name": "OpenEBS",
         "options": [],
-        "query": "label_values(OpenEBS_size_of_volume, instance)",
+        "query": "label_values(OpenEBS_size_of_volume, kubernetes_pod_name)",
         "refresh": 1,
         "regex": "",
         "sort": 0,

--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -1,0 +1,684 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "OpenEBS Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.5.2"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [
+    {
+      "icon": "info",
+      "tags": [],
+      "targetBlank": true,
+      "title": "OpenEBS Docs",
+      "tooltip": "OpenEBS Documentation",
+      "type": "link",
+      "url": "http://openebs.readthedocs.io/en/latest/"
+    }
+  ],
+  "refresh": false,
+  "rows": [
+    {
+      "collapse": false,
+      "height": 328,
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "description": "Time Since volume registered",
+          "format": "m",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 10,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/60",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "refId": "A",
+              "step": 30
+            }
+          ],
+          "thresholds": "",
+          "title": "Uptime",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 81, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "description": "This shows the total size of the volume used.",
+          "format": "decgbytes",
+          "gauge": {
+            "maxValue": 5,
+            "minValue": 0,
+            "show": true,
+            "thresholdLabels": false,
+            "thresholdMarkers": false
+          },
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": true,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "__name__",
+          "targets": [
+            {
+              "expr": "OpenEBS_actual_used{instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "A",
+              "step": 30
+            }
+          ],
+          "thresholds": "4,5",
+          "title": "Capacity",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "format": "none",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "id": 12,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 3,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": true
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "expr": "OpenEBS_actual_used{instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "refId": "A",
+              "step": 15
+            }
+          ],
+          "thresholds": "",
+          "timeFrom": "2h",
+          "timeShift": null,
+          "title": "Storage Usage",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "content": "<img src=\"https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png\" alt=\"OpenEBS logo\" style=\"height: 40px;\">\n<span style=\"font-family: 'Open Sans', 'Helvetica Neue', Helvetica; font-size: 25px;vertical-align: text-top;color: #bbbfc2;margin-left: 10px;\">OpenEBS</span>\n\n<p style=\"margin-top: 10px;\">You're monitoring OpenEBS Volumes using Prometheus. For more information, check out the <a href=\"http://openebs.io/\">OpenEBS</a> and <a href=\"http://prometheus.io/\">Prometheus</a> projects. If you would like to retain this volume monitoring data and much more, sign-up for <a href=\"http://mayaonline.io/\">MayaOnline</a> </p>",
+          "id": 11,
+          "links": [],
+          "mode": "html",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 298,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "description": "Read IOPS of volume",
+          "fill": 1,
+          "id": 3,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{Read IOPS}}",
+              "refId": "A",
+              "step": 2
+            },
+            {
+              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{Write IOPS}}",
+              "refId": "B",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Read/Write IOPS",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 285,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "description": "Bandwidth of volume",
+          "fill": 1,
+          "id": 9,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "connected",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/(1024*1024)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{Read Throughput}}",
+              "refId": "A",
+              "step": 2
+            },
+            {
+              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}/(1024*1024)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{Write Throughput}}",
+              "refId": "B",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Read/Write Throughput",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "MBs",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "description": "Read/Write latency of volume",
+          "fill": 1,
+          "id": 5,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 12,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{Read latency}}",
+              "refId": "A",
+              "step": 2
+            },
+            {
+              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", instance=~\"$OpenEBS\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{Write latency}}",
+              "refId": "B",
+              "step": 2
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Read/Write Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_OPENEBS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": false,
+        "label": "OpenEBS Volume",
+        "multi": false,
+        "name": "OpenEBS",
+        "options": [],
+        "query": "label_values(OpenEBS_size_of_volume, instance)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "2017-11-24T03:59:09.463Z",
+    "to": "2017-11-24T04:28:03.958Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "OpenEBS Volume Stats",
+  "version": 2
+}

--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -650,8 +650,8 @@
     ]
   },
   "time": {
-    "from": "2017-11-24T03:59:09.463Z",
-    "to": "2017-11-24T04:28:03.958Z"
+    "from": "now-6h",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [

--- a/k8s/openebs-storageclasses.yaml
+++ b/k8s/openebs-storageclasses.yaml
@@ -5,10 +5,10 @@ metadata:
    name: openebs-standalone
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "1"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -16,10 +16,10 @@ metadata:
    name: openebs-standard
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -27,10 +27,10 @@ metadata:
    name: openebs-percona
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "1"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -38,10 +38,10 @@ metadata:
    name: openebs-jupyter
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -49,10 +49,10 @@ metadata:
    name: openebs-mongodb
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -60,10 +60,10 @@ metadata:
    name: openebs-cassandra
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -71,10 +71,10 @@ metadata:
    name: openebs-redis
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -82,10 +82,10 @@ metadata:
    name: openebs-kafka
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 10G
+  openebs.io/capacity: 10G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -93,10 +93,10 @@ metadata:
    name: openebs-zk
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -104,8 +104,8 @@ metadata:
    name: openebs-es-data-sc
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
+  openebs.io/storage-pool: "default"
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
-  size: 5G
+  openebs.io/capacity: 5G
 ---

--- a/k8s/openebs-storageclasses.yaml
+++ b/k8s/openebs-storageclasses.yaml
@@ -7,6 +7,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "1"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -17,6 +18,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -27,6 +29,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -37,6 +40,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -47,6 +51,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -57,6 +62,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -67,6 +73,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -77,6 +84,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 10G
 ---
 apiVersion: storage.k8s.io/v1
@@ -87,6 +95,7 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---
 apiVersion: storage.k8s.io/v1
@@ -97,5 +106,6 @@ provisioner: openebs.io/provisioner-iscsi
 parameters:
   pool: hostdir-var
   openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
   size: 5G
 ---


### PR DESCRIPTION
Update the openebs yaml files to make use of the latest features added to the different components like m-apiserver, provisioner etc., that involve implementation of feature support via policy tags from storage classes. 

To test this changes:

Setup openebs using the following commands: (similar to previous versions)
kubectl apply -f openebs-operator.yaml (this will now also setup the CRDs for defining storagepools, and some updates to the default env variables)
kubectl apply -f openebs-config.yaml (optional - create a default storagepool with hostdir type )
kubectl apply -f openebs-monitoring-pg.yaml (optional - sets up a cluster-local prometheus and grafana services that can monitor the openebs volumes) 
kubectl apply -f opnebs-storageclasses.yaml (modified the parameters to include storage policy tags supported by openebs) 

Now run a demo app, that uses one of the storageclasses loaded above. The openebs-volumes controller will have the monitoring sidecar:
```
kiran@kmaya:~/github/kmova/openebs$ kubectl get pods
NAME                                                             READY     STATUS    RESTARTS   AGE
maya-apiserver-85f75cf8b7-z58mx                                  1/1       Running   0          56m
openbs-grafana-5fbdd5c547-xmllv                                  1/1       Running   0          6h
openebs-prometheus-866db48788-gctbq                              1/1       Running   0          26m
openebs-provisioner-69b495bff5-jb8l5                             1/1       Running   0          5h
percona                                                          1/1       Running   0          55m
pvc-2063145d-d032-11e7-9171-288023c0529e-ctrl-686cd4c696-6qdkv   2/2       Running   0          55m
pvc-2063145d-d032-11e7-9171-288023c0529e-rep-95844c586-dnz99     1/1       Running   0          55m
pvc-435bb7fd-d035-11e7-9171-288023c0529e-ctrl-5f88ff5cdc-gtwm6   2/2       Running   0          32m
pvc-435bb7fd-d035-11e7-9171-288023c0529e-rep-6f54f7cdd5-7jbwq    0/1       Pending   0          32m
pvc-435bb7fd-d035-11e7-9171-288023c0529e-rep-6f54f7cdd5-c6x76    1/1       Running   0          32m
kiran@kmaya:~/github/kmova/openebs$ 
```

```
kiran@kmaya:~/github/kmova/openebs$ kubectl describe pod pvc-2063145d-d032-11e7-9171-288023c0529e-ctrl-686cd4c696-6qdkv
<snipped>.. shows
  maya-volume-exporter:
    Container ID:  docker://c58caa99d3d0077453a09538870adb195ae52b5b941fff48729c3a410adc333f
    Image:         openebs/m-exporter:ci
    Image ID:      docker://sha256:28cfd6b38043ae3d0ae43404d11d4b653362ca8cb83d95ee20889c641f133f52
    Port:          9500/TCP
    Command:
<snipped>..
```


Related Issues:
- https://github.com/openebs/openebs/issues/921
- https://github.com/openebs/openebs/issues/925

Notes to the Reviewer:
- openebs-monitoring-pg is an optional file that users can apply
  to launch prometheus to monitor only openebs volumes. Alternatively,
  the users can opt to only add the openebs-volume job_spec to their
  existing prometheus configuration.

- Moved the StoragePool CRDs to openebs-operator, since they are
  part of the openebs-operator. Admin can now use the openebs-config.yaml
  file to declare their own StoragePools.

- Added the parameter to enable monitoring on all the storageclasses

- Also update the operator to use the latest ci images. (pre-release versions)
  This will be have to be replaced with 0.5.0 as soon as we release

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
