### PR TITLE
Update the chart yaml files with 0.5.0-RC2

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-version: 0.4.0
+version: 0.5.0
 name: openebs
-appVersion: 0.4.0
+appVersion: 0.5.0
 description: Containerized Storage for Containers
-icon: https://raw.githubusercontent.com/openebs/chitrakala/master/logo/png/logo-01.png
+icon: https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png
 home: http://www.openebs.io/
 keywords:
   - cloud-native-storage

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -8,7 +8,10 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 rules:
 - apiGroups: ["*"]
-  resources: ["services","pods","deployments", "events"]
+  resources: ["nodes","nodes/proxy"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["services","pods","deployments", "events", "endpoints"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["persistentvolumes","persistentvolumeclaims"]
@@ -16,4 +19,6 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["*"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
 {{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -40,6 +40,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_label_vsm]
+        action: replace
+        target_label: openebs_pv
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: drop
         regex: '(.*)9501'

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.policies.monitoring.enabled }}
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-config
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+apiVersion: v1
+data:
+  prometheus.yml: |-
+    global:
+      external_labels:
+        slave: slave1
+      scrape_interval: 5s
+      evaluation_interval: 5s
+    scrape_configs:
+    #- job_name: 'prometheus'
+      #static_configs:
+      # Added this to allow for federation collection
+      # Replace localhost with the nodeIP
+      #  - targets: ['localhost:32514']
+    - job_name: 'openebs-prometheus-server'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_name]
+        regex: openebs-prometheus-server
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+    - job_name: 'openebs-volumes'
+      scheme: http
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_monitoring]
+        regex: volume_exporter_prometheus
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9501'
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)3260'
+{{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.policies.monitoring.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-prometheus-tunables
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+data:
+  storage-retention: 24h
+{{- end }}

--- a/k8s/charts/openebs/templates/crd-sp.yaml
+++ b/k8s/charts/openebs/templates/crd-sp.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepools.openebs.io
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepools
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepool
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePool
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - sp

--- a/k8s/charts/openebs/templates/crd-spc.yaml
+++ b/k8s/charts/openebs/templates/crd-spc.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: storagepoolclaims.openebs.io
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: storagepoolclaims
+    # singular name to be used as an alias on the CLI and for display
+    singular: storagepoolclaim
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: StoragePoolClaim
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - spc

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -25,5 +25,7 @@ spec:
           value: {{ .Values.jiva.image }}
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
           value: {{ .Values.jiva.image }}
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "{{ .Values.policies.monitoring.image }}"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "{{ .Values.jiva.replicas }}"

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -21,9 +21,9 @@ spec:
         ports: 
         - containerPort: 5656
         env:
-        - name: DEFAULT_CONTROLLER_IMAGE
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: {{ .Values.jiva.image }}
-        - name: DEFAULT_REPLICA_IMAGE
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
           value: {{ .Values.jiva.image }}
-        - name: DEFAULT_REPLICA_COUNT
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "{{ .Values.jiva.replicas }}"

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -23,3 +23,7 @@ spec:
           valueFrom: 
             fieldRef:
               fieldPath: spec.nodeName
+        - name: OPENEBS_MONITOR_URL
+          value: "{{ .Values.provisioner.monitorurl }}"
+        - name: MAYA_PORTAL_URL
+          value: "{{ .Values.provisioner.mayaportalurl }}"

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.policies.monitoring.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: openbs-grafana
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+  name: openbs-grafana
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: openbs-grafana
+    spec:
+      containers:
+      - image: grafana/grafana:4.5.2
+        name: grafana
+        ports:
+        - containerPort: 3000
+        env:
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "false"
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+{{- end }}

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.policies.monitoring.enabled }}
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: openebs-prometheus
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: openebs-prometheus-server
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: prometheus
+          image: prom/prometheus:v1.7.2
+          args:
+            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            # Metrics are stored in an emptyDir volume which
+            # exists as long as the Pod is running on that Node.
+            # The data in an emptyDir volume is safe across container crashes.
+            - "-storage.local.path=/prometheus"
+            # How long to retain samples in the local storage. 
+            - "-storage.local.retention=$(STORAGE_RETENTION)"
+          ports:
+            - containerPort: 9090
+          env:
+            # environment vars are stored in prometheus-env configmap. 
+            - name: STORAGE_RETENTION
+              valueFrom:
+                configMapKeyRef:
+                  name: openebs-prometheus-tunables
+                  key: storage-retention
+          resources:
+            requests:
+              # A memory request of 250M means it will try to ensure minimum
+              # 250MB RAM .
+              memory: "128M"
+              # A cpu request of 128m means it will try to ensure minimum
+              # .125 CPU; where 1 CPU means :
+              # 1 *Hyperthread* on a bare-metal Intel processor with Hyperthreading
+              cpu: "128m"
+            limits:
+              memory: "700M"
+              cpu: "500m"
+          
+          volumeMounts:
+            # prometheus config file stored in the given mountpath
+            - name: prometheus-server-volume
+              mountPath: /etc/prometheus/conf
+            # metrics collected by prometheus will be stored at the given mountpath.
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
+      volumes:
+        # Prometheus Config file will be stored in this volume 
+        - name: prometheus-server-volume
+          configMap:
+            name: openebs-prometheus-config
+        # All the time series stored in this volume in form of .db file.
+        - name: prometheus-storage-volume
+          # containers in the Pod can all read and write the same files here.
+          emptyDir: {} 
+{{- end }}

--- a/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-percona.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-percona.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-redis.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-redis.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "1"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "1"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-standard.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standard.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-zk.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-zk.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 provisioner: openebs.io/provisioner-iscsi
 parameters:
-  pool: hostdir-var
-  replica: "2"
-  size: 5G
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.policies.monitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbs-grafana
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: NodePort
+  ports:
+  - port: 3000
+    targetPort: 3000
+    nodePort: 32515
+  selector:
+    app: openbs-grafana
+{{- end }}

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.policies.monitoring.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-prometheus-service
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  selector: 
+    name: openebs-prometheus-server
+  type: NodePort
+  ports:
+    - port: 80 # this Service's port (cluster-internal IP clusterIP)
+      targetPort: 9090 # pods expose this port
+      nodePort: 32514
+      # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
+{{- end }}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -9,13 +9,18 @@ image:
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.4.0"
+  tag: "0.5.0-RC1"
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.4.0"
+  tag: "0.5.0-RC1"
+  mayaportalurl: "https://mayaonline.io/"
+  monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
 
 jiva:
-  image: "openebs/jiva:0.4.0"
+  image: "openebs/jiva:0.5.0-RC1"
   replicas: 2
 
+policies:
+  monitoring:
+    enabled: true

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -24,3 +24,4 @@ jiva:
 policies:
   monitoring:
     enabled: true
+    image: "openebs/m-exporter:0.5.0-RC1"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -9,11 +9,11 @@ image:
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.5.0-RC1"
+  tag: "0.5.0-RC2"
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.5.0-RC1"
+  tag: "0.5.0-RC2"
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
 

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -50,6 +50,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_label_vsm]
+        action: replace
+        target_label: openebs_pv
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: drop
         regex: '(.*)9501'

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -70,7 +70,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.5.0-RC1
+        image: openebs/m-apiserver:0.5.0-RC2
         ports:
         - containerPort: 5656
         env:
@@ -78,6 +78,8 @@ spec:
           value: "openebs/jiva:0.5.0-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
           value: "openebs/jiva:0.5.0-RC1"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:0.5.0-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "2"
 ---
@@ -111,7 +113,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.5.0-RC1
+        image: openebs/openebs-k8s-provisioner:0.5.0-RC2
         env:
         - name: NODE_NAME
           valueFrom:
@@ -119,6 +121,8 @@ spec:
               fieldPath: spec.nodeName
         - name: OPENEBS_MONITOR_URL
           value: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
+        - name: OPENEBS_MONITOR_VOLKEY
+          value: "&var-OpenEBS"
         - name: MAYA_PORTAL_URL
           value: "https://mayaonline.io/"
 ---
@@ -167,3 +171,14 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - sp
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-standard
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "2"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/k8s/openebs-storageclasses.yaml
+++ b/k8s/openebs-storageclasses.yaml
@@ -13,17 +13,6 @@ parameters:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-   name: openebs-standard
-provisioner: openebs.io/provisioner-iscsi
-parameters:
-  openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
-  openebs.io/volume-monitor: "true"
-  openebs.io/capacity: 5G
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
    name: openebs-percona
 provisioner: openebs.io/provisioner-iscsi
 parameters:


### PR DESCRIPTION
This PR updates the helm chart with the new yaml files for monitoring as well as update the existing files with attribute changes. 

Fixes #921 

Tested on minikube:
```
kiran@kmaya:~/github/kmova/openebs/k8s/charts/openebs$ helm install --name openebs .
NAME:   openebs
LAST DEPLOYED: Tue Nov 28 13:08:58 2017
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/Deployment
NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
maya-apiserver       1        1        1           0          1s
openebs-provisioner  1        1        1           0          1s
openbs-grafana       1        1        1           0          1s
openebs-prometheus   1        1        1           0          1s

==> v1/Pod(related)
NAME                                 READY  STATUS             RESTARTS  AGE
openbs-grafana-5fbdd5c547-krr94      0/1    ContainerCreating  0         1s
openebs-prometheus-866db48788-xg72p  0/1    ContainerCreating  0         1s

==> v1/ConfigMap
NAME                         DATA  AGE
openebs-prometheus-config    1     2s
openebs-prometheus-tunables  1     2s

==> v1/StorageClass
NAME                PROVISIONER
openebs-cassandra   openebs.io/provisioner-iscsi
openebs-es-data-sc  openebs.io/provisioner-iscsi
openebs-jupyter     openebs.io/provisioner-iscsi
openebs-kafka       openebs.io/provisioner-iscsi
openebs-mongodb     openebs.io/provisioner-iscsi
openebs-percona     openebs.io/provisioner-iscsi
openebs-redis       openebs.io/provisioner-iscsi
openebs-standalone  openebs.io/provisioner-iscsi
openebs-standard    openebs.io/provisioner-iscsi
openebs-zk          openebs.io/provisioner-iscsi

==> v1/ServiceAccount
NAME                   SECRETS  AGE
openebs-maya-operator  1        2s

==> v1beta1/CustomResourceDefinition
NAME                          AGE
storagepools.openebs.io       2s
storagepoolclaims.openebs.io  2s

==> v1/Service
NAME                        TYPE       CLUSTER-IP  EXTERNAL-IP  PORT(S)         AGE
maya-apiserver-service      ClusterIP  10.0.0.189  <none>       5656/TCP        2s
openbs-grafana              NodePort   10.0.0.33   <none>       3000:32515/TCP  1s
openebs-prometheus-service  NodePort   10.0.0.115  <none>       80:32514/TCP    1s


NOTES:
The OpenEBS has been installed. Check its status by running:
  kubectl get pods -l "name=maya-apiserver"

To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
Please visit http://openebs.readthedocs.io/en/latest/getting_started/quick_install.html for instructions


kiran@kmaya:~/github/kmova/openebs/k8s/charts/openebs$ helm ls
NAME   	REVISION	UPDATED                 	STATUS  	CHART        	NAMESPACE
openebs	1       	Tue Nov 28 13:08:58 2017	DEPLOYED	openebs-0.5.0	default  
kiran@kmaya:~/github/kmova/openebs/k8s/charts/openebs$
```