### PR TITLE
Initial commit for kubernetes job spec to generate load on mongo-db

### DIFF
--- a/k8s/demo/mongodb/mongo-loadgen.yaml
+++ b/k8s/demo/mongodb/mongo-loadgen.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongo-loadgen
+spec:
+  template:
+    metadata:
+      name: mongo-loadgen
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: mongo-loadgen
+        image: openebs/tests-sysbench-mongo
+        command: ["/bin/bash"]
+        args: ["-c", "./sysbench/sysbench --mongo-write-concern=1 --mongo-url='mongodb://10.47.0.3' --mongo-database-name=sbtest --test=./sysbench/tests/mongodb/oltp.lua --oltp_table_size=100 --oltp_tables_count=10 --num-threads=10 --rand-type=pareto --report-interval=10 --max-requests=0 --max-time=600 --oltp-point-selects=10 --oltp-simple-ranges=1 --oltp-sum-ranges=1 --oltp-order-ranges=1 --oltp-distinct-ranges=1 --oltp-index-updates=1 --oltp-non-index-updates=1 --oltp-inserts=1 run"]
+        tty: true 
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Created a kubernetes job that will run an OLTP benchmark load on the mongodb replica cluster. It uses the custom image openebs/tests-sysbench-mongo to achieve this.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #953 

**Special notes for your reviewer**:

This commit adds the mongodb db prepare & test command in the job yaml. The command consists of multiple options which we should ideally handle via a config map and consume inside the pod. This will be fixed in separate PRs. 