### PR TITLE
use pv_name as key instead of pod name

### DIFF
--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -123,7 +123,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/60",
+              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/60",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -201,7 +201,7 @@
           "tableColumn": "__name__",
           "targets": [
             {
-              "expr": "OpenEBS_actual_used{kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_actual_used{openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -279,7 +279,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "OpenEBS_actual_used{kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_actual_used{openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A",
@@ -360,7 +360,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -369,7 +369,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{Writes}}",
@@ -461,7 +461,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/(1024*1024)",
+              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/(1024*1024)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -470,7 +470,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}/(1024*1024)",
+              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/(1024*1024)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -563,7 +563,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -572,7 +572,7 @@
               "step": 2
             },
             {
-              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", kubernetes_pod_name=~\"$OpenEBS\"}",
+              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -641,7 +641,7 @@
         "multi": false,
         "name": "OpenEBS",
         "options": [],
-        "query": "label_values(OpenEBS_size_of_volume, kubernetes_pod_name)",
+        "query": "label_values(OpenEBS_size_of_volume, openebs_pv)",
         "refresh": 1,
         "regex": "",
         "sort": 0,


### PR DESCRIPTION
PR https://github.com/openebs/openebs/pull/949 added pv_name to the metrics. 

This PR makes use of the pv_name instead of pod_name. 