### PR TITLE
update jiva to 0.5.0-RC2 with capacity fmt fix

### DIFF
--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -25,5 +25,7 @@ spec:
               fieldPath: spec.nodeName
         - name: OPENEBS_MONITOR_URL
           value: "{{ .Values.provisioner.monitorurl }}"
+        - name: OPENEBS_MONITOR_VOLKEY
+          value: "{{ .Values.provisioner.monitorvolkey }}"
         - name: MAYA_PORTAL_URL
           value: "{{ .Values.provisioner.mayaportalurl }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -16,9 +16,10 @@ provisioner:
   tag: "0.5.0-RC2"
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
+  monitorvolkey: "&var-OpenEBS"
 
 jiva:
-  image: "openebs/jiva:0.5.0-RC1"
+  image: "openebs/jiva:0.5.0-RC2"
   replicas: 2
 
 policies:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -75,9 +75,9 @@ spec:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.0-RC1"
+          value: "openebs/jiva:0.5.0-RC2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.0-RC1"
+          value: "openebs/jiva:0.5.0-RC2"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "openebs/m-exporter:0.5.0-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT


### PR DESCRIPTION
This PR updates the operator and yaml files to use the latest jiva image with the fix to handle errors seen in #541, when user provides capacity in - Gi format.  

Also included in this PR is to update the helm charts to specify the monitorvolkey, which will allow kubernetes dashboard to redirect to volume page. (Related to : https://github.com/openebs/external-storage/pull/15)