### PR TITLE
Initial commit for kubernetes job spec to generate load on cassandra-db

### DIFF
--- a/k8s/demo/cassandra/cassandra-loadgen.yaml
+++ b/k8s/demo/cassandra/cassandra-loadgen.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cassandra-loadgen
+spec:
+  template:
+    metadata:
+      name: cassandra-loadgen
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: cassandra-loadgen
+        image: cassandra
+        command: ["/bin/bash"]
+        args: ["-c", "cassandra-stress write duration=5m no-warmup -node 10.47.0.4"]
+        tty: true 
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Created a kubernetes job that will run a concurrent write workload on the cassandra cluster. It uses *cassandra-stress*, which is shipped along with the official cassandra docker image. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #964

**Special notes for your reviewer**:

Cassandra-stress is a Java-based stress testing utility for basic benchmarking and load
testing a Cassandra cluster.The job file has to be updated to point to the cassandra node IP address. Also, here are some sample workloads that can run instead of the default provided in the spec. 

cassandra-stress write n=1000000 -rate threads=50
cassandra-stress read n=200000 no-warmup -rate threads=50
cassandra-stress mixed ratio\(write=1,read=3\) n=100000 

The tool takes multiple arguments which can be used to build a meaningful custom workload profile for cassandra db. Ideally, this can be achieved using config-maps from simple conf files (say, json or yaml).  A separate PR will be raised to achieve this. 