### PR TITLE
update the yamls to 0.5.0 containers

### DIFF
--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -3,16 +3,16 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: openbs-grafana
+    app: openebs-grafana
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-  name: openbs-grafana
+  name: openebs-grafana
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   template:
     metadata:
       labels:
-        app: openbs-grafana
+        app: openebs-grafana
     spec:
       containers:
       - image: grafana/grafana:4.5.2

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: openbs-grafana
+  name: openebs-grafana
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
@@ -12,5 +12,5 @@ spec:
     targetPort: 3000
     nodePort: 32515
   selector:
-    app: openbs-grafana
+    app: openebs-grafana
 {{- end }}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -9,20 +9,20 @@ image:
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.5.0-RC2"
+  tag: "0.5.0"
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.5.0-RC2"
+  tag: "0.5.0"
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
   monitorvolkey: "&var-OpenEBS"
 
 jiva:
-  image: "openebs/jiva:0.5.0-RC2"
+  image: "openebs/jiva:0.5.0"
   replicas: 2
 
 policies:
   monitoring:
     enabled: true
-    image: "openebs/m-exporter:0.5.0-RC1"
+    image: "openebs/m-exporter:0.5.0"

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -141,7 +141,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: openbs-grafana
+  name: openebs-grafana
 spec:
   type: NodePort
   ports:
@@ -149,21 +149,21 @@ spec:
     targetPort: 3000
     nodePort: 32515
   selector:
-    app: openbs-grafana
+    app: openebs-grafana
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    app: openbs-grafana
-  name: openbs-grafana
+    app: openebs-grafana
+  name: openebs-grafana
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   template:
     metadata:
       labels:
-        app: openbs-grafana
+        app: openebs-grafana
     spec:
       containers:
       - image: grafana/grafana:4.5.2

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -70,16 +70,16 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.5.0-RC2
+        image: openebs/m-apiserver:0.5.0
         ports:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.0-RC2"
+          value: "openebs/jiva:0.5.0"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.0-RC2"
+          value: "openebs/jiva:0.5.0"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.5.0-RC1"
+          value: "openebs/m-exporter:0.5.0"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "2"
 ---
@@ -113,7 +113,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.5.0-RC2
+        image: openebs/openebs-k8s-provisioner:0.5.0
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
0.5.0-RC2 images have got clearance from CI and Manual tests performed on Vagrant - Multinode Cluster, minikube, GKE and AWS K8s cluster. The helm charts have been verified by importing into stackpoint. 

Released the 0.5.0 container tags. 

This PR updates the yaml files to use 0.5.0 release and fixes the type in the openebs spelling in the grafana yaml files. 

The modified yaml files have been verified on the minikube setup. 