### PR TITLE
Initial implementation logic to create boxes of specific version of Kubernetes.

### DIFF
--- a/k8s/lib/vagrant/Vagrantfile
+++ b/k8s/lib/vagrant/Vagrantfile
@@ -11,6 +11,8 @@ BOX_MODE_KUBERNETES = 2
 
 box_Mode=ENV['OPENEBS_BUILD_BOX'] || 2
 
+kube_version=ENV['KUBE_VERSION'] || "1.7.5"
+
 Vagrant.configure("2") do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
@@ -108,6 +110,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.provision :shell, 
     path: "boxes/k8s/fetch_k8scontainers.sh",
+    :args => "#{kube_version}",
     privileged: true
 
     config.vm.provision :shell, 
@@ -124,6 +127,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.provision :shell,
     path: "boxes/k8s/cleanup_k8s.sh",
+    :args => "#{kube_version}",
     privileged: true
 
   elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i

--- a/k8s/lib/vagrant/Vagrantfile
+++ b/k8s/lib/vagrant/Vagrantfile
@@ -106,6 +106,7 @@ Vagrant.configure("2") do |config|
 
     config.vm.provision :shell, 
     path: "boxes/k8s/fetch_kubeadm.sh",
+    :args => "#{kube_version}",
     privileged: true
 
     config.vm.provision :shell, 

--- a/k8s/lib/vagrant/boxes/k8s-dashboard/fetch_dashboard.sh
+++ b/k8s/lib/vagrant/boxes/k8s-dashboard/fetch_dashboard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sudo docker -- pull gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3
+sudo docker pull gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3
 
 mkdir -p /home/ubuntu/setup/dashboard
 cp /vagrant/boxes/k8s-dashboard/external/kubernetes-dashboard-1.6.3.yaml /home/ubuntu/setup/dashboard/

--- a/k8s/lib/vagrant/boxes/k8s-weave/fetch_weave.sh
+++ b/k8s/lib/vagrant/boxes/k8s-weave/fetch_weave.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-sudo docker -- pull weaveworks/weave-kube:2.0.4
-sudo docker -- pull weaveworks/weave-npc:2.0.4
+sudo docker pull weaveworks/weave-kube:2.0.4
+sudo docker pull weaveworks/weave-npc:2.0.4
 
 mkdir -p /home/ubuntu/setup/weave
 cp /vagrant/boxes/k8s-weave/external/weave-daemonset-k8s-1.6.yaml /home/ubuntu/setup/weave/

--- a/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
@@ -28,5 +28,12 @@ cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.co
 Persistent=false
 EOF
 
+sudo systemctl disable apt-daily.service
+sudo systemctl disable apt-daily.timer
+
+cat <<EOF | sudo tee -a /etc/apt/apt.conf.d/02periodic > /dev/null
+APT::Periodic::Enable "0";
+EOF
+
 sudo apt-get clean
 cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
@@ -3,13 +3,6 @@
 kubeversion=${1:-"1.7.5"}
 kuberegex='^1.[0-7].[0-9][0-9]?$'
 
-# Cleaning up apt and bash history before packaing the box. 
-sudo mkdir -p /etc/systemd/system/apt-daily.timer.d/
-cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf > /dev/null
-[Timer]
-Persistent=false
-EOF
-
 [[ $1 =~ $kuberegex ]]
 
 # For versions 1.8 and above, swap needs to be disabled
@@ -26,6 +19,14 @@ sudo kubeadm reset
 
 # Remove the deb packages from the /vagrant/ folder.
 rm -rf /vagrant/workdir/dpkgs
+
+
+# Cleaning up apt and bash history before packaing the box. 
+sudo mkdir -p /etc/systemd/system/apt-daily.timer.d/
+cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf > /dev/null
+[Timer]
+Persistent=false
+EOF
 
 sudo apt-get clean
 cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
+++ b/k8s/lib/vagrant/boxes/k8s/cleanup_k8s.sh
@@ -1,11 +1,31 @@
 #!/bin/bash
 
+kubeversion=${1:-"1.7.5"}
+kuberegex='^1.[0-7].[0-9][0-9]?$'
+
 # Cleaning up apt and bash history before packaing the box. 
 sudo mkdir -p /etc/systemd/system/apt-daily.timer.d/
 cat <<EOF | sudo tee -a /etc/systemd/system/apt-daily.timer.d/apt-daily.timer.conf > /dev/null
 [Timer]
 Persistent=false
 EOF
+
+[[ $1 =~ $kuberegex ]]
+
+# For versions 1.8 and above, swap needs to be disabled
+if [[ $? -eq 1 ]]; then
+    cat <<EOF | sudo tee -a /etc/systemd/system/kubelet.service.d/90-local-extras.conf > /dev/null
+    Environment="KUBELET_EXTRA_ARGS=--fail-swap-on=false"
+EOF
+    sudo systemctl daemon-reload
+    sudo systemctl restart kubelet
+fi
+
+# To fix the '/var/lib/kubelet not empty' error
+sudo kubeadm reset
+
+# Remove the deb packages from the /vagrant/ folder.
+rm -rf /vagrant/workdir/dpkgs
 
 sudo apt-get clean
 cat /dev/null > ~/.bash_history && history -c && exit

--- a/k8s/lib/vagrant/boxes/k8s/fetch_k8scontainers.sh
+++ b/k8s/lib/vagrant/boxes/k8s/fetch_k8scontainers.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
+kubeversion=${1:-"1.7.5"}
+
 # Get kubernetes containers from gcr.io
 gcrUrl="gcr.io/google_containers/"
 PACKAGES=(\
 pause-amd64:3.0 \
 etcd-amd64:3.0.17 \
-kube-scheduler-amd64:v1.7.5 \
-kube-apiserver-amd64:v1.7.5 \
-kube-controller-manager-amd64:v1.7.5 \
-kube-proxy-amd64:v1.7.5 \
+kube-scheduler-amd64:v${kubeversion} \
+kube-apiserver-amd64:v${kubeversion} \
+kube-controller-manager-amd64:v${kubeversion} \
+kube-proxy-amd64:v${kubeversion} \
 k8s-dns-kube-dns-amd64:1.14.4 \
 k8s-dns-sidecar-amd64:1.14.4 \
 k8s-dns-dnsmasq-nanny-amd64:1.14.4 \
@@ -16,6 +18,6 @@ k8s-dns-dnsmasq-nanny-amd64:1.14.4 \
 
 # Pull kubernetes container images.
 for i in "${!PACKAGES[@]}"; do
-    sudo docker -- pull $gcrUrl${PACKAGES[i]}
+    sudo docker pull $gcrUrl${PACKAGES[i]}
 done
 

--- a/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
+++ b/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+kubeversion=${1:-"1.7.5"}
 #Update the repository index
 apt-get update && apt-get install -y apt-transport-https 
 
@@ -7,6 +7,6 @@ apt-get update && apt-get install -y apt-transport-https
 apt-get install -y docker.io socat ebtables
 
 sudo dpkg -i /vagrant/workdir/dpkgs/kubernetes-cni*.deb
-sudo dpkg -i /vagrant/workdir/dpkgs/kubelet*.deb
-sudo dpkg -i /vagrant/workdir/dpkgs/kubectl*.deb
-sudo dpkg -i /vagrant/workdir/dpkgs/kubeadm*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubelet_${kubeversion}-00*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubectl_${kubeversion}-00*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubeadm_${kubeversion}-00*.deb

--- a/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
+++ b/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
 #Update the repository index
-apt-get update && apt-get install -y apt-transport-https
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-xenial main
-EOF
-apt-get update
-# Install docker if you don't have it already.
-apt-get install -y docker-engine
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+apt-get update && apt-get install -y apt-transport-https 
 
+# Install docker if you don't have it already.
+apt-get install -y docker.io socat ebtables
+
+sudo dpkg -i /vagrant/workdir/dpkgs/kubernetes-cni*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubelet*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubectl*.deb
+sudo dpkg -i /vagrant/workdir/dpkgs/kubeadm*.deb

--- a/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
+++ b/k8s/lib/vagrant/boxes/k8s/fetch_kubeadm.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 kubeversion=${1:-"1.7.5"}
-#Update the repository index
-apt-get update && apt-get install -y apt-transport-https 
 
+#Update the repository index
+apt-get update && apt-get install -y apt-transport-https
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+apt-get update
 # Install docker if you don't have it already.
-apt-get install -y docker.io socat ebtables
+apt-get install -y docker-engine socat ebtables
 
 sudo dpkg -i /vagrant/workdir/dpkgs/kubernetes-cni*.deb
 sudo dpkg -i /vagrant/workdir/dpkgs/kubelet_${kubeversion}-00*.deb


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add ENV variable in Vagrantfile to hold the kubernetes version for the box to be created.
- Update 'docker pull' commands in all the fetch scripts pulling docker images.
- Add cleanup of /var/lib/kubelet directory to the cleanup script.
- Enable swap on/off based on Kubernetes version.
- Install deb packages of specific version of Kubernetes, rather than using apt-get.
- Pass Kubernetes Version as argument to create_vagrantbox script, if argument is empty defaults to 1.7.5.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #991 

**Special notes for your reviewer**:
This is an initial implementation further PRs will try to include checks for edge cases and passing arguments in a more standard way somewhat like `--version=1.7.8`

Signed-off-by: yudaykiran <udaykiran.y@gmail.com>