### PR TITLE
Upload sample yaml files for spc-sp crd

### DIFF
--- a/k8s/crd-samples/sdc-spc.yaml
+++ b/k8s/crd-samples/sdc-spc.yaml
@@ -1,0 +1,8 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: sdc
+spec:
+  name : sdc
+  format : ext4
+  mountpoint : /mnt/sdc

--- a/k8s/crd-samples/sdd-spc.yaml
+++ b/k8s/crd-samples/sdd-spc.yaml
@@ -1,5 +1,5 @@
-apiVersion: openebs.io/v1
-kind: Storagepoolclaim
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
 metadata:
   name: sdd
 spec:

--- a/k8s/crd-samples/sdd-spc.yaml
+++ b/k8s/crd-samples/sdd-spc.yaml
@@ -1,0 +1,8 @@
+apiVersion: openebs.io/v1
+kind: Storagepoolclaim
+metadata:
+  name: sdd
+spec:
+  name : sdd
+  format : ext3
+  mountpoint : /mnt/sdd

--- a/k8s/crd-samples/spc-crd.yaml
+++ b/k8s/crd-samples/spc-crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storagepoolclaims.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: StoragePoolClaim
+    listKind: StoragePoolClaimList
+    plural: storagepoolclaims
+    shortNames:
+    - spc
+  scope: Namespaced
+  version: v1alpha1

--- a/k8s/crd-samples/storagepool-crd.yaml
+++ b/k8s/crd-samples/storagepool-crd.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storagepools.openebs.io
+spec:
+  group: openebs.io
+  names:
+    kind: StoragePool
+    listKind: StoragePoolList
+    plural: storagepools
+    shortNames:
+    - sp
+  scope: Namespaced
+  version: v1alpha1


### PR DESCRIPTION
1. Why is this change necessary ?
   fixes: openebs/openebs#1016

2. How does this change address the issue ?
   spc-crd.yaml - storagepoolclaim custom resouce definition
   storagepool-crd.yaml - storagepool custom resouce definition
   sdc-spc.yaml - sample resouce for spc
   sdd-spc.yaml - sample resouce for spc

3. How to verify this change ?
   kubectl apply -f spc-crd.yaml
   kubectl apply -f storagepool-crd.yaml
   kubectl apply -f sdc-crd.yaml
   kubectl apply -f sdd-crd.yaml

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
