### PR TITLE
Removing hardcoded namespace from Helm chart

### DIFF
--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -26,7 +26,7 @@ List
 helm ls --all
 ```
 
-# Note the `openebs` from above command
+Note the `openebs` from above command
 To uninstall/delete the `openebs` deployment:
 ```bash
 $ helm delete openebs

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -1,27 +1,33 @@
+# OpenEBS
+
+**It is based on Helm community chart [openebs](https://github.com/openebs/openebs/tree/master/k8s/charts/openebs)**
+
+[OpenEBS](http://openebs.io/) is a cloud-native storage solution built with the goal of providing containerized storage for containers. Using OpenEBS, a developer can seamlessly get the persistent storage for stateful applications on Kubernetes with ease.
+
+## Introduction
+
+This chart bootstraps a [OpenEBS](https://github.com/openebs/openebs) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 - Kubernetes 1.7.5+ with RBAC enabled
 - iSCSI PV support in the underlying infrastructure
 
-## Installing OpenEBS 
-```
-helm repo add openebs-charts https://openebs.github.io/charts/
-helm repo update
-helm install openebs-charts/openebs
+## Installing the Chart 
+
+The command deploys OpenEBS on the Kubernetes cluster with the release name `openebs` and the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation:
+
+```bash
+$ helm install tc/openebs --name openebs --namespace=openebs
 ```
 
-## Installing OpenEBS from Chart codebase
-```
-git clone https://github.com/openebs/openebs.git
-cd openebs/k8s/charts/openebs/
-helm install --name openebs .
-```
-
-## Unistalling OpenEBS from Chart codebase
+## Unistalling the Chart
+List 
 ```
 helm ls --all
-# Note the openebs-chart-name from above command
-helm del --purge <openebs-chart-name>
+# Note the `openebs` from above command
+To uninstall/delete the `openebs` deployment:
+```bash
+$ helm delete openebs
 ```
 
 ## Configuration
@@ -33,10 +39,10 @@ The following tables lists the configurable parameters of the OpenEBS chart and 
 | `rbacEnable`            | Enable RBAC Resources              | `true`                                                     |
 | `image.pullPolicy`      | Container pull policy              | `IfNotPresent`                                             |
 | `apiserver.image`       | Docker Image for API Server        | `openebs/m-apiserver`                                      |
-| `apiserver.tag`         | Docker Image Tag for API Server    | `0.4.0`                                                    |
+| `apiserver.tag`         | Docker Image Tag for API Server    | `0.5.0`                                                    |
 | `provisioner.image`     | Docker Image for Provisioner       | `openebs/openebs-k8s-provisioner`                          |
-| `provisioner.tag`       | Docker Image Tag for Provisioner   | `0.4.0`                                                    |
-| `jiva.image`            | Docker Image for Jiva              | `openebs/jiva:0.4.0`                                       |
+| `provisioner.tag`       | Docker Image Tag for Provisioner   | `0.5.0`                                                    |
+| `jiva.image`            | Docker Image for Jiva              | `openebs/jiva:0.5.0`                                       |
 | `jiva.tag`              | Number of Jiva Replicas            | `2`                                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
@@ -44,7 +50,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install --name openebs -f values.yaml openebs-charts/openebs
+helm install tc/openebs --name openebs -f values.yaml
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -11,11 +11,10 @@ helm install openebs-charts/openebs
 ```
 
 ## Installing OpenEBS from Chart codebase
-The command deploys OpenEBS on the Kubernetes cluster with the release name `openebs` and the default configuration. 
 ```
 git clone https://github.com/openebs/openebs.git
 cd openebs/k8s/charts/openebs/
-helm install --name openebs --namespace=openebs
+helm install --name openebs .
 ```
 
 ## Unistalling OpenEBS from Chart codebase

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -1,35 +1,28 @@
-# OpenEBS
-
-**It is based on Helm community chart [openebs](https://github.com/openebs/openebs/tree/master/k8s/charts/openebs)**
-
-[OpenEBS](http://openebs.io/) is a cloud-native storage solution built with the goal of providing containerized storage for containers. Using OpenEBS, a developer can seamlessly get persistent storage for stateful applications on Kubernetes with ease.
-
-## Introduction
-
-This chart bootstraps a [OpenEBS](https://github.com/openebs/openebs) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 - Kubernetes 1.7.5+ with RBAC enabled
 - iSCSI PV support in the underlying infrastructure
 
-## Installing the Chart 
-
-The command deploys OpenEBS on the Kubernetes cluster with the release name `openebs` and the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation:
-
-```bash
-$ helm install tc/openebs --name openebs --namespace=openebs
+## Installing OpenEBS 
+```
+helm repo add openebs-charts https://openebs.github.io/charts/
+helm repo update
+helm install openebs-charts/openebs
 ```
 
-## Unistalling the Chart
-List 
+## Installing OpenEBS from Chart codebase
+The command deploys OpenEBS on the Kubernetes cluster with the release name `openebs` and the default configuration. 
+```
+git clone https://github.com/openebs/openebs.git
+cd openebs/k8s/charts/openebs/
+helm install --name openebs .--namespace=openebs
+```
+
+## Unistalling OpenEBS from Chart codebase
 ```
 helm ls --all
-```
-
-Note the `openebs` from above command.
-To uninstall/delete the `openebs` deployment:
-```bash
-$ helm delete openebs
+# Note the openebs-chart-name from above command
+helm del --purge <openebs-chart-name>
 ```
 
 ## Configuration
@@ -52,7 +45,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```shell
-helm install tc/openebs --name openebs -f values.yaml
+helm install --name openebs -f values.yaml openebs-charts/openebs
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -2,7 +2,7 @@
 
 **It is based on Helm community chart [openebs](https://github.com/openebs/openebs/tree/master/k8s/charts/openebs)**
 
-[OpenEBS](http://openebs.io/) is a cloud-native storage solution built with the goal of providing containerized storage for containers. Using OpenEBS, a developer can seamlessly get the persistent storage for stateful applications on Kubernetes with ease.
+[OpenEBS](http://openebs.io/) is a cloud-native storage solution built with the goal of providing containerized storage for containers. Using OpenEBS, a developer can seamlessly get persistent storage for stateful applications on Kubernetes with ease.
 
 ## Introduction
 

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -24,6 +24,8 @@ $ helm install tc/openebs --name openebs --namespace=openebs
 List 
 ```
 helm ls --all
+```
+
 # Note the `openebs` from above command
 To uninstall/delete the `openebs` deployment:
 ```bash

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -15,7 +15,7 @@ The command deploys OpenEBS on the Kubernetes cluster with the release name `ope
 ```
 git clone https://github.com/openebs/openebs.git
 cd openebs/k8s/charts/openebs/
-helm install --name openebs .--namespace=openebs
+helm install --name openebs --namespace=openebs
 ```
 
 ## Unistalling OpenEBS from Chart codebase

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -26,7 +26,7 @@ List
 helm ls --all
 ```
 
-Note the `openebs` from above command
+Note the `openebs` from above command.
 To uninstall/delete the `openebs` deployment:
 ```bash
 $ helm delete openebs

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: maya-apiserver
-  namespace: default
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: openebs-provisioner
-  namespace: default
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:


### PR DESCRIPTION
Hardcoded namespace in OpenEBS Helm chart is causing deployment to fail if namespace is specified with Helm installation.
This issue is open under #1035 "OpenEBS Helm installation fails if namespace is used"

Solution is validated on StackPointCloud.
