### PR TITLE
Change spc, sp crd scope to Namespace default

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -131,13 +131,14 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepoolclaims.openebs.io
+  namespace: default
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io
   # version name to use for REST API: /apis/<group>/<version>
   version: v1alpha1
   # either Namespaced or Cluster
-  scope: Cluster
+  scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: storagepoolclaims
@@ -154,13 +155,14 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepools.openebs.io
+  namespace: default
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io
   # version name to use for REST API: /apis/<group>/<version>
   version: v1alpha1
   # either Namespaced or Cluster
-  scope: Cluster
+  scope: Namespaced
   names:
     # plural name to be used in the URL: /apis/<group>/<version>/<plural>
     plural: storagepools
@@ -182,3 +184,4 @@ parameters:
   openebs.io/jiva-replica-count: "2"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
+


### PR DESCRIPTION
1. Why is this change necessary ?
 fixes: openebs/openebs#1081

2. How does this change address the issue ?
 The scope is changed to Namespaced and default namespace is specified on openebs-operator.yaml

3. How to verify this change ?
 kubectl apply -f openebs-operator.yaml

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
