### PR TITLE
update jiva image to 0.5.1-RC1

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -75,9 +75,9 @@ spec:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.0"
+          value: "openebs/jiva:0.5.1-RC1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.0"
+          value: "openebs/jiva:0.5.1-RC1"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "openebs/m-exporter:0.5.0"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
@@ -113,7 +113,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.5.1-RC1
+        image: openebs/openebs-k8s-provisioner:0.5.1-RC2
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Update the Jiva to 0.5.1-RC1 and Provisioner to 0.5.1-RC2 for Cent OS support
