### PR TITLE
update to 0.5.1

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-version: 0.5.0
+version: 0.5.1
 name: openebs
-appVersion: 0.5.0
+appVersion: 0.5.1
 description: Containerized Storage for Containers
 icon: https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png
 home: http://www.openebs.io/

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -9,20 +9,20 @@ image:
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.5.0"
+  tag: "0.5.1"
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.5.0"
+  tag: "0.5.1"
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
   monitorvolkey: "&var-OpenEBS"
 
 jiva:
-  image: "openebs/jiva:0.5.0"
+  image: "openebs/jiva:0.5.1"
   replicas: 2
 
 policies:
   monitoring:
     enabled: true
-    image: "openebs/m-exporter:0.5.0"
+    image: "openebs/m-exporter:0.5.1"

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -70,16 +70,16 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.5.1-RC1
+        image: openebs/m-apiserver:0.5.1
         ports:
         - containerPort: 5656
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.1-RC1"
+          value: "openebs/jiva:0.5.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.1-RC1"
+          value: "openebs/jiva:0.5.1"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.5.0"
+          value: "openebs/m-exporter:0.5.1"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "2"
 ---
@@ -113,7 +113,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.5.1-RC2
+        image: openebs/openebs-k8s-provisioner:0.5.1
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Update the default version to 0.5.1 in operator and helm charts. 

The scope of 0.5.1 and the issues fixed in 0.5.1 are available at:
https://github.com/openebs/openebs/milestone/6

Fixes #1085
  
  