### PR TITLE
Create a kubernetes job to run iscsi compliance tests

### DIFF
--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-job.yaml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-job.yaml
@@ -13,6 +13,9 @@ spec:
       - name: libiscsi
         image: openebs/tests-libiscsi
         command: ["/bin/bash"]
+        # Use the appropriate iSCSI target portal IP address in args
+        # For OpenEBS obtain this via:  
+        # kubectl get svc 
         args: ["-c", "./testiscsi.sh --ctrl-svc-ip 10.107.125.0"]
         volumeMounts:
         - name: logpath

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-job.yaml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-job.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: libiscsi
+spec:
+  template:
+    metadata:
+      name: libiscsi
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: libiscsi
+        image: openebs/tests-libiscsi
+        command: ["/bin/bash"]
+        args: ["-c", "./testiscsi.sh --ctrl-svc-ip 10.107.125.0"]
+        volumeMounts:
+        - name: logpath
+          mountPath: /mnt/logs
+      volumes: 
+        - name: logpath
+          hostPath: 
+            path: /logdir


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

This kubernetes job can be used to evaluate iscsi compliance (via libiscsi) of any containerized storage solution exposing iscsi target.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1113 

**Special notes for your reviewer**:

The `ctrl-svc-ip` is the IP address of the iSCSI target portal