### PR TITLE
Allow configuration of replicas/affinity and refactor to follow common helm patterns

### DIFF
--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -28,16 +28,23 @@ helm del --purge <openebs-chart-name>
 
 The following tables lists the configurable parameters of the OpenEBS chart and their default values.
 
-| Parameter               | Description                        | Default                                                    |
-| ----------------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `rbacEnable`            | Enable RBAC Resources              | `true`                                                     |
-| `image.pullPolicy`      | Container pull policy              | `IfNotPresent`                                             |
-| `apiserver.image`       | Docker Image for API Server        | `openebs/m-apiserver`                                      |
-| `apiserver.tag`         | Docker Image Tag for API Server    | `0.5.1`                                                    |
-| `provisioner.image`     | Docker Image for Provisioner       | `openebs/openebs-k8s-provisioner`                          |
-| `provisioner.tag`       | Docker Image Tag for Provisioner   | `0.5.1`                                                    |
-| `jiva.image`            | Docker Image for Jiva              | `openebs/jiva:0.5.1`                                       |
-| `jiva.tag`              | Number of Jiva Replicas            | `2`                                                        |
+| Parameter                            | Description                                   | Default                           |
+| ------------------------------------ | --------------------------------------------- | --------------------------------- |
+| `rbacEnable`                         | Enable RBAC Resources                         | `true`                            |
+| `image.pullPolicy`                   | Container pull policy                         | `IfNotPresent`                    |
+| `apiserver.image`                    | Docker Image for API Server                   | `openebs/m-apiserver`             |
+| `apiserver.imageTag`                 | Docker Image Tag for API Server               | `0.5.1`                           |
+| `apiserver.replicas`                 | Number of API Server Replicas                 | `2`                               |
+| `apiserver.antiAffinity.enabled`     | Enable anti-affinity for API Server Replicas  | `true`                           |
+| `apiserver.antiAffinity.type`        | Anti-affinity type for API Server             | `Hard`                           |
+| `provisioner.image`                  | Docker Image for Provisioner                  | `openebs/openebs-k8s-provisioner` |
+| `provisioner.imageTag`               | Docker Image Tag for Provisioner              | `0.5.1`                           |
+| `provisioner.replicas`               | Number of Provisioner Replicas                | `2`                               |
+| `provisioner.antiAffinity.enabled`   | Enable anti-affinity for API Server Replicas  | `true`                           |
+| `provisioner.antiAffinity.type`      | Anti-affinity type for Provisioner            | `Hard`                           |
+| `jiva.image`                         | Docker Image for Jiva                         | `openebs/jiva`                    |
+| `jiva.imageTag`                      | Docker Image Tag for Jiva                     | `0.5.1`                           |
+| `jiva.replicas`                      | Number of Jiva Replicas                       | `2`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/k8s/charts/openebs/templates/_helpers.tpl
+++ b/k8s/charts/openebs/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "openebs.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "openebs.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   namespace: default
-  name: openebs-maya-operator
+  name: {{ .Values.serviceAccountName }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 rules:

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -3,16 +3,16 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   namespace: default
-  name: openebs-maya-operator
+  name: {{ .Values.serviceAccountName }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openebs-maya-operator
+  name: {{ .Values.serviceAccountName }}
 subjects:
 - kind: ServiceAccount
-  name: openebs-maya-operator
+  name: {{ .Values.serviceAccountName }}
   namespace: default
 - kind: User
   name: system:serviceaccount:default:default

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -1,10 +1,15 @@
 {{- if .Values.policies.monitoring.enabled }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: openebs-prometheus-config
+  name: {{ template "openebs.fullname" . }}-prometheus-config
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-apiVersion: v1
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: prometheus-config
 data:
   prometheus.yml: |-
     global:

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -2,9 +2,14 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: openebs-prometheus-tunables
+  name: {{ template "openebs.fullname" . }}-prometheus-tunables
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: prometheus-tunables
 data:
   storage-retention: 24h
 {{- end }}

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -1,30 +1,68 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: maya-apiserver
+  name: {{ template "openebs.fullname" . }}-maya-apiserver
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: apiserver
 spec:
-  replicas: 1
+  replicas: {{ .Values.apiserver.replicas }}
   template:
     metadata:
       labels:
-        name: maya-apiserver
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ template "openebs.fullname" . }}
+        role: apiserver
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
-      - name: maya-apiserver
-        image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.tag }}"
+      - name: {{ template "openebs.name" . }}-maya-apiserver
+        image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports: 
-        - containerPort: 5656
+        ports:
+        - containerPort: {{ .Values.apiserver.ports.internalPort }}
         env:
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: {{ .Values.jiva.image }}
+          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: {{ .Values.jiva.image }}
+          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "{{ .Values.policies.monitoring.image }}"
+          value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "{{ .Values.jiva.replicas }}"
+
+{{- if .Values.apiserver.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.apiserver.nodeSelector | indent 8 }}
+{{- end }}
+
+{{- if .Values.apiserver.tolerations }}
+      tolerations:
+{{ toYaml .Values.apiserver.tolerations | indent 8 }}
+{{- end }}
+
+{{- if .Values.apiserver.antiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+  {{- $antiAffinityType := .Values.apiserver.antiAffinity.type | lower -}}
+  {{- if eq $antiAffinityType "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  name: {{ template "openebs.fullname" . }}-maya-apiserver
+  {{- else if eq $antiAffinityType "soft" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    name: {{ template "openebs.fullname" . }}-maya-apiserver
+  {{- end }}
+{{- end }}

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -1,25 +1,32 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: openebs-provisioner
+  name: {{ template "openebs.fullname" . }}-provisioner
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: provisioner
 spec:
-  replicas: 1
+  replicas: {{ .Values.provisioner.replicas }}
   template:
     metadata:
       labels:
-        name: openebs-provisioner
-        chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ template "openebs.fullname" . }}
+        role: provisioner
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
-      - name: openebs-provisioner
-        image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.tag }}"
+      - name: {{ template "openebs.name" . }}-provisioner
+        image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: NODE_NAME
-          valueFrom: 
+          valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
         - name: OPENEBS_MONITOR_URL
@@ -28,3 +35,34 @@ spec:
           value: "{{ .Values.provisioner.monitorvolkey }}"
         - name: MAYA_PORTAL_URL
           value: "{{ .Values.provisioner.mayaportalurl }}"
+
+{{- if .Values.provisioner.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.provisioner.nodeSelector | indent 8 }}
+{{- end }}
+
+{{- if .Values.provisioner.tolerations }}
+      tolerations:
+{{ toYaml .Values.provisioner.tolerations | indent 8 }}
+{{- end }}
+
+{{- if .Values.provisioner.antiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+  {{- $antiAffinityType := .Values.provisioner.antiAffinity.type | lower -}}
+  {{- if eq $antiAffinityType "hard" }}
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  name: {{ template "openebs.fullname" . }}-provisioner
+  {{- else if eq $antiAffinityType "soft" }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "kubernetes.io/hostname"
+                labelSelector:
+                  matchLabels:
+                    name: {{ template "openebs.fullname" . }}-provisioner
+  {{- end }}
+{{- end }}

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -2,23 +2,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
+  name: {{ template "openebs.fullname" . }}-grafana
   labels:
-    app: openebs-grafana
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
-  name: openebs-grafana
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: grafana
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   template:
     metadata:
       labels:
-        app: openebs-grafana
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ template "openebs.fullname" . }}
+        role: grafana
     spec:
       containers:
-      - image: grafana/grafana:4.5.2
-        name: grafana
+      - name: {{ template "openebs.name" . }}-grafana
+        image: "{{ .Values.grafana.image }}:{{ .Values.grafana.imageTag }}"
         ports:
-        - containerPort: 3000
+        - containerPort: {{ .Values.grafana.ports.internalPort }}
         env:
           - name: GF_AUTH_BASIC_ENABLED
             value: "true"
@@ -27,7 +34,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 3000
+            port: {{ .Values.grafana.ports.internalPort }}
           initialDelaySeconds: 30
           timeoutSeconds: 1
 {{- end }}

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -2,36 +2,45 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: openebs-prometheus
+  name: {{ template "openebs.fullname" . }}-prometheus
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ template "openebs.fullname" . }}
+    role: prometheus
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        name: openebs-prometheus-server
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: {{ template "openebs.fullname" . }}
+        role: prometheus
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
-        - name: prometheus
-          image: prom/prometheus:v1.7.2
+        - name: {{ template "openebs.name" . }}-prometheus
+          image: "{{ .Values.prometheus.image }}:{{ .Values.prometheus.imageTag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "-config.file=/etc/prometheus/conf/prometheus.yml"
             # Metrics are stored in an emptyDir volume which
             # exists as long as the Pod is running on that Node.
             # The data in an emptyDir volume is safe across container crashes.
             - "-storage.local.path=/prometheus"
-            # How long to retain samples in the local storage. 
+            # How long to retain samples in the local storage.
             - "-storage.local.retention=$(STORAGE_RETENTION)"
           ports:
-            - containerPort: 9090
+            - containerPort: {{ .Values.prometheus.ports.internalPort }}
           env:
-            # environment vars are stored in prometheus-env configmap. 
+            # environment vars are stored in prometheus-env configmap.
             - name: STORAGE_RETENTION
               valueFrom:
                 configMapKeyRef:
-                  name: openebs-prometheus-tunables
+                  name: {{ template "openebs.fullname" . }}-prometheus-tunables
                   key: storage-retention
           resources:
             requests:
@@ -57,9 +66,9 @@ spec:
         # Prometheus Config file will be stored in this volume 
         - name: prometheus-server-volume
           configMap:
-            name: openebs-prometheus-config
+            name: {{ template "openebs.fullname" . }}-prometheus-config
         # All the time series stored in this volume in form of .db file.
         - name: prometheus-storage-volume
           # containers in the Pod can all read and write the same files here.
-          emptyDir: {} 
+          emptyDir: {}
 {{- end }}

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  # service name must be `maya-apiserver-service` until a time when the serivce name is not hardcoded in the provisioner.
+  # See https://git.io/vNBGa
   name: maya-apiserver-service
   labels:
     app: {{ template "openebs.name" . }}
@@ -15,7 +17,7 @@ spec:
     targetPort: {{ .Values.apiserver.ports.internalPort }}
     protocol: TCP
   selector:
-    app: {{ template "openebs.name" . }}-maya-apiserver
+    app: {{ template "openebs.name" . }}
     release: {{ .Release.Name }}
     component: {{ template "openebs.fullname" . }}
     role: apiserver

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -3,13 +3,20 @@ kind: Service
 metadata:
   name: maya-apiserver-service
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role: apiserver
 spec:
   ports:
   - name: api
-    port: 5656
+    port: {{ .Values.apiserver.ports.externalPort }}
+    targetPort: {{ .Values.apiserver.ports.internalPort }}
     protocol: TCP
-    targetPort: 5656
   selector:
-    name: maya-apiserver
+    app: {{ template "openebs.name" . }}-maya-apiserver
+    release: {{ .Release.Name }}
+    component: {{ template "openebs.fullname" . }}
+    role: apiserver
   sessionAffinity: None

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -2,15 +2,22 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: openebs-grafana
+  name: {{ template "openebs.fullname" . }}-grafana
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role: grafana
 spec:
   type: NodePort
   ports:
-  - port: 3000
-    targetPort: 3000
-    nodePort: 32515
+  - port: {{ .Values.grafana.ports.externalPort }}
+    targetPort: {{ .Values.grafana.ports.internalPort }}
+    nodePort: {{ .Values.grafana.ports.nodePort }}
   selector:
-    app: openebs-grafana
+    app: {{ template "openebs.name" . }}-grafana
+    release: {{ .Release.Name }}
+    component: {{ template "openebs.fullname" . }}
+    role: grafana
 {{- end }}

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -2,16 +2,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: openebs-prometheus-service
+  name: {{ template "openebs.fullname" . }}-prometheus-service
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    role: prometheus
 spec:
-  selector: 
-    name: openebs-prometheus-server
   type: NodePort
   ports:
-    - port: 80 # this Service's port (cluster-internal IP clusterIP)
-      targetPort: 9090 # pods expose this port
-      nodePort: 32514
-      # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
+  - port: {{ .Values.prometheus.ports.externalPort }} # this Service's port (cluster-internal IP clusterIP)
+    targetPort: {{ .Values.prometheus.ports.internalPort }} # pods expose this port
+    nodePort: {{ .Values.prometheus.ports.nodePort }}
+    # Note that this Service will be visible as both NodeIP:nodePort and clusterIp:Port
+  selector:
+    app: {{ template "openebs.name" . }}-prometheus
+    release: {{ .Release.Name }}
+    component: {{ template "openebs.fullname" . }}
+    role: prometheus
 {{- end }}

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-maya-operator
+  name: {{ .Values.serviceAccountName }}
   namespace: default
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -4,25 +4,60 @@
 ##
 rbacEnable: true
 
+serviceAccountName: "openebs-maya-operator"
+
 image:
   pullPolicy: IfNotPresent
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.5.1"
+  imageTag: "0.5.1"
+  replicas: 2
+  ports:
+    externalPort: 5656
+    internalPort: 5656
+  nodeSelector: {}
+  tolerations: {}
+  antiAffinity:
+    enabled: true
+    type: Hard
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.5.1"
+  imageTag: "0.5.1"
+  replicas: 2
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
   monitorvolkey: "&var-OpenEBS"
+  nodeSelector: {}
+  tolerations: {}
+  antiAffinity:
+    enabled: true
+    type: Hard
+
+grafana:
+  image: "grafana/grafana"
+  imageTag: "4.5.2"
+  ports:
+    externalPort: 3000
+    internalPort: 3000
+    nodePort: 32515
+
+prometheus:
+  image: "prom/prometheus"
+  imageTag: "v1.7.2"
+  ports:
+    externalPort: 80
+    internalPort: 9090
+    nodePort: 32514
 
 jiva:
-  image: "openebs/jiva:0.5.1"
+  image: "openebs/jiva"
+  imageTag: "0.5.1"
   replicas: 2
 
 policies:
   monitoring:
     enabled: true
-    image: "openebs/m-exporter:0.5.1"
+    image: "openebs/m-exporter"
+    imageTag: "0.5.1"


### PR DESCRIPTION
- add ability to configure apiserver and provisioner replica count and
affinity
- allow configuration of ports via values
- refactor labels
- refactor to follow observed patterns in stable charts and helm create