### PR TITLE
Bump chart version to 0.5.2

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.1
+version: 0.5.2
 name: openebs
 appVersion: 0.5.1
 description: Containerized Storage for Containers


### PR DESCRIPTION
- related to https://github.com/openebs/openebs/pull/1120
- related to https://github.com/openebs/charts/pull/2