### PR TITLE
Fix RBAC permission in cluster-scope

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -3,7 +3,7 @@
 # Launch the maya-apiserver ( deployment )
 # Launch the maya-storagemanager ( deameon set )
 
-# Create Maya Service Account 
+# Create Maya Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -51,7 +51,7 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: openebs-maya-operator
+  name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: apps/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
Set `ClusterRole` as `cluster-admin` we are able to list the volume in all namespace , the error we are getting while making list call in cluster setup is:

```
[ERR] http: Request GET /latest/volumes/, error: namespaces is forbidden: User "system:serviceaccount:default:openebs-maya-operator" cannot list namespaces at the cluster scope
```

**Which issue this PR fixes** 
fixes #1075