### PR TITLE
Convert ARA embedded webserver into systemd service

### DIFF
--- a/e2e/ansible/roles/ara/defaults/main.yml
+++ b/e2e/ansible/roles/ara/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+#####################################
+#    ARA COMMON PRE-REQUISITES      #
+#####################################
+
 ara_apt_packages: 
   - gcc 
   - python-dev
@@ -7,9 +11,13 @@ ara_apt_packages:
   - python-pip
   - libxml2-dev
   - libxslt1-dev
+  - python-setuptools 
 
 ara_pip_packages:
   - tox
   - ara 
 
 ara_webserver_port: 9191
+
+ara_webserver: embedded
+

--- a/e2e/ansible/roles/ara/handlers/main.yml
+++ b/e2e/ansible/roles/ara/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: Reload systemctl
+  command: systemctl daemon-reload
+  become: true 

--- a/e2e/ansible/roles/ara/tasks/main.yml
+++ b/e2e/ansible/roles/ara/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: Install ara apt packages
   apt:
     name: "{{ item }}"
@@ -68,33 +69,34 @@
     option: notification_callback 
     value: "ara"
 
-- name: Get ara-manage binary location
-  command: which ara-manage
-  register: ara_manage_binary
+- block:
+    - name: Get ara-manage binary location
+      command: which ara-manage
+      register: ara_manage_binary
 
-- name: Start ara webserver on localhost
-  shell: >
-    nohup {{ ara_manage_binary.stdout }} 
-    runserver
-    -h {{ ansible_default_ipv4.address }} 
-    -p {{ ara_webserver_port }} 
-    > {{ ansible_env.HOME }}/ara-manage.log
-    2>&1
-    &
-  args:
-    executable: /bin/bash
+    - name: Copy systemd service template
+      template:
+        src: templates/ara-service.conf.j2
+        dest: /etc/systemd/system/ara.service
+        owner: root
+        group: root
+        mode: 0644
+      become: true 
+      notify: 
+        - Reload systemctl
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+    - name: Start and enable the embedded server service
+      service:
+        name: ara
+        state: started
+        enabled: yes
+      become: true 
+  when: ara_webserver == "embedded"
 
 - name: Display ara UI URL  
   debug: 
     msg: "Access playbook records at http://{{ ansible_default_ipv4.address }}:{{ ara_webserver_port }}"
-
-
-
-  
-
-
-  
-
-
-
 

--- a/e2e/ansible/roles/ara/templates/ara-service.conf.j2
+++ b/e2e/ansible/roles/ara/templates/ara-service.conf.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=ARA
+After=network.target
+
+[Service]
+Type=simple
+TimeoutStartSec=0
+Restart=on-failure
+RestartSec=10
+RemainAfterExit=yes
+ExecStart={{ ara_manage_binary.stdout }} runserver -h {{ ansible_default_ipv4.address }} -p {{ ara_webserver_port }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- ARA is used to log/record ansible playbook runs in OpenEBS e2e. It was observed that the embedded webserver running on the test harness generally fails/stops due to which the ARA webpage is not accessible (though the run details are stored in the sqlite db)

- One solution was to attempt use of apache+mod_wsgi webserver to display playbook records from db. However, the official ansible role & documentation for use of apache w/ ARA is inadequate (Planned to be fixed in ARA 1.0, with focus on mysql + mod_wsgi use-case for large deployments)

- Another solution is to create a service for the embedded webserver with appropriate restart & timeout configuration to ensure that the webpages are always available. This commit consists of changes for this solution.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #471 

**Special notes for your reviewer**:

Discussion on ARA Slack/IRC with the ARA project core contributor recommendations wrt running ARA w/ apache webserver : http://eavesdrop.openstack.org/irclogs/%23ara/%23ara.2017-08-28.log.html
