### PR TITLE
Adds ENV changes related to maya api service & K8s connection

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -77,14 +77,14 @@ spec:
         ports:
         - containerPort: 5656
         env:
-        # Enables this service to connect to K8s based on this config
-        # Ignored if empty
-        - name: OPENEBS_IO_KUBE_CONFIG
-          value: ""
-        # Enables this service to connect to K8s based on this address
-        # Ignored if empty
-        - name: OPENEBS_IO_K8S_MASTER
-          value: ""
+        # OPENEBS_IO_KUBE_CONFIG enables this service to connect to K8s
+        # based on this config. This is ignored if empty
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables this service to connect to K8s 
+        # based on this address. This is ignored if empty
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "openebs/jiva:0.5.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
@@ -125,6 +125,14 @@ spec:
       - name: openebs-provisioner
         imagePullPolicy: Always
         image: openebs/openebs-k8s-provisioner:0.5.1
+        command: ["openebs-provisioner"]
+        args:
+        # master enables this service to connect to K8s 
+        # based on this address. This is ignored if empty.
+        #- -master=http://172.28.128.3:8080
+        # kubeconfig enables this service to connect to K8s
+        # based on this config. This is ignored if empty.
+        #- -kubeconfig=/home/ubuntu/.kube/config
         env:
         - name: NODE_NAME
           valueFrom:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -77,6 +77,14 @@ spec:
         ports:
         - containerPort: 5656
         env:
+        # Enables this service to connect to K8s based on this config
+        # Ignored if empty
+        - name: OPENEBS_IO_KUBE_CONFIG
+          value: ""
+        # Enables this service to connect to K8s based on this address
+        # Ignored if empty
+        - name: OPENEBS_IO_K8S_MASTER
+          value: ""
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "openebs/jiva:0.5.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE


### PR DESCRIPTION
1. Why is this change necessary ?

This lets maya api service connect to K8s based on
K8s Master address or KubeConfig

2. How does this change address the issue ?

- Adds a set of optional ENV variables

3. How to verify this change ?

- Set a value to either of these variables & check
if maya api service can connect to K8s

4. What side effects does this change have ?

- This will make all the requests to maya api server served
by connecting to K8s using these ENV variables.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
