### PR TITLE
Adds ENV variables to connect to K8s APIs

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -79,10 +79,12 @@ spec:
         env:
         # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
         # based on this config. This is ignored if empty.
+        # This is supported for maya api server v0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
         # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
         # based on this address. This is ignored if empty.
+        # This is supported for maya api server v0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
@@ -128,10 +130,12 @@ spec:
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner v0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://10.128.0.12:8080"
         # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
         # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner v0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
         - name: NODE_NAME

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -79,12 +79,12 @@ spec:
         env:
         # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
         # based on this config. This is ignored if empty.
-        # This is supported for maya api server v0.5.2 onwards
+        # This is supported for maya api server version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
         # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
         # based on this address. This is ignored if empty.
-        # This is supported for maya api server v0.5.2 onwards
+        # This is supported for maya api server version 0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
@@ -130,12 +130,12 @@ spec:
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
-        # This is supported for openebs provisioner v0.5.2 onwards
+        # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://10.128.0.12:8080"
         # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
         # based on this config. This is ignored if empty.
-        # This is supported for openebs provisioner v0.5.2 onwards
+        # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
         - name: NODE_NAME

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -77,6 +77,14 @@ spec:
         ports:
         - containerPort: 5656
         env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "openebs/jiva:0.5.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
@@ -118,6 +126,14 @@ spec:
         imagePullPolicy: Always
         image: openebs/openebs-k8s-provisioner:0.5.1
         env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
         - name: NODE_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
1. Why is this change necessary ?

This lets maya api service & openebs provisioner connect to
K8s APIs based on K8s Master address or KubeConfig.

These ENV variables are optional.

2. How does this change address the issue ?

- Adds ENV to specs
  - OPENEBS_IO_KUBE_CONFIG
  - OPENEBS_IO_K8S_MASTER

3. How to verify this change ?

- Refer to the comments specified in the specs

4. What side effects does this change have ?

- This will let the services connect to K8s using
either of above ENV variables.

Signed-off-by: amitkumardas <amit.das@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
