### PR TITLE
Update mongodb documentation to use correct package name (libsasl2-dev) 

### DIFF
--- a/k8s/demo/mongodb/README.md
+++ b/k8s/demo/mongodb/README.md
@@ -49,7 +49,7 @@ In ubuntu, the iSCSI initiator can be installed using the following procedure :
   sudo apt-get install <packagename>:
 
   make
-  libsas12-dev
+  libsasl2-dev
   libssl-dev
   libmongoc-dev
   libbson-dev


### PR DESCRIPTION
Typo in package name libsasl2-dev
