### PR TITLE
Update openebs-monitoring-pg.yaml to use Prometheus v2

### DIFF
--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -75,15 +75,15 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: prometheus
-          image: prom/prometheus:v1.7.2
+          image: prom/prometheus:v2.1.0
           args:
-            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            - "--config.file=/etc/prometheus/conf/prometheus.yml"
             # Metrics are stored in an emptyDir volume which
             # exists as long as the Pod is running on that Node.
             # The data in an emptyDir volume is safe across container crashes.
-            - "-storage.local.path=/prometheus"
-            # How long to retain samples in the local storage. 
-            - "-storage.local.retention=$(STORAGE_RETENTION)"
+            - "--storage.tsdb.path=/prometheus"
+            # How long to retain samples in the local storage.
+            - "--storage.tsdb.retention=$(STORAGE_RETENTION)"
           ports:
             - containerPort: 9090
           env:
@@ -166,7 +166,7 @@ spec:
         app: openebs-grafana
     spec:
       containers:
-      - image: grafana/grafana:4.5.2
+      - image: grafana/grafana:4.6.3
         name: grafana
         ports:
         - containerPort: 3000


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

You're still running an outdated version of Prometheus. Let's bump it to v2.

**Special notes for your reviewer**:

I just saw that you also ship a Prometheus Operator folder. Should we update this one too?
It's fairly outdated as well. Instead of deploying Prometheus and Alertmanager as deployment the operator actually uses CRDs. Should we use these in the operator?
That would be another PR, I guess.