### PR TITLE
Update prometheus configurations to use version > v2.0

### DIFF
--- a/k8s/openebs-monitoring/configs/alertmanager-config.yaml
+++ b/k8s/openebs-monitoring/configs/alertmanager-config.yaml
@@ -10,7 +10,7 @@ data:
       # if it has not been updated.
       resolve_timeout: 5m
       # Replace the given api url by your slack webhook url.        
-      slack_api_url: 'https://hooks.slack.com/services/Token'
+      slack_api_url: 'https://hooks.slack.com/services/T3NU2A2UV/Your_Token'
 
     # The directory from which notification templates are read.
     templates:

--- a/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
@@ -3,74 +3,55 @@ metadata:
   name: prometheus-alert-rules
 apiVersion: v1
 data:
-  alert.rules: |-
-    ## alert.rules ##
-    #
-    # CPU Alerts
-    #
-    # alerts when cpu usage exceeds the given limit within the 
-    # interval of 5 min
-    # The given expression below are the queries (PromQL) to
-    # get the details.
-    ALERT NodeCPUUsage
-      IF (100 - (avg by (instance) (irate(node_cpu{name="node-exporter",mode="idle"}[5m])) * 100)) > 75
-      FOR 2m
-      LABELS { severity="warning" }  
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: High CPU usage detected",
-        DESCRIPTION = "{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})"
-      }
-  
-    #
-    # Disk Alerts
-    # 
-    ALERT NodeLowRootDisk
-      IF ((node_filesystem_size{mountpoint="/root-disk"} - node_filesystem_free{mountpoint="/root-disk"} ) / node_filesystem_size{mountpoint="/root-disk"} * 100) > 75
-      FOR 2m
-      LABELS { severity="warning" }
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: Low root disk space",
-        DESCRIPTION = "{{$labels.instance}}: Root disk usage is above 75% (current value is: {{ $value }})"
-      }
-
-    ALERT NodeLowDataDisk
-      IF ((node_filesystem_size{mountpoint="/data-disk"} - node_filesystem_free{mountpoint="/data-disk"} ) / node_filesystem_size{mountpoint="/data-disk"} * 100) > 75
-      FOR 2m
-      LABELS { severity="warning" }
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: Low data disk space",
-        DESCRIPTION = "{{$labels.instance}}: Data disk usage is above 75% (current value is: {{ $value }})"
-      }
- 
-    #
-    # Node Load Alerts (5m)
-    # alerts when Load on node exceeds the given limit with in 5 min
-    ALERT NodeLoadAverage
-      IF ((node_load5 / count without (cpu, mode) (node_cpu{mode="system"})) > 1)
-      FOR 2m
-      LABELS { severity="warning" }
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: High Node Load average(5m) detected",
-        DESCRIPTION = "{{$labels.instance}}: LA is high"
-      }
-
-    #
-    # RAM Alerts
-    #
-    ALERT NodeSwapUsage
-      IF (((node_memory_SwapTotal-node_memory_SwapFree)/node_memory_SwapTotal)*100) > 75
-      FOR 2m
-      LABELS { severity="warning" }
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: High Swap usage detected",
-        DESCRIPTION = "{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})"
-      }
-
-    ALERT NodeMemoryUsage
-      IF (((node_memory_MemTotal-node_memory_MemFree-node_memory_Cached)/(node_memory_MemTotal)*100)) > 75
-      FOR 2m
-      LABELS { severity="warning" }
-      ANNOTATIONS {
-        SUMMARY = "{{$labels.instance}}: High memory usage detected",
-        DESCRIPTION = "{{$labels.instance}}: Memory usage is above 75% (current value is: {{ $value }})"
-      }  
+  alert.rules.yml: |-
+    groups:
+    - name: prometheus-alert.rules
+      rules:
+      - alert: NodeCPUUsage
+        expr: (100 - (avg(irate(node_cpu{mode="idle",name="node-exporter"}[5m])) BY (instance) * 100)) > 75
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: CPU usage is above 75% (current value is: {{ $value }})'
+          SUMMARY: '{{$labels.instance}}: High CPU usage detected'
+      - alert: NodeLowRootDisk
+        expr: ((node_filesystem_size{mountpoint="/root-disk"} - node_filesystem_free{mountpoint="/root-disk"}) / node_filesystem_size{mountpoint="/root-disk"} * 100) > 75
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: Root disk usage is above 75% (current value is: {{ $value }})'
+          SUMMARY: '{{$labels.instance}}: Low root disk space'
+      - alert: NodeLowDataDisk
+        expr: ((node_filesystem_size{mountpoint="/data-disk"} - node_filesystem_free{mountpoint="/data-disk"}) / node_filesystem_size{mountpoint="/data-disk"} * 100) > 75
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: Data disk usage is above 75% (current value is: {{ $value }})'
+          SUMMARY: '{{$labels.instance}}: Low data disk space'
+      - alert: NodeLoadAverage
+        expr: ((node_load5 / count(node_cpu{mode="system"}) WITHOUT (cpu, mode)) > 1)
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: LA is high'
+          SUMMARY: '{{$labels.instance}}: High Node Load average(5m) detected'
+      - alert: NodeSwapUsage
+        expr: (((node_memory_SwapTotal - node_memory_SwapFree) / node_memory_SwapTotal) * 100) > 75
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: Swap usage usage is above 75% (current value is: {{ $value }})'
+          SUMMARY: '{{$labels.instance}}: High Swap usage detected'
+      - alert: NodeMemoryUsage
+        expr: (((node_memory_MemTotal - node_memory_MemFree - node_memory_Cached) / (node_memory_MemTotal) * 100)) > 75
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          DESCRIPTION: '{{$labels.instance}}: Memory usage is above 75% (current value is: {{ $value }})'
+          SUMMARY: '{{$labels.instance}}: High memory usage detected'

--- a/k8s/openebs-monitoring/configs/prometheus-config.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-config.yaml
@@ -30,7 +30,7 @@ data:
       evaluation_interval: 5s
     rule_files:
     # alert rules passed as argument in prometheus-deployment at given path
-    - '/etc/prometheus-rules/alert.rules'
+    - '/etc/prometheus-rules/alert.rules.yaml'
     # scrape config for maya-apiserver pods
     #
     # The relabeling allows the actual pod scrape endpoint to be configured via
@@ -40,6 +40,23 @@ data:
     # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
     # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
     # pod's declared ports (default is a port-free target if none are declared).
+    alerting:
+      alertmanagers:
+      - kubernetes_sd_configs:
+        - role: pod
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_name]
+          regex: alertmanager
+          action: keep
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: default
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          regex:
+          action: drop
     scrape_configs:
     - job_name: 'prometheus'
       static_configs:
@@ -75,6 +92,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: drop
         regex: '(.*)3260'
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: '(.*)9500'
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name

--- a/k8s/openebs-monitoring/grafana-operator.yaml
+++ b/k8s/openebs-monitoring/grafana-operator.yaml
@@ -26,7 +26,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:4.5.2
+      - image: grafana/grafana:5.0.0-beta4
         name: grafana
         imagePullPolicy: Always
         ports:

--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -95,16 +95,15 @@ spec:
       serviceAccountName: prometheus
       containers:
         - name: prometheus
-          image: prom/prometheus:v1.7.2
+          image: prom/prometheus:v2.0.0
           args:
-            - "-config.file=/etc/prometheus/conf/prometheus.yml"
+            - "--config.file=/etc/prometheus/conf/prometheus.yml"
             # Metrics are stored in an emptyDir volume which
             # exists as long as the Pod is running on that Node.
             # The data in an emptyDir volume is safe across container crashes.
-            - "-storage.local.path=/prometheus"
+            - "--storage.tsdb.path=/prometheus"
             # How long to retain samples in the local storage. 
-            - "-storage.local.retention=$(STORAGE_RETENTION)"
-            - "-alertmanager.url=http://alertmanager:9093" 
+            - "--storage.tsdb.retention=$(STORAGE_RETENTION)"
           ports:
             - containerPort: 9090
           env:
@@ -185,7 +184,7 @@ spec:
       name: node-exporter
     spec:
       containers:
-      - image: prom/node-exporter:latest
+      - image: prom/node-exporter:v0.15.2
         name: node-exporter
         ports:
         - containerPort: 9100


### PR DESCRIPTION
1. Why is this change necessary ?
- To support prometheus version > v2.0
- See issue : #1250 for more details

2. How does this change address the issue ?
- Made changes in configs of prometheus and alertmanager and changed the
  alerting rules supported by the latest prometheus

3. How to verify this change ?
- Please follow the README.md

4. What side effects does this change have ?
- Older grafana versions will not support some prometheus metrics queries
  while other queries are supported.
- Grafana deployment uses beta versions so some queries may be broken (only prometheus's)

5. Other details
- Fixes : #1250

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
<!--
**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
