### PR TITLE
Openebs namespace and rbac related changes

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-version: 0.5.1
+version: 0.5.2
 name: openebs
-appVersion: 0.5.1
+appVersion: 0.5.2
 description: Containerized Storage for Containers
 icon: https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png
 home: http://www.openebs.io/

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -2,8 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  namespace: default
-  name: openebs-maya-operator
+  name: {{ .Values.operator.name }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 rules:
@@ -11,7 +10,7 @@ rules:
   resources: ["nodes","nodes/proxy"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["*"]
-  resources: ["services","pods","deployments", "events", "endpoints"]
+  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["persistentvolumes","persistentvolumeclaims"]
@@ -19,6 +18,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["storagepools"]
+  verbs: ["get", "list"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -2,19 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  namespace: default
-  name: openebs-maya-operator
+  name: {{ .Values.operator.name }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: openebs-maya-operator
+  name: {{ .Values.operator.name }}
 subjects:
 - kind: ServiceAccount
-  name: openebs-maya-operator
-  namespace: default
-- kind: User
-  name: system:serviceaccount:default:default
-  apiGroup: rbac.authorization.k8s.io
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.rbac.namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -2,6 +2,9 @@
 kind: ConfigMap
 metadata:
   name: openebs-prometheus-config
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 apiVersion: v1

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openebs-prometheus-tunables
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 data:

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: maya-apiserver
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
@@ -12,7 +15,7 @@ spec:
         name: maya-apiserver
         chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
       - name: maya-apiserver
         image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.tag }}"
@@ -20,6 +23,16 @@ spec:
         ports: 
         - containerPort: 5656
         env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: {{ .Values.jiva.image }}
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: openebs-provisioner
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
@@ -12,12 +15,28 @@ spec:
         name: openebs-provisioner
         chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
       - name: openebs-provisioner
         image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this provisioner will
+        # lookup to find maya api service
+{{- if .Values.rbacEnable }}
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Values.rbac.namespace }}"
+{{- end }}
         - name: NODE_NAME
           valueFrom: 
             fieldRef:

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -1,11 +1,14 @@
 {{- if .Values.policies.monitoring.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:
     app: openebs-grafana
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
   name: openebs-grafana
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
 spec:
   replicas: 1
   revisionHistoryLimit: 2
@@ -14,6 +17,7 @@ spec:
       labels:
         app: openebs-grafana
     spec:
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
       - image: grafana/grafana:4.5.2
         name: grafana

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -1,8 +1,11 @@
 {{- if .Values.policies.monitoring.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: openebs-prometheus
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
@@ -12,7 +15,7 @@ spec:
       labels:
         name: openebs-prometheus-server
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
         - name: prometheus
           image: prom/prometheus:v1.7.2

--- a/k8s/charts/openebs/templates/namespace.yaml
+++ b/k8s/charts/openebs/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.rbacEnable }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+{{- end }}

--- a/k8s/charts/openebs/templates/namespace.yaml
+++ b/k8s/charts/openebs/templates/namespace.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openebs
+  name: {{ .Values.rbac.namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-percona.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-percona.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-redis.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-redis.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-standard.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standard.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-zk.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-zk.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: maya-apiserver-service
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-grafana
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-prometheus-service
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-maya-operator
-  namespace: default
+  name: {{ .Values.operator.name }}
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -4,23 +4,29 @@
 ##
 rbacEnable: true
 
+rbac:
+  namespace: "openebs"
+
+operator:
+  name: "openebs-maya-operator"
+
 image:
   pullPolicy: IfNotPresent
 
 apiserver:
   image: "openebs/m-apiserver"
-  tag: "0.5.1"
+  tag: "0.5.2"
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  tag: "0.5.1"
+  tag: "0.5.2"
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
   monitorvolkey: "&var-OpenEBS"
 
 jiva:
   image: "openebs/jiva:0.5.1"
-  replicas: 2
+  replicas: 3
 
 policies:
   monitoring:


### PR DESCRIPTION
1. Why is this change necessary ?

Users want to to create a separate namespace for
openebs components. Users want a better rbac control.

ref - https://github.com/openebs/openebs/issues/1234

2. How does this change address the issue ?

- changes are done in various charts

3. How to verify this change ?

- Download the templates, Chart.yaml & values.yaml
- Some of the steps can be used from this link to verify
https://github.com/openebs/community/tree/master/demos/21FEB2018

4. What side effects does this change have ?

- All standard StorageClasses now have replica count as 3
- Openebs components with rbac on have a dedicated namespace

Signed-off-by: amitkumardas <amit.das@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
