### PR TITLE
Merge rbac/namespace chanage from PR#1265

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-version: 0.5.2.1
+version: 0.5.3
 name: openebs
-appVersion: 0.5.2
+appVersion: 0.5.3
 description: Containerized Storage for Containers
 icon: https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png
 home: http://www.openebs.io/

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -2,8 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  namespace: default
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.operator.name }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 rules:
@@ -11,7 +10,7 @@ rules:
   resources: ["nodes","nodes/proxy"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["*"]
-  resources: ["namespaces","services","pods","deployments", "events", "endpoints"]
+  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["persistentvolumes","persistentvolumeclaims"]
@@ -19,6 +18,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["storagepools"]
+  verbs: ["get", "list"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -2,19 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  namespace: default
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.operator.name }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.serviceAccountName }}
+  name: {{ .Values.operator.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccountName }}
-  namespace: default
-- kind: User
-  name: system:serviceaccount:default:default
-  apiGroup: rbac.authorization.k8s.io
+  name: {{ .Values.operator.name }}
+  namespace: {{ .Values.rbac.namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-config
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-tunables
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-maya-apiserver
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -19,7 +22,7 @@ spec:
         component: {{ template "openebs.fullname" . }}
         role: apiserver
     spec:
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
       - name: {{ template "openebs.name" . }}-maya-apiserver
         image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
@@ -27,6 +30,16 @@ spec:
         ports:
         - containerPort: {{ .Values.apiserver.ports.internalPort }}
         env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-provisioner
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -19,12 +22,28 @@ spec:
         component: {{ template "openebs.fullname" . }}
         role: provisioner
     spec:
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
       - name: {{ template "openebs.name" . }}-provisioner
         image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this provisioner will
+        # lookup to find maya api service
+{{- if .Values.rbacEnable }}
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Values.rbac.namespace }}"
+{{- end }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -48,12 +48,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: OPENEBS_MONITOR_URL
-          value: "{{ .Values.provisioner.monitorurl }}"
-        - name: OPENEBS_MONITOR_VOLKEY
-          value: "{{ .Values.provisioner.monitorvolkey }}"
-        - name: MAYA_PORTAL_URL
-          value: "{{ .Values.provisioner.mayaportalurl }}"
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that provisioner should forward the volume creaet/delete requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+        - name: OPENEBS_MAYA_SERVICE_NAME
+          value: "{{ template "openebs.fullname" . }}-maya-apiservice"
+        # The following values will be set as annotations to the PV object.
+        # Refer : https://github.com/openebs/external-storage/pull/15
+        #- name: OPENEBS_MONITOR_URL
+        #  value: "{{ .Values.provisioner.monitorurl }}"
+        #- name: OPENEBS_MONITOR_VOLKEY
+        #  value: "{{ .Values.provisioner.monitorvolkey }}"
+        #- name: MAYA_PORTAL_URL
+        #  value: "{{ .Values.provisioner.mayaportalurl }}"
 
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -1,8 +1,11 @@
 {{- if .Values.policies.monitoring.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-grafana
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -1,8 +1,11 @@
 {{- if .Values.policies.monitoring.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -20,7 +23,7 @@ spec:
         component: {{ template "openebs.fullname" . }}
         role: prometheus
     spec:
-      serviceAccountName: {{ .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.operator.name }}
       containers:
         - name: {{ template "openebs.name" . }}-prometheus
           image: "{{ .Values.prometheus.image }}:{{ .Values.prometheus.imageTag }}"

--- a/k8s/charts/openebs/templates/namespace.yaml
+++ b/k8s/charts/openebs/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.rbacEnable }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.rbac.namespace }}
+{{- end }}

--- a/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-percona.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-percona.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-redis.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-redis.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-standard.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standard.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/sc-openebs-zk.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-zk.yaml
@@ -8,6 +8,6 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -1,9 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  # service name must be `maya-apiserver-service` until a time when the serivce name is not hardcoded in the provisioner.
-  # See https://git.io/vNBGa
-  name: maya-apiserver-service
+  name: {{ template "openebs.fullname" . }}-maya-apiservice
 {{- if .Values.rbacEnable }}
   namespace: {{ .Values.rbac.namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -4,6 +4,9 @@ metadata:
   # service name must be `maya-apiserver-service` until a time when the serivce name is not hardcoded in the provisioner.
   # See https://git.io/vNBGa
   name: maya-apiserver-service
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "openebs.fullname" . }}-grafana
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-service
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccountName }}
-  namespace: default
+  name: {{ .Values.operator.name }}
+{{- if .Values.rbacEnable }}
+  namespace: {{ .Values.rbac.namespace }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -3,8 +3,11 @@
 ## If true, create & use RBAC resources
 ##
 rbacEnable: true
+rbac:
+  namespace: "openebs"
 
-serviceAccountName: "openebs-maya-operator"
+operator:
+  name: "openebs-maya-operator"
 
 image:
   pullPolicy: IfNotPresent
@@ -54,7 +57,7 @@ prometheus:
 jiva:
   image: "openebs/jiva"
   imageTag: "0.5.2"
-  replicas: 2
+  replicas: 3
 
 policies:
   monitoring:

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -27,7 +27,7 @@ apiserver:
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  imageTag: "0.5.2"
+  imageTag: "0.5.3-RC1"
   replicas: 2
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

This PR has two parts:

(a) Merges the rbac related changes done as part of PR #1265 ( Issue #1266)
(b) Removes the hard-coding of maya-apiserver-service name  (Issue #1227 )

Output of using a custom name:
```
kiran_mova@kmova-dev:~/go/src/github.com/kmova/openebs/k8s$ kubectl get pods,services -n openebs
NAME                                                 READY     STATUS    RESTARTS   AGE
po/autogen-openebs-grafana-5569cdc594-pkgph          1/1       Running   0          2h
po/autogen-openebs-maya-apiserver-845b7c66d7-s58vh   1/1       Running   0          2h
po/autogen-openebs-maya-apiserver-845b7c66d7-v6gzg   1/1       Running   0          2h
po/autogen-openebs-prometheus-64bdbb78d4-mrkc2       1/1       Running   0          2h
po/autogen-openebs-provisioner-6cb5c9dc54-7ffnv      1/1       Running   0          18m
po/autogen-openebs-provisioner-6cb5c9dc54-kjjdq      1/1       Running   0          15m

NAME                                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
svc/autogen-openebs-grafana              NodePort    10.23.252.28    <none>        3000:32515/TCP   2h
svc/autogen-openebs-maya-apiservice      ClusterIP   10.23.245.50    <none>        5656/TCP         18m
svc/autogen-openebs-prometheus-service   NodePort    10.23.250.136   <none>        80:32514/TCP     2h
kiran_mova@kmova-dev:~/go/src/github.com/kmova/openebs/k8s$ 
```