### PR TITLE
Grant get and list permission to storagepool in cluster-scope

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -35,6 +35,9 @@ rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: [ "get", "list", "create" ]
+- apiGroups: ["*"]
+  resources: ["storagepools"]
+  verbs: ["get", "list"] 
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR will fix the issue of list and get permission for `storagepool` in GKE cluster in v1.8.7-gke.1 version.

**Which issue this PR fixes**:
 fixes #1273 
