### PR TITLE
Specify the order of application of Kafka YAML specification

### DIFF
--- a/k8s/demo/kafka/README.md
+++ b/k8s/demo/kafka/README.md
@@ -1,6 +1,6 @@
-Apply the k8s podspecs mentioned in the folder.
+Apply the k8s podspecs mentioned in the folder as per the numbering prefixed on the YAMLs. 
 
-`kubectl apply -f .`
+`kubectl apply -f <spec>`
 
 This will create a 3 node zookeeper ensemble and a 3 node Kafka cluster which uses OpenEBS volumes.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Specify the order of application of Kafka YAML specification
- Failing to deploy as per the order (based on numbering on the specs) can cause a failed/pending deployment

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1221 

