### PR TITLE
Addition in tutorial-configure-openebs-gke.md

### DIFF
--- a/k8s/hyperconverged/tutorial-configure-openebs-gke.md
+++ b/k8s/hyperconverged/tutorial-configure-openebs-gke.md
@@ -92,6 +92,15 @@ The below command will prompt for username/password. Provide username as "admin"
 kubectl config use-context demo-openebs03
 kubectl config use-context gke_strong-eon-153112_us-central1-a_demo-openebs03
 ```
+**To get the admin priviledge to your cluster(cluster-role admin)**
+ get current google identity
+`$ gcloud info | grep Account`
+Account: [myname@example.org]
+
+ grant cluster-admin to your current identity
+`$ kubectl create clusterrolebinding myname-cluster-admin-binding --clusterrole=cluster-admin --user=myname@example.org`
+Clusterrolebinding "myname-cluster-admin-binding" created
+
 
 Download the latest OpenEBS Operator Files:
 


### PR DESCRIPTION
Came across and error while executing command **kubectl apply -f openebs-operator.yaml** that Error from server (forbidden-server),
This will give the cluster-role admin priviledge.
When you try to apply `kubectl apply -f openebs-operator.yaml` on GKE Kubernetes cluster running 1.6 version, you will probably run into permission errors:

<....>
Error from server (Forbidden): error when creating 
"openebs-operator.yaml": 
clusterroles.rbac.authorization.k8s.io "prometheus-operator" is forbidden: attempt to grant extra privileges:
<....>



<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
