### PR TITLE
Openshift doc updates : More edits to restricted SCC

### DIFF
--- a/k8s/openshift/byo/baremetal/README.md
+++ b/k8s/openshift/byo/baremetal/README.md
@@ -211,8 +211,9 @@ Alternatively, the following command may be used:
 oc adm policy add-scc-to-user anyuid -z default --as=system:admin 
 ```
 
-Note: While the above procedures may be sufficient to enable host access to the containers, it may also be needed to disable
-selinux (via ```setenforce 0```) to ensure the same. 
+Note: While the above procedures may be sufficient to enable host access to the containers, it may also be needed to :
+- Disable selinux (via ```setenforce 0```) to ensure the same. 
+- Edit the restricted scc to use ```runAsUser: runAsAny``` (the replica pod runs with root user) 
 
 #### Step-5: Setup OpenEBS Control Plane  
 

--- a/k8s/openshift/byo/baremetal/README.md
+++ b/k8s/openshift/byo/baremetal/README.md
@@ -213,7 +213,7 @@ oc adm policy add-scc-to-user anyuid -z default --as=system:admin
 
 Note: While the above procedures may be sufficient to enable host access to the containers, it may also be needed to :
 - Disable selinux (via ```setenforce 0```) to ensure the same. 
-- Edit the restricted scc to use ```runAsUser: runAsAny``` (the replica pod runs with root user) 
+- Edit the restricted scc to use ```runAsUser: type: RunAsAny``` (the replica pod runs with root user) 
 
 #### Step-5: Setup OpenEBS Control Plane  
 


### PR DESCRIPTION
As of today, the replica pod runs with a "root" user. By default the default (restricted) SCC disallows running pods as root. One way to get this running today is to use "RunAsAny" option in the restricted security context. Other approaches (creating a separate/dedicated security context for OpenEBS etc.,) needs to be thought about. 

Signed-off-by: ksatchit <karthik.s@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
