### PR TITLE
Include memcheck test playbook into CI suite.

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
@@ -1,0 +1,33 @@
+---     
+- name: Logout to iSCSI target
+  open_iscsi:
+    show_nodes: yes
+    login: no
+    target: "{{iqn}}"
+  become: true
+  delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+  register: result
+
+- name: Delete the iSCSI target
+  shell: source ~/.profile; kubectl delete -f {{ volume_def }}
+  args:
+     executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Unmount the ext4 filesystem
+  mount:
+     name: /mnt/jiva
+     state: absent
+  become: true
+  delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+- name: Confirm the iSCSI target has been deleted
+  shell: source ~/.profile; kubectl get pvc
+  args:
+     executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'pvc' not in result.stdout"
+  delay: 120
+  retries: 6
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
@@ -1,5 +1,5 @@
 ---
-
+test_name: volume_memcheck_test
 volume_def: test-pvc.yaml
 io_duration: 200s
 block_size: 32k

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
@@ -1,0 +1,9 @@
+---
+
+volume_def: test-pvc.yaml
+io_duration: 200s
+block_size: 32k
+py_file: test-mem.py
+count_num: 10000
+mount_point: /mnt/jiva
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -1,9 +1,6 @@
 #Description: Memory resource utilization test with dd workload on OpenEBS JIVA.
-#Before running this ansible playbook make sure to run pre-requisites.yml
-#Variables required to run this test are placed under test-vars.yml, update variables accordingly.
-#Author: Sudarshan Darga
+#Variables required to run this test are placed under memleak-vars.yml, update variables accordingly.
 #Ansible Version: 2.4.3.0
-#Date: 09-03-2018
 - hosts: localhost
 
   vars_files:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -148,7 +148,7 @@
                     flag: "PASS"
          rescue:
              - set_fact:
-               flag: "FAIL"         
+                    flag: "FAIL"         
 
          always:
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -124,23 +124,16 @@
          become: true
          delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
-       - name: Get $HOME of Kube minion for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: kube_minion_home
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
        - block:
              - name: Copy the python script to kubeminion
                copy:
                   src: "{{ py_file }}"
-                  dest: "{{ kube_minion_home.stdout }}"
-               delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+                  dest: "{{ result_kube_home.stdout }}"
+               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
              - name: Run python script for memory usage validation it takes couple of minutes
                shell: python test-mem.py
-               become: true
-               delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+               delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
                register: result
                failed_when: "'Pass' not in result.stdout"
               

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -1,6 +1,6 @@
 #Description: Memory resource utilization test with dd workload on OpenEBS JIVA.
 #Variables required to run this test are placed under memleak-vars.yml, update variables accordingly.
-#Ansible Version: 2.4.3.0
+
 - hosts: localhost
 
   vars_files:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -1,0 +1,166 @@
+#Description: Memory resource utilization test with dd workload on OpenEBS JIVA.
+#Before running this ansible playbook make sure to run pre-requisites.yml
+#Variables required to run this test are placed under test-vars.yml, update variables accordingly.
+#Author: Sudarshan Darga
+#Ansible Version: 2.4.3.0
+#Date: 09-03-2018
+- hosts: localhost
+
+  vars_files:
+     - memleak-vars.yml
+  
+  tasks:
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 120
+         retries: 5
+   
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+       - name: Copy the volume claim to kube master
+         copy:
+           src: "{{ volume_def }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"       
+
+       - name: Create a storage volume via a pvc
+         shell: source ~/.profile; kubectl apply -f "{{ volume_def }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       
+       - name: Confirm volume container is running
+         shell: source ~/.profile; kubectl get pods | grep pvc | grep {{item}} | grep Running | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: result.stdout|int >= 1
+         delay: 30
+         retries: 10
+         with_items:
+           - ctrl
+           - rep
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Get storage ctrl pod name
+         shell: source ~/.profile; kubectl get pods | grep ctrl
+         args:
+           executable: /bin/bash
+         register: ctrl_name
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       
+       - name: Set ctrl pod name to variable
+         set_fact:
+           ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
+
+       - name: Get IP address of ctrl pod
+         shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} | grep IP
+         args:
+           executable: /bin/bash
+         register: ctrl_IP
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Set IP of Pod to variable
+         set_fact:
+           ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
+
+
+       - name: Establish iSCSI session with volume
+         shell: iscsiadm -m discovery -t st -p {{ ctrl_ip }}:3260
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+         register: result
+
+       - name: Store target iqn in variable
+         set_fact:
+           iqn: "{{result.stdout.split(',')[1].split()[1]}}"
+
+       - name: Login to iSCSI target
+         open_iscsi:
+           show_nodes: yes
+           login: yes
+           target: "{{iqn}}"
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+         register: result
+
+       - name: Check device nodes
+         set_fact:
+           scsi_device: "{{result.devicenodes[0]}}"
+
+       - name: Create file system on iSCSI disk
+         filesystem:
+           fstype: ext4
+           dev: "{{scsi_device}}"
+           force: no
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+       - name: Mount device by Label
+         mount:
+           name: "{{mount_point}}"
+           src: "{{scsi_device}}"
+           fstype: ext4
+           opts: discard,_netdev
+           state: mounted
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+       - name: Place data using dd
+         shell: timeout 200s dd if=/dev/urandom of={{mount_point}}/f1 bs=512k count=10000 &
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+       - name: Place data using dd
+         shell: timeout 200s dd if=/dev/urandom of={{mount_point}}/f2 bs=1m count=10000 &
+         become: true
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+
+       - name: Get $HOME of Kube minion for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: kube_minion_home
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+       - block:
+             - name: Copy the python script to kubeminion
+               copy:
+                  src: "{{ py_file }}"
+                  dest: "{{ kube_minion_home.stdout }}"
+               delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+
+             - name: Run python script for memory usage validation it takes couple of minutes
+               shell: python test-mem.py
+               become: true
+               delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+               register: result
+               failed_when: "'Pass' not in result.stdout"
+              
+             - set_fact:
+                    flag: "PASS"
+         rescue:
+             - set_fact:
+               flag: "FAIL"         
+
+         always:
+
+             - include: memleak-cleanup.yml
+               when: clean | bool
+
+             - name: Send slack notification
+               slack:
+                 token: "{{ lookup('env','SLACK_TOKEN') }}"
+                 msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -1,0 +1,26 @@
+from __future__ import division
+import subprocess
+import time, os
+
+cmd_total_mem = "sudo free | awk ' /'Mem'/ {print $2}'"
+
+out = subprocess.Popen(cmd_total_mem,stdout=subprocess.PIPE, shell=True)
+total_mem = out.communicate()
+list = []
+n = 10
+count = 0
+while count < n:
+    count = count + 1
+    cmd_used_mem = "sudo free | awk ' /'Mem'/ {print $3}'"
+    out = subprocess.Popen(cmd_used_mem,stdout=subprocess.PIPE, shell=True)
+    used_mem = out.communicate()
+    mem_in_mb = int(used_mem[0])/1024
+    time.sleep(20)
+    list.append(mem_in_mb)
+print list
+if all(i <= 500 for i in list):
+        print "Pass"
+else:
+        print "Fail"
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -7,16 +7,25 @@ from __future__ import division
 import subprocess
 import time, os
 list = []
-n = 10
+n = 5
 count = 0
+#Obtaining memory consumed by longhorn process from the node where the controller
+#is scheduled.
 while count < n:
     count = count + 1
-    #Obtaining memory consumed using free command from the node where the controller
-    #is scheduled.
-    cmd_used_mem = "sudo free | awk ' /'Mem'/ {print $3}'"
-    out = subprocess.Popen(cmd_used_mem,stdout=subprocess.PIPE, shell=True)
+    cmd_cntrl_name = "kubectl get pod -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
+    out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE, shell=True)
+    cntrl_name = out.communicate()
+    cntrl_pod_name = cntrl_name[0].strip('\n')
+    n = cntrl_pod_name.split('-')
+    lst = n[:len(n)-2]
+    lst.append("con")
+    container_name = "-".join(lst)
+    used_mem_process = "kubectl exec %s -c %s -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
+    out = subprocess.Popen(used_mem_process,stdout=subprocess.PIPE, shell=True)
     used_mem = out.communicate()
     mem_in_mb = int(used_mem[0])/1024
+    print mem_in_mb, "MB"
     time.sleep(20)
     list.append(mem_in_mb)
 print list

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -7,21 +7,20 @@ from __future__ import division
 import subprocess
 import time, os
 list = []
+cmd_cntrl_name = "kubectl get pod -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
+out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE, shell=True)
+cntrl_name = out.communicate()
+cntrl_pod_name = cntrl_name[0].strip('\n')
+n = cntrl_pod_name.split('-')
+lst = n[:len(n)-2]
+lst.append("con")
+container_name = "-".join(lst)
+used_mem_process = "kubectl exec %s -c %s -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
 n = 5
 count = 0
-#Obtaining memory consumed by longhorn process from the node where the controller
-#is scheduled.
+#Obtaining memory consumed by longhorn process from the cntroller pod.
 while count < n:
     count = count + 1
-    cmd_cntrl_name = "kubectl get pod -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
-    out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE, shell=True)
-    cntrl_name = out.communicate()
-    cntrl_pod_name = cntrl_name[0].strip('\n')
-    n = cntrl_pod_name.split('-')
-    lst = n[:len(n)-2]
-    lst.append("con")
-    container_name = "-".join(lst)
-    used_mem_process = "kubectl exec %s -c %s -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
     out = subprocess.Popen(used_mem_process,stdout=subprocess.PIPE, shell=True)
     used_mem = out.communicate()
     mem_in_mb = int(used_mem[0])/1024

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -1,16 +1,18 @@
+#------------------------------------------------------------------------------
+#!/usr/bin/env python
+#description     :Test to verify the memory consumed with sample workloads. 
+#==============================================================================
+
 from __future__ import division
 import subprocess
 import time, os
-
-cmd_total_mem = "sudo free | awk ' /'Mem'/ {print $2}'"
-
-out = subprocess.Popen(cmd_total_mem,stdout=subprocess.PIPE, shell=True)
-total_mem = out.communicate()
 list = []
 n = 10
 count = 0
 while count < n:
     count = count + 1
+    #Obtaining memory consumed using free command from the node where the controller
+    #is scheduled.
     cmd_used_mem = "sudo free | awk ' /'Mem'/ {print $3}'"
     out = subprocess.Popen(cmd_used_mem,stdout=subprocess.PIPE, shell=True)
     used_mem = out.communicate()
@@ -18,6 +20,9 @@ while count < n:
     time.sleep(20)
     list.append(mem_in_mb)
 print list
+# A watermark of 500MB has been set based on benchmark runs with the workload 
+# profile chosen in this test
+# TODO: Identify better mem consumption strategies
 if all(i <= 500 for i in list):
         print "Pass"
 else:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-pvc.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: vut 
+spec:
+  storageClassName: openebs-standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 25G

--- a/e2e/ansible/run-hyperconverged-tests.yml
+++ b/e2e/ansible/run-hyperconverged-tests.yml
@@ -10,6 +10,13 @@
         msg: "{{ ansible_date_time.time }} OPENEBS TESTSUITE: STARTED"
       when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 ###########################################################################################
+# TC NAME: test-k8s-memleak
+# TC DETAILS: Test memory consumption on k8s cluster with openebs storage
+# TC NOTES:
+#
+- include: playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+#
+###########################################################################################
 # TC NAME: test-k8s-percona-mysql-pod
 # TC DETAILS: Deploys percona pod on k8s cluster with openebs storage
 # TC NOTES:           


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR adds the test suite to check the memory consumed by JIVA controller pod with dd workloads.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1342

**Special notes for your reviewer**:
This playbook will run couple of dd workload threads and verify the memory consumed by the OpenEBS JIVA controller pod.

As part of verifying memory usage, getting used memory for interval of 20s for 10 iterations.
A watermark of 500MB has been set based on benchmark runs with the workload profile chosen in this test.
#### TODO: Identify better memory consumption strategies.