### PR TITLE
Adding playbook to test svc deletion

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/create_pvc.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/create_pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: openebsvolume
+spec:
+  storageClassName: openebs-test
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
@@ -1,0 +1,6 @@
+---
+test_name: Delete_PVC_K8s
+
+sc_def: storage-class.yaml
+pvc_def: create_pvc.yaml
+ 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -63,26 +63,16 @@
          args:
            executable: /bin/bash
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-      
-       - name: Check if the svc is created
-         shell: kubectl get svc | grep pvc | grep ctrl
+   
+       - name: Finding PV name 
+         shell: source ~/.profile; kubectl get pv | grep "openebs-test" | awk {'print $1'}
          args:
            executable: /bin/bash
-         register: svc
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}" 
-         until: "'<none>' in svc.stdout"
-         delay: 100
-         retries: 3      
-
-       - name: Getting service name
-         shell: kubectl get svc | grep svc | awk {'print $1'}
-         args:
-           executable: /bin/bash
-         register: svc_name
+         register: pv_name
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
- 
+
        - name: Confirm whether the volume pods are created
-         shell: source ~/.profile; kubectl get pods | grep pvc | grep {{item}}  | wc -l
+         shell: source ~/.profile; kubectl get pods | grep "{{ pv_name.stdout }}" | grep {{item}}  | wc -l
          args:
            executable: /bin/bash
          register: result
@@ -94,6 +84,36 @@
            - rep
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
  
+       - name: Check if one replica is unscheduled
+         shell: kubectl get pods | grep "{{ pv_name.stdout }}" | grep -i "pending" |wc -l
+         args:
+           executable: /bin/bash
+         register: unscheduled_pod
+         until: unscheduled_pod.stdout|int ==1
+         delay: 10
+         retries: 5
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+#Checking if there is svc created by grepping pv name
+      
+       - name: Check if the svc is created
+         shell: kubectl get svc | grep "{{ pv_name.stdout }}" |wc -l
+         args:
+           executable: /bin/bash
+         register: svc
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}" 
+         until: svc.stdout|int ==1
+         delay: 10
+         retries: 3
+         
+#Getting service name by greping the pv name
+       - name: Getting service name
+         shell: kubectl get svc | grep "{{ pv_name.stdout }}" | awk {'print $1'}
+         args:
+           executable: /bin/bash
+         register: svc_name
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+ 
        - name: Delete PVC
          shell: kubectl delete -f "{{ pvc_def }}"
          args:
@@ -102,7 +122,7 @@
        
        - block:
              - name: check if the pods are deleted
-               shell: kubectl get pods | grep pvc | grep {{item}}  | wc -l
+               shell: kubectl get pods | grep "{{pv_name.stdout}}" | grep {{item}}  | wc -l
                args:
                  executable: /bin/bash
                register: pods
@@ -114,6 +134,16 @@
                  - rep
                delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
   
+             - name: Check if the pv is deleted
+               shell: kubectl get pv 
+               args:
+                 executable: /bin/bash
+               register: pv_out
+               until: "'{{ pv_name.stdout }}' not in pv_out.stdout"
+               delay: 10
+               retries: 3
+               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+               
              - name: Check if the svc is deleted
                shell: kubectl get svc | grep "{{ svc_name.stdout }}" | wc -l
                args:
@@ -121,7 +151,7 @@
                register: delete_svc
                delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
                until: delete_svc.stdout|int == 0
-               delay: 30
+               delay: 20
                retries: 5
             
              - set_fact:
@@ -138,10 +168,4 @@
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
  
        
-      # - name: Get the number of OpenEBS replicas in the K8s cluster
-      #   shell: kubectl get pods | grep rep | wc -l
-       #  args:
-        #   executable: /bin/bash
-         #register: replica_count
-         #delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -1,0 +1,147 @@
+- hosts: localhost
+
+  vars_files:
+    - k8s-delete-pvc-vars.yml
+
+  tasks:
+     
+       - name: Get the number of nodes in the cluster
+         shell: kubectl get nodes | grep '<none>' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_out
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Fetch the node count from stdout
+         set_fact:
+            node_count: " {{ node_out.stdout}}"
+
+       - name: Replace the replica count in storage class file
+         replace:
+           path: storage-class.yaml 
+           regexp: 'openebs.io/jiva-replica-count: "1"'
+           replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int+1}}"'
+           backup: yes
+
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Copy the volume claim to k8s master
+         copy:
+           src: "{{ sc_def }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in result.stdout"
+         delay: 120
+         retries: 5
+
+       - name: Create the storage class in K8s master
+         shell: kubectl apply -f "{{ sc_def }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Copy pvc yaml to K8s master
+         copy:
+           src: "{{ pvc_def }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+      
+       - name: Create PVC in k8s cluster
+         shell: kubectl apply -f "{{ pvc_def }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+      
+       - name: Check if the svc is created
+         shell: kubectl get svc | grep pvc | grep ctrl
+         args:
+           executable: /bin/bash
+         register: svc
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}" 
+         until: "'<none>' in svc.stdout"
+         delay: 100
+         retries: 3      
+
+       - name: Getting service name
+         shell: kubectl get svc | grep svc | awk {'print $1'}
+         args:
+           executable: /bin/bash
+         register: svc_name
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+ 
+       - name: Confirm whether the volume pods are created
+         shell: source ~/.profile; kubectl get pods | grep pvc | grep {{item}}  | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: result.stdout|int >= 1
+         delay: 30
+         retries: 10
+         with_items:
+           - ctrl
+           - rep
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+ 
+       - name: Delete PVC
+         shell: kubectl delete -f "{{ pvc_def }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       
+       - block:
+             - name: check if the pods are deleted
+               shell: kubectl get pods | grep pvc | grep {{item}}  | wc -l
+               args:
+                 executable: /bin/bash
+               register: pods
+               until: pods.stdout|int == 0
+               delay: 30
+               retries: 10
+               with_items:
+                 - ctrl
+                 - rep
+               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  
+             - name: Check if the svc is deleted
+               shell: kubectl get svc | grep "{{ svc_name.stdout }}" | wc -l
+               args:
+               executable: /bin/bash
+               register: delete_svc
+               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+               until: delete_svc.stdout|int == 0
+               delay: 30
+               retries: 5
+            
+             - set_fact:
+                   flag: "PASS"
+         rescue:
+             - set_fact:
+                   flag: "FAIL"
+
+         always:
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+ 
+       
+      # - name: Get the number of OpenEBS replicas in the K8s cluster
+      #   shell: kubectl get pods | grep rep | wc -l
+       #  args:
+        #   executable: /bin/bash
+         #register: replica_count
+         #delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -16,6 +16,7 @@
          set_fact:
             node_count: " {{ node_out.stdout}}"
 
+# Attempting to create more replicas than the number of nodes
        - name: Replace the replica count in storage class file
          replace:
            path: storage-class.yaml 
@@ -30,7 +31,8 @@
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Copy the volume claim to k8s master
+#Copying openebs-test storage class yaml file to k8s master
+       - name: Copy the storage classes yaml to k8s master
          copy:
            src: "{{ sc_def }}"
            dest: "{{ result_kube_home.stdout }}"
@@ -46,12 +48,14 @@
          delay: 120
          retries: 5
 
+#create the storage class 'openebs-test'
        - name: Create the storage class in K8s master
          shell: kubectl apply -f "{{ sc_def }}"
          args:
            executable: /bin/bash
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
+#Copying the create_pvc.yaml to k8s master
        - name: Copy pvc yaml to K8s master
          copy:
            src: "{{ pvc_def }}"
@@ -64,6 +68,7 @@
            executable: /bin/bash
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
    
+#Find the PV name by referring the storage class 'openebs-test'
        - name: Finding PV name 
          shell: source ~/.profile; kubectl get pv | grep "openebs-test" | awk {'print $1'}
          args:
@@ -71,6 +76,7 @@
          register: pv_name
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
+#Checking pods using the PV name
        - name: Confirm whether the volume pods are created
          shell: source ~/.profile; kubectl get pods | grep "{{ pv_name.stdout }}" | grep {{item}}  | wc -l
          args:
@@ -83,6 +89,8 @@
            - ctrl
            - rep
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+#Check if there is one replica in pending state
  
        - name: Check if one replica is unscheduled
          shell: kubectl get pods | grep "{{ pv_name.stdout }}" | grep -i "pending" |wc -l

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-test
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, adding a playbook which checks for successful deletion of SVCs and pods during PVC deletion.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #1237 
verifies # https://github.com/openebs/maya/pull/263

**Special notes for your reviewer**:
- This playbook does the below actions.
- Check the number of nodes in K8s cluster.
- Replace replica count in storage class yaml by providing the count greater than the number of nodes.
- Create storage class and replica.
- Check  if it gets created.
- Delete PVC and check if the pods and svc are deleted successfully.