### PR TITLE
helm/openebs: use Helm's namespace flag instead of relying on rbac.namespace in the values.yaml

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.3
+version: 0.5.4
 name: openebs
 appVersion: 0.5.3
 description: Containerized Storage for Containers

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -7,14 +7,14 @@
 ```
 helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
-helm install openebs-charts/openebs
+helm install openebs-charts/openebs --name openebs --namespace openebs
 ```
 
 ## Installing OpenEBS from Chart codebase
 ```
 git clone https://github.com/openebs/openebs.git
 cd openebs/k8s/charts/openebs/
-helm install --name openebs .
+helm install --name openebs --namespace openebs .
 ```
 
 ## Unistalling OpenEBS from Chart codebase
@@ -30,7 +30,7 @@ The following tables lists the configurable parameters of the OpenEBS chart and 
 
 | Parameter                            | Description                                   | Default                           |
 | ------------------------------------ | --------------------------------------------- | --------------------------------- |
-| `rbacEnable`                         | Enable RBAC Resources                         | `true`                            |
+| `rbac.create`                        | Enable RBAC Resources                         | `true`                            |
 | `image.pullPolicy`                   | Container pull policy                         | `IfNotPresent`                    |
 | `apiserver.image`                    | Docker Image for API Server                   | `openebs/m-apiserver`             |
 | `apiserver.imageTag`                 | Docker Image Tag for API Server               | `0.5.3`                           |

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbacEnable }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -12,5 +12,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
-  namespace: {{ .Values.rbac.namespace }}
+  namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-config
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-tunables
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -2,9 +2,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-maya-apiserver
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -2,9 +2,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-provisioner
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -40,9 +37,9 @@ spec:
         #  value: "/home/ubuntu/.kube/config"
         # OPENEBS_NAMESPACE is the namespace that this provisioner will
         # lookup to find maya api service
-{{- if .Values.rbacEnable }}
+{{- if .Values.rbac.create }}
         - name: OPENEBS_NAMESPACE
-          value: "{{ .Values.rbac.namespace }}"
+          value: "{{ .Release.Namespace }}"
 {{- end }}
         - name: NODE_NAME
           valueFrom:

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -3,9 +3,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-grafana
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -3,9 +3,6 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/namespace.yaml
+++ b/k8s/charts/openebs/templates/namespace.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.rbacEnable }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.rbac.namespace }}
-{{- end }}

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -2,9 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "openebs.fullname" . }}-maya-apiservice
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "openebs.fullname" . }}-grafana
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-service
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -2,8 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.operator.name }}
-{{- if .Values.rbacEnable }}
-  namespace: {{ .Values.rbac.namespace }}
-{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -2,9 +2,8 @@
 
 ## If true, create & use RBAC resources
 ##
-rbacEnable: true
 rbac:
-  namespace: "openebs"
+  create: true
 
 operator:
   name: "openebs-maya-operator"


### PR DESCRIPTION
**What this PR does / why we need it**:
`helm install` has a `--namespace` flag that isn't being respected by the current chart. `{{ .Release.Namespace }}` can be used in place of `{{ .rbac.namespace}}`
Also changed the enable rbac flag to `rbac.create` to follow [kubernetes/charts](https://github.com/kubernetes/charts).