### PR TITLE
Include resiliency test suite in OpenEBS e2e (Test: periodic controller failures)

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/chaoskube.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/chaoskube.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: chaoskube
+    spec:
+      serviceAccountName: chaoskube
+      containers:
+      - name: chaoskube
+        image: quay.io/linki/chaoskube:v0.8.0
+        args:
+        # Provided below are possible flags to set in chaoskube.
+        # This deployment will create a vanilla chaoskube w/o policies
+        # which will be configured by a test playbook
+       
+        # kill a pod every 10 minutes
+        #- --interval=10m
+        
+        # only target pods in the test environment
+        #- --labels=openebs/controller=jiva-controller
+        
+        # only consider pods with this annotation
+        #- --annotations=chaos.alpha.kubernetes.io/enabled=true
+        
+        # exclude all pods in the kube-system namespace
+        #- --namespaces=!kube-system
+        
+        # don't kill anything on weekends
+        #- --excluded-weekdays=Sat,Sun
+        
+        # don't kill anything during the night or at lunchtime
+        #- --excluded-times-of-day=22:00-08:00,11:00-13:00
+        
+        # don't kill anything as a joke or on christmas eve
+        #- --excluded-days-of-year=Apr1,Dec24
+        
+        # let's make sure we all agree on what the above times mean
+        #- --timezone=UTC
+        
+        # terminate pods for real: this disables dry-run mode which is on by default
+        #- --no-dry-run
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaoskube
+  labels:
+    app: chaoskube

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/percona.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/percona.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+            - mountPath: /sql-test.sh
+              subPath: sql-test.sh
+              name: sqltest-configmap
+          livenessProbe: 
+            exec: 
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+        - name: sqltest-configmap
+          configMap: 
+            name: sqltest
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-percona
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/rbac.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chaoskube
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list", "delete"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chaoskube
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: chaoskube
+subjects:
+- kind: ServiceAccount
+  name: chaoskube
+  namespace: default

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/sql-test.sh
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/sql-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE Inventory;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" Inventory
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" Inventory
+mysql -uroot -pk8sDem0 -e "DROP DATABASE Inventory;"

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -1,0 +1,64 @@
+---
+- name: Delete percona mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods -l name=percona 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 120 
+  retries: 6
+
+- name: Remove the percona liveness check config map 
+  shell: source ~/.profile; kubectl delete cm sqltest 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'configmap' and 'deleted' not in result.stdout"
+
+- name: Delete the chaoskube infrastructure
+  shell: source ~/.profile; kubectl delete -f {{ item }}
+  args: 
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items: "{{ chaoskube_files }}"
+
+- name: Confirm that the chaoskube pod has been deleted
+  shell: source ~/.profile; kubectl get pods -l app=chaoskube
+  args: 
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'chaoskube' not in result.stdout"
+
+- name: Confirm the chaoskube sa has been deleted
+  shell: >
+    source ~/.profile; 
+    kubectl get sa --no-headers -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'chaoskube' in result.stdout"
+
+- name: Confirm the chaoskube clusterrolebinding has been deleted
+  shell: >
+    source ~/.profile;
+    kubectl get clusterrolebinding --no-headers -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'chaoskube' in result.stdout"
+
+
+  
+ 
+ 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
@@ -1,0 +1,20 @@
+---
+test_name: test_ctrl_failure
+
+percona_files: 
+  - percona.yaml
+  - sql-test.sh
+
+chaoskube_files:
+  - rbac.yaml
+  - chaoskube.yaml 
+
+chaos_duration: 120
+
+chaos_interval: 20 
+
+test_pod_regex: maya*|openebs*|pvc*|percona*|chaos*
+
+test_log_path: setup/logs/controller_failure_test.log
+
+

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -1,0 +1,210 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - test-ctrl-failure-vars.yml 
+ 
+  tasks:
+   - block:
+
+       ###################################################
+       #                PREPARE FOR TEST                 #
+       # (Place artifacts in kubemaster, start logger &  # 
+       # confirm OpenEBS operator is ready for requests. #
+       ###################################################
+
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Copy the percona spec and liveness script to kubemaster 
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items: "{{ percona_files }}"
+
+       - name: Copy the chaoskube specs to kubemaster  
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items: "{{ chaoskube_files }}"
+
+       - name: Start the log aggregator to capture test pod logs
+         shell: >
+           source ~/.profile;
+           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
+         until: "'Running' in result.stdout"
+         delay: 120 
+         retries: 5
+      
+       ####################################################
+       #          SETUP FAULT-INJECTION ENV               #
+       # (Setup chaoskube deployment with an empty policy,#
+       # deploy percona w/ a liveness check for DB writes)# 
+       ####################################################
+
+       - name: Setup the chaoskube infrastructure
+         shell: source ~/.profile; kubectl apply -f {{ item }} 
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         with_items: "{{ chaoskube_files }}"
+
+       - name: Confirm that the chaoskube deployment is running 
+         shell: source ~/.profile; kubectl get pods --no-headers -l app=chaoskube
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_chaoskube 
+         until: "'chaoskube' and 'Running' in result_chaoskube.stdout"
+         delay: 120
+         retries: 15        
+
+       - name: Create a configmap with the liveness sql script 
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result 
+         failed_when: "'configmap' and 'created' not in result.stdout"
+
+       - name: Create percona deployment with OpenEBS storage
+         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Wait for 120s to ensure liveness check starts 
+         wait_for:
+           timeout: 120
+         
+       - name: Confirm percona pod is running
+         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 120 
+         retries: 15
+
+       - name: Set chaoskube pod name to variable 
+         set_fact: 
+           chaospod: "{{ result_chaoskube.stdout_lines[0].split()[0] }}"
+
+       - name: Get the name of the volume ctrl deployment 
+         shell: > 
+           source ~/.profile; kubectl get deployments 
+           -l openebs/controller=jiva-controller --no-headers
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_deploy
+
+       - name: Set the ctrl deployment name to variable 
+         set_fact: 
+           ctrl_deploy: "{{ result_deploy.stdout_lines[0].split()[0] }}"
+
+       ########################################################
+       #        INJECT FAULTS FOR SPECIFIED PERIOD            #
+       # (Obtain begin marker before fault-inject(FI),do ctrl # 
+       # failures, verify successful FI via end marker)       # 
+       ########################################################
+
+       - name: Get the resourceVersion of the controller deployment
+         shell: >
+           source ~/.profile; kubectl get deploy 
+           {{ ctrl_deploy }} -o yaml | grep resourceVersion
+           | awk '{print $2}' | sed 's|"||g'
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: rv_bef          
+ 
+       - name: Initiate periodic controller failures from chaoskube
+         shell: >
+           source ~/.profile; kubectl exec {{ chaospod }}  
+           -- timeout -t {{ chaos_duration }} chaoskube 
+           --labels 'openebs/controller=jiva-controller'
+           --no-dry-run --interval={{ chaos_interval }}s 
+           --debug
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: chaos_result
+         ignore_errors: true 
+
+       - name: Get the resourceVersion of the controller deployment
+         shell: >
+           source ~/.profile; kubectl get deploy 
+           {{ ctrl_deploy }} -o yaml | grep resourceVersion
+           | awk '{print $2}' | sed 's|"||g'
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: rv_aft    
+ 
+       - name: Compare resourceVersions of controller deployments 
+         debug: 
+           msg: "Verified controller pods were restarted by chaoskube"
+         failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"
+
+       ########################################################
+       #        VERIFY RESILINCY/FAULT-TOLERATION             #
+       # (Confirm liveness checks on percona are successful & #
+       # pod is still in running state)                       #
+       ########################################################
+
+       - name: Confirm percona application is still running
+         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 120 
+         retries: 15
+
+       ########################################################
+       #                        CLEANUP                       #			      
+       # (Tear down application, liveness configmap as well as#
+       # the FI (chaoskube) infrastructure. Also stop logger) # 
+       ########################################################
+
+       - include: test-ctrl-failure-cleanup.yml
+         when: clean | bool
+
+       - name: Terminate the log aggregator
+         shell: source ~/.profile; killall stern
+         args:
+           executable: /bin/bash 
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack: 
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Includes a resiliency test suite into OpenEBS e2e. This commit adds the first test - Periodic failures of OpenEBS volume controller

- The failures are injected by the tool *chaoskube* which takes label based filters & failure interval as args and perform periodic pod kills

- The fault-injection is confirmed by `resourceVersion` updates on the ctrl deployment

- The volume resiliency is tracked via `liveness probe` on the application deployment, with the probe performing continuous writes on the volume (In this case, DB writes are performed on percona). This probe is implemented via a shell script which is mounted into percona deployment as a `configmap`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: (partially-fixes) #1048 (adds a pilot test)

**Special notes for your reviewer**:

- The failures are "periodic" & not "random" - So, it is more a fault-injection/resiliency test than "chaos". Actual chaos engineering will take place in staging with long-running setups with greater load. 

- chaoskube is deployed w/ a "vanilla" policy or *dry-run* mode ,i.e., with no pre-configuration. The test invokes the chaoskube binary within the pod and triggers the fault-injection with desired args (such as pod labels, kill intervals etc.,) - this is more convenient compared to burning it into the ENV of chaoskube deployment

- The "failure_duration" for which the pod kills occur is controlled using the `timeout` binary. This sends a SIGTERM to the chaoskube process once duration elapses.

- Currently, the application (percona) & chaoskube deployment YAMLs are placed in the testcase folder - these will be moved to a separate location once their use is tested across runs/improvements are made. They will be common to similar resiliency tests.