### PR TITLE
Kill OpenEBS Replica pods (meet quorum) under loaded conditions and verify recovery

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
@@ -1,0 +1,66 @@
+---
+- name: Get the resourceVersion of the replica deployment
+  shell: >
+    source ~/.profile; kubectl get deploy 
+    {{ replica_deploy }} -o yaml | grep resourceVersion
+    | awk '{print $2}' | sed 's|"||g'
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: rv_bef
+
+- name: Get replica pod name
+  shell: source ~/.profile; kubectl get pods | grep rep | shuf -n1 | awk 'FNR == 1 {print}' | awk {'print $1'} 
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Kill replica pod
+  shell: source ~/.profile; kubectl delete pod {{ result.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Get Controller SVC IP
+  shell: source ~/.profile; kubectl get svc | grep ctrl | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  register: SVC
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Check if replica is rebuilded 
+  shell: curl GET http://{{ SVC.stdout }}:9501/v1/replicas | grep createTypes | jq -r '.data[].mode' | grep 'RW'
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: "result.stdout_lines | length  == 3" 
+  delay: 60
+  retries: 10
+
+- name: Verify replica pod status
+  shell: source ~/.profile; kubectl get pods -l openebs/replica=jiva-replica --no-headers | awk '{print $3}' | grep 'Running'
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: "result.stdout_lines | length  == 3"
+
+- name: Get the resourceVersion of the replica deployment
+  shell: >
+    source ~/.profile; kubectl get deploy 
+    {{ replica_deploy }} -o yaml | grep resourceVersion
+    | awk '{print $2}' | sed 's|"||g'
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: rv_aft    
+
+- name: Compare resourceVersions of replica deployments 
+  debug: 
+    msg: "Verified replica pods were restarted by fault injection"
+  failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"
+  
+  
+

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/percona.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/percona.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+            - mountPath: /sql-test.sh
+              subPath: sql-test.sh
+              name: sqltest-configmap
+          livenessProbe: 
+            exec: 
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+        - name: sqltest-configmap
+          configMap: 
+            name: sqltest
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: replica-quorum-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/replica-quorum-sc.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/replica-quorum-sc.yaml
@@ -1,0 +1,11 @@
+# Define a storage classes supported by OpenEBS
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: replica-quorum-sc
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/sql-test.sh
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/sql-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE Inventory;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" Inventory
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" Inventory
+mysql -uroot -pk8sDem0 -e "DROP DATABASE Inventory;"

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
@@ -1,0 +1,35 @@
+---
+- name: Delete percona mysql pod 
+  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Confirm percona pod has been deleted
+  shell: source ~/.profile; kubectl get pods -l name=percona 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'percona' not in result.stdout"
+  delay: 120 
+  retries: 6
+
+- name: Remove the percona liveness check config map 
+  shell: source ~/.profile; kubectl delete cm sqltest 
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'configmap' and 'deleted' not in result.stdout"
+
+- name: Remove the replica-quorum-sc storage class
+  shell: source ~/.profile; kubectl delete sc replica-quorum-sc
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+  
+ 
+ 

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-vars.yml
@@ -1,0 +1,18 @@
+---
+test_name: test_replica_quorum_failure
+
+percona_files: 
+  - percona.yaml
+  - sql-test.sh
+
+interval: 3
+
+fault_injection_file: inject_replica_quorum_failure.yml
+
+storage_class_file: replica-quorum-sc.yaml 
+
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: setup/logs/replica_quorum_failure_test.log
+
+

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
@@ -1,0 +1,171 @@
+- hosts: localhost
+ 
+  vars_files: 
+    - test-replica-quorum-failure-vars.yml 
+ 
+  tasks:
+   - block:
+
+       ###################################################
+       #                PREPARE FOR TEST                 #
+       # (Place artifacts in kubemaster, start logger &  # 
+       # confirm OpenEBS operator is ready for requests. #
+       ###################################################
+
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args: 
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Copy the percona spec and liveness script to kubemaster 
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items: "{{ percona_files }}"
+
+       - name: Copy the fault injection specs to kubemaster  
+         copy:
+           src: "{{ fault_injection_file }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Copy the storage class specs to kubemaster  
+         copy:
+           src: "{{ storage_class_file }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Start the log aggregator to capture test pod logs
+         shell: >
+           source ~/.profile;
+           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check whether maya-apiserver pod is deployed
+         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
+         args: 
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
+         until: "'Running' in result.stdout"
+         delay: 120 
+         retries: 5
+      
+       ####################################################
+       #          SETUP FAULT-INJECTION ENV               #
+       # (Setup chaoskube deployment with an empty policy,#
+       # deploy percona w/ a liveness check for DB writes)# 
+       ####################################################
+
+       - name: Setup the storage class
+         shell: source ~/.profile; kubectl apply -f {{ storage_class_file }} 
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Create a configmap with the liveness sql script 
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result 
+         failed_when: "'configmap' and 'created' not in result.stdout"
+
+       - name: Create percona deployment with OpenEBS storage
+         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Wait for 120s to ensure liveness check starts 
+         wait_for:
+           timeout: 120
+         
+       - name: Confirm percona pod is running
+         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 120 
+         retries: 15
+
+       - name: Get the name of the volume replica deployment 
+         shell: > 
+           source ~/.profile; kubectl get deployments 
+           -l openebs/replica=jiva-replica --no-headers
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result_deploy
+
+       - name: Set the replica deployment name to variable 
+         set_fact: 
+           replica_deploy: "{{ result_deploy.stdout_lines[0].split()[0] }}"
+
+       ########################################################
+       #        INJECT FAULTS FOR SPECIFIED PERIOD            #
+       # (Obtain begin marker before fault-inject(FI),do ctrl # 
+       # failures, verify successful FI via end marker)       # 
+       ########################################################
+       - name: Populate the iterator with the values to loop
+         shell: >
+           shuf -i 1-100 -n {{interval}}
+         args:
+           executable: /bin/bash
+         register: iterator
+
+       - include: inject_replica_quorum_failure.yml
+         with_items: "{{ iterator.stdout_lines }}"
+
+       ########################################################
+       #        VERIFY RESILINCY/FAULT-TOLERATION             #
+       # (Confirm liveness checks on percona are successful & #
+       # pod is still in running state)                       #
+       ########################################################
+
+       - name: Confirm percona application is still running
+         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
+         args: 
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: "'percona' and 'Running' in result.stdout"
+         delay: 120 
+         retries: 15
+
+       ########################################################
+       #                        CLEANUP                       #			      
+       # (Tear down application, liveness configmap as well as#
+       # the FI (chaoskube) infrastructure. Also stop logger) # 
+       ########################################################
+
+       - include: test-replica-quorum-failure-cleanup.yml
+         when: clean | bool
+
+       - name: Terminate the log aggregator
+         shell: source ~/.profile; killall stern
+         args:
+           executable: /bin/bash 
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
+
+       - set_fact:
+           flag: "Pass"
+
+     rescue: 
+       - set_fact: 
+           flag: "Fail"
+
+     always:
+       - name: Send slack notification
+         slack: 
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
1. Involves setting up 3 node cluster in CI
2. Updating storage class to create 3 replicas
3. Generate & monitor load on the OpenEBS volume
4. Use fault injection to kill one of the replica pods
5. Verify iSCSI connections/load is intact
6. Verify replica is recreated & is added back in RW mode
7. Repeat steps 4-6 and check for resourceVersion of deployment on subsequent intervals specified in the vars file.
8. End test with success if quorum is met and all replicas are in RW state.
9. End test with failure if quorum is not met or the RW states of the replicas do not match the replica count.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # (Partial Fix for Issue #1048)

**Special notes for your reviewer**:
Signed-off-by: yudaykiran <udaykiran.y@gmail.com>