### PR TITLE
script for creating cluster and deploy openebs in azure

### DIFF
--- a/e2e/scripts/Readme.md
+++ b/e2e/scripts/Readme.md
@@ -55,18 +55,9 @@ To verify the Created cluster run the following command.
 ```
 To verify the successful deployment of OpenEBS run the following command.
 ```
-    devops@Azure:~/openebs/k8s$ kubectl get pods --all-namespaces
+    devops@Azure:~/openebs/k8s$ kubectl get pods 
     NAMESPACE     NAME                                                            READY     STATUS    RESTARTS   AGE
     default       maya-apiserver-69f9db69-gfh4x                                   1/1       Running   0          17h
     default       openebs-provisioner-77cb47986c-4nghb                            1/1       Running   0          17h
-    kube-system   heapster-669488959c-wj76s                                       2/2       Running   0          18h
-    kube-system   kube-dns-v20-5bf84586f4-72vmh                                   3/3       Running   0          18h
-    kube-system   kube-dns-v20-5bf84586f4-tp9rj                                   3/3       Running   0          18h
-    kube-system   kube-proxy-l28s4                                                1/1       Running   0          18h
-    kube-system   kube-proxy-s2mhj                                                1/1       Running   0          18h
-    kube-system   kube-svc-redirect-4nfjk                                         1/1       Running   0          18h
-    kube-system   kube-svc-redirect-mvs5g                                         1/1       Running   0          18h
-    kube-system   kubernetes-dashboard-69bb965b88-t8x5v                           1/1       Running   0          18h
-    kube-system   tunnelfront-8d78b6c97-kvwsn                                     1/1       Running   0          18h
 ```
 

--- a/e2e/scripts/Readme.md
+++ b/e2e/scripts/Readme.md
@@ -1,6 +1,6 @@
 ## OpenEBS on AZURE - Deployment using Shell script
 
-The purpose of this user guide is to provide the instructions to set up a Kubernetes cluster on AWS (Amazon Web Services) and have OpenEBS running in hyperconverged mode.
+The purpose of this user guide is to provide the instructions to set up a Kubernetes cluster on AKS and have OpenEBS running in hyperconverged mode.
 
 ### Prerequisites
 

--- a/e2e/scripts/Readme.md
+++ b/e2e/scripts/Readme.md
@@ -34,9 +34,16 @@ This script require the AZURE credentials to access AKS services.
 ```
 **NOTE:** Node count will be the number of nodes, and Node vm size is the size of the virtual machine. For details of node vm size goto the following URL  https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
 
-Create a cluster on AKS
+### Create a cluster on AKS
 
-Run the  oebs_aks.sh to create AKS cluster and deploy OpenEBS. The above script will installs the Azure CLI, Kubectl,  iSCSI packages on Kubelet container and it deploy OpenEBS operator and OpenEBS storage class files. And It creates the Log file in the name of oebs_aks.log.
+Run the oebs_aks.sh to create a Kubernetes Cluster on AKS and deploy OpenEBS.
+
+The script will first install the following prerequisites:
+- Azure CLI
+- kubectl
+Once the Kubernetes Cluster is created, the script goes ahead and installs the ISCSI packages in the kubelet container of all worker nodes.
+
+Finally the script deploys OpenEBS operator and OpenEBS Storage Classes on the cluster
 
 To verify the resource group run the below command.
 ```

--- a/e2e/scripts/Readme.md
+++ b/e2e/scripts/Readme.md
@@ -1,0 +1,65 @@
+## OpenEBS on AZURE - Deployment using Shell script
+
+The purpose of this user guide is to provide the instructions to set up a Kubernetes cluster on AWS (Amazon Web Services) and have OpenEBS running in hyperconverged mode.
+
+### Prerequisites
+
+- An Azure account
+
+Download the script file called oebs_aks.sh.
+```
+    $ mkdir -p openebs
+    $ cd openebs
+    $ wget https://raw.githubusercontent.com/openebs/openebs/master/e2e/scripts/oebs_aks.sh
+    $ chmod +x oebs_aks.sh
+```
+#### Updating .profile file:
+
+This script require the AZURE credentials to access AKS services.
+
+- Add path /usr/local/bin to the PATH environment variable.
+```
+    $ vim ~/.profile
+    
+    # Add the AKS credentials as environment variables in .profile
+    export USERNAME="<username>"
+    export PASSWORD="<password>"
+    export NODE_COUNT="<node count>"
+    export NODE_VM_SIZE="<node vm size>"
+    
+    # Add /usr/local/bin to PATH
+    PATH="$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH"
+    
+    $ source ~/.profile
+```
+**NOTE:** Node count will be the number of nodes, and Node vm size is the size of the virtual machine. For details of node vm size goto the following URL  https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs
+
+Create a cluster on AKS
+
+Run the  oebs_aks.sh to create AKS cluster and deploy OpenEBS. The above script will installs the Azure CLI, Kubectl,  iSCSI packages on Kubelet container and it deploy OpenEBS operator and OpenEBS storage class files. And It creates the Log file in the name of oebs_aks.log.
+
+To verify the resource group run the below command.
+```
+    devops@Azure:~$ az group list
+```
+To verify the Created cluster run the following command.
+```
+    devops@Azure:~$ az aks list -g <resource group name>
+```
+To verify the successful deployment of OpenEBS run the following command.
+```
+    devops@Azure:~/openebs/k8s$ kubectl get pods --all-namespaces
+    NAMESPACE     NAME                                                            READY     STATUS    RESTARTS   AGE
+    default       maya-apiserver-69f9db69-gfh4x                                   1/1       Running   0          17h
+    default       openebs-provisioner-77cb47986c-4nghb                            1/1       Running   0          17h
+    kube-system   heapster-669488959c-wj76s                                       2/2       Running   0          18h
+    kube-system   kube-dns-v20-5bf84586f4-72vmh                                   3/3       Running   0          18h
+    kube-system   kube-dns-v20-5bf84586f4-tp9rj                                   3/3       Running   0          18h
+    kube-system   kube-proxy-l28s4                                                1/1       Running   0          18h
+    kube-system   kube-proxy-s2mhj                                                1/1       Running   0          18h
+    kube-system   kube-svc-redirect-4nfjk                                         1/1       Running   0          18h
+    kube-system   kube-svc-redirect-mvs5g                                         1/1       Running   0          18h
+    kube-system   kubernetes-dashboard-69bb965b88-t8x5v                           1/1       Running   0          18h
+    kube-system   tunnelfront-8d78b6c97-kvwsn                                     1/1       Running   0          18h
+```
+

--- a/e2e/scripts/oebs_aks.sh
+++ b/e2e/scripts/oebs_aks.sh
@@ -40,8 +40,6 @@ function azure_login(){
      sleep 1
   else
      echo "Logging into Azure Account"
-     username=$(echo $USERNAME)
-     password=$(echo $PASSWORD)
      login=$(az login -u ${username} -p ${password})
      a=$(az account show | grep name | awk 'FNR == 2 {print $2}' | cut -d '"' -f2)
      echo "Logged in Account name :" ${a}

--- a/e2e/scripts/oebs_aks.sh
+++ b/e2e/scripts/oebs_aks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-node_count=$(echo $NODE COUNT) #--- number of nodes for the Azure kubernetes cluster
-node_vm_size=$(echo $NODE VM SIZE) #--- VM size for the Azure Kubernetes  cluster
+node_count=$(echo $NODE_COUNT) #--- number of nodes for the Azure kubernetes cluster
+node_vm_size=$(echo $NODE_VM_SIZE) #--- VM size for the Azure Kubernetes  cluster
 username=$(echo $USERNAME) #--- Username of the azure account 
 password=$(echo $PASSWORD) #--- Password for the azure account
 

--- a/e2e/scripts/oebs_aks.sh
+++ b/e2e/scripts/oebs_aks.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+node_count="2" #--- number of nodes for the Azure kubernetes cluster
+node_vm_size="Standard_A2_v2" #--- VM size for the Azure Kubernetes  cluster
+name=$(echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2)
+
+echo "Installing Prerequisites..."
+sudo apt-get update
+
+# Installing Azure CLI
+function azure_cli_installed(){
+  IS_AZ_INSTALLED=$(which az >> /dev/null 2>&1; echo $?)
+  if [ $IS_AZ_INSTALLED -eq 0 ]; then
+     echo "Azure CLI already Installed, Skipping"
+     az=$(az --version | grep azure-cli | head -1 | cut -d ' ' -f2)
+     echo "Installed Azure CLI Version:" ${az}
+  else
+     echo "Installing Python Packages"
+     python=$(sudo apt-get install -y python-pip > oebs_aks.log)
+     version=$(python --version)
+     echo ${version}
+     sleep 1
+     echo "Installing Azure CLI" |& tee -a oebs_aks.log
+     curl -L https://aka.ms/InstallAzureCli | bash >> oebs_aks.log
+     az=$(az --version | grep azure-cli | head -1 | cut -d ' ' -f2)
+     echo "Installed Azure CLI Version:" ${az}
+  fi
+}
+
+# Login into Azure using Account Credentials
+function azure_login(){
+  IS_AZURE_LOGIN=$(az account show >> /dev/null 2>&1; echo $?)
+  if [ $IS_AZURE_LOGIN -eq 0 ]; then
+     echo "Already Logged in, Skipping"
+     a=$(az account show | grep name | awk 'FNR == 2 {print $2}' | cut -d '"' -f2)
+     echo "Logged in Account name :" ${a}
+     sleep 1
+  else
+     echo "Logging into Azure Account"
+     username=$(echo $USERNAME)
+     password=$(echo $PASSWORD)
+     login=$(az login -u ${username} -p ${password})
+     a=$(az account show | grep name | awk 'FNR == 2 {print $2}' | cut -d '"' -f2)
+     echo "Logged in Account name :" ${a}
+  fi
+}
+
+# Install kubernetes newest version >> aks-cluster.log
+function kubectl_installed(){
+  IS_KUBECTL_INSTALLED=$(which kubectl >> /dev/null 2>&1; echo $? )
+  if [ $IS_KUBECTL_INSTALLED -eq 0 ]; then
+     echo "Kubectl already Installed, Skipping"
+     sleep 1
+  else
+     echo "Installing Kubectl newest version" |& tee -a oebs_aks.log
+     az aks install-cli --install-location=./kubectl && sudo mv kubectl /usr/local/bin/kubectl >> oebs_aks.log
+  fi
+ }
+
+#Creating Resource Group
+function create_resource_group(){
+  echo "Creating Resource Group" |& tee -a oebs_aks.log
+  group=$(az group create -l eastus -n aks-openebs-${name}-rg >> oebs_aks.log)
+  group_list=$(az group list | grep name | awk '{print $2}' | cut -d '"' -f2 | grep ${name})
+  echo "Resource Group created in the name of :" ${group_list}
+}
+
+#Create AKS cluster
+function create_cluster(){
+  echo "Creating AKS Cluster....." |& tee -a oebs_aks.log
+  cluster=$(az aks create -n aks-openebs-${name}-cluster  -g ${group_list} --node-count ${node_count} --node-vm-size ${node_vm_size} --generate-ssh-key >> oebs_aks.log)
+  cluster_list=$( az aks list -g ${group_list} | grep name | awk '{print $2}' | cut -d '"' -f2 | grep ${name})
+  echo "AKS cluster created in the name of:" ${cluster_list}
+  #Connect to the AKS cluster
+  echo "Getting credentials to connect aks cluster " |& tee -a oebs_aks.log
+  az aks get-credentials -g ${group_list} -n ${cluster_list} >> oebs_aks.log
+ }
+
+#Create the Network Public IP Address
+function create_public_ip(){
+	 echo "Creating Public IP....." |& tee -a oebs_aks.log
+	 MC_group_list=$(az group list | grep name | grep MC | awk '{print $2}' | cut -d '"' -f2 | grep ${name})
+	 max=$(kubectl get nodes | grep -v 'NAME' | wc -l)
+	 for (( i=0; i < $max; i++ ))
+	 do
+	   ip=$(az network public-ip create --resource-group ${MC_group_list} --name ip_${i}_${name} --allocation-method static >> oebs_aks.log)
+	 done
+}
+
+#Associate the Public IP address to the Network Interface
+function associate_ip(){
+    echo "Associating Public IP to the Network Interface..." |& tee -a oebs_aks.log
+    x=0
+    nic_list=$(az network nic list -g ${MC_group_list} | grep name | grep nic | awk '{print $2}' | cut -d '"' -f2)
+	for j in $nic_list
+    do
+       associate=$(az network nic ip-config update -g ${MC_group_list} --nic-name ${j} -n "ipconfig1" --public-ip-address ip_${x}_${name} >> oebs_aks.log)
+       x=$((x+1))
+    done
+}
+
+#SSH into nodes and install iscsi in kubelet container
+function iscsi_install(){
+ echo "Installing iSCSI packages" | & tee -a oebs_aks.log
+    ip_address=$(az network public-ip list -g ${MC_group_list} | grep ipAddress | awk '{print $2}' | cut -d '"' -f2 )
+    for k in $ip_address
+    do
+      container_id=$(ssh azureuser@"${k}" '( sudo docker ps  | grep "hyperkube kubele" )'| awk '{print $1}')
+      ssh azureuser@"${k}" "( sudo docker exec $container_id /bin/bash -c \"rm -rf /var/lib/dpkg/statoverride && apt-get update && apt-get install -y open-iscsi\" )"
+    done
+	sleep 1
+}
+
+# Apply OpenEBS Operator to the kubernetes cluster
+function openebs_operator(){
+  echo "Deploying OpenEBS operator... " |& tee -a oebs_aks.log
+  sleep 1
+  kubectl create -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml >> oebs_aks.log
+  # Apply OpenBES Storage Classes
+  echo "Deploying OpenEBS Storage classes" |& tee -a oebs_aks.log
+  sleep 1
+  kubectl create -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml >> oebs_aks.log
+ }
+
+# Checking status of OpenEBS Pods 
+function pod_status(){
+  echo "Checking Pod status... " |& tee -a oebs_aks.log
+  sleep 20
+  kubectl get pods --all-namespaces |& tee -a oebs_aks.log
+}
+
+
+azure_cli_installed
+azure_login
+create_resource_group
+create_cluster
+kubectl_installed
+create_public_ip
+associate_ip
+iscsi_install
+openebs_operator
+pod_status
+

--- a/e2e/scripts/oebs_aks.sh
+++ b/e2e/scripts/oebs_aks.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-node_count="2" #--- number of nodes for the Azure kubernetes cluster
-node_vm_size="Standard_A2_v2" #--- VM size for the Azure Kubernetes  cluster
+node_count=$(echo $NODE COUNT) #--- number of nodes for the Azure kubernetes cluster
+node_vm_size=$(echo $NODE VM SIZE) #--- VM size for the Azure Kubernetes  cluster
+username=$(echo $USERNAME) #--- Username of the azure account 
+password=$(echo $PASSWORD) #--- Password for the azure account
+
 name=$(echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2)
 
 echo "Installing Prerequisites..."


### PR DESCRIPTION
Signed-off-by: nsathyaseelan

**What this PR does / why we need it**:
 This PR will gives the script for creatng aks cluster and setup OpenEBS in Azure

**Special notes for your reviewer**:
While running the above script it gives the below output and it creates the log file in the name of oebs_aks.log

output : 
```
Installing Prerequisites...
Get:1 http://security.ubuntu.com/ubuntu xenial-security InRelease [102 kB]
Hit:2 http://archive.ubuntu.com/ubuntu xenial InRelease
Hit:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease
Fetched 102 kB in 2s (42.9 kB/s)
Reading package lists... Done
Installing Azure CLI
Installed Azure CLI Version: (2.0.29)
Logging into Azure Account
Logged in Account name : admin@*****************
Creating Resource Group
Resource Group created in the name of : aks-openebs-zp3pvh35pf-rg
Creating AKS Cluster.....
AKS cluster created in the name of: aks-openebs-zp3pvh35pf-cluster
Getting credentials to connect aks cluster
Kubectl already Installed, Skipping
Creating Public IP.....
Associating Public IP to the Network Interface...
Installing iSCSI packages
The authenticity of host '13.90.224.116 (13.90.224.116)' can't be established.
ECDSA key fingerprint is SHA256:YYaLJOEPUdRn50hlIs0+0qhOZMu6buaVD4ui5ybVI6c.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '13.90.224.116' (ECDSA) to the list of known hosts.
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Get:3 http://deb.debian.org jessie Release.gpg [2434 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [643 kB]
Get:6 http://deb.debian.org jessie-updates/main amd64 Packages [23.1 kB]
Get:7 http://deb.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 10.1 MB in 33s (299 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  open-iscsi
0 upgraded, 1 newly installed, 0 to remove and 39 not upgraded.
Need to get 296 kB of archives.
After this operation, 2052 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian/ jessie/main open-iscsi amd64 2.0.873+git0.3b4b4500-8+deb8u2 [296 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 296 kB in 5s (49.7 kB/s)
Selecting previously unselected package open-iscsi.
(Reading database ... 14826 files and directories currently installed.)
Preparing to unpack .../open-iscsi_2.0.873+git0.3b4b4500-8+deb8u2_amd64.deb ...
Unpacking open-iscsi (2.0.873+git0.3b4b4500-8+deb8u2) ...
Processing triggers for systemd (215-17+deb8u7) ...
Running in chroot, ignoring request.
Setting up open-iscsi (2.0.873+git0.3b4b4500-8+deb8u2) ...
invoke-rc.d: policy-rc.d denied execution of start.
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Running in chroot, ignoring request.
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Running in chroot, ignoring request.
Processing triggers for systemd (215-17+deb8u7) ...
Running in chroot, ignoring request.
The authenticity of host '13.82.92.161 (13.82.92.161)' can't be established.
ECDSA key fingerprint is SHA256:3Tfg1N+lngSpzO3zKiE/eib8i0vNNYIKaOacHKW2h9w.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '13.82.92.161' (ECDSA) to the list of known hosts.
Get:1 http://security.debian.org jessie/updates InRelease [63.1 kB]
Ign http://deb.debian.org jessie InRelease
Get:2 http://deb.debian.org jessie-updates InRelease [145 kB]
Get:3 http://deb.debian.org jessie Release.gpg [2434 B]
Get:4 http://deb.debian.org jessie Release [148 kB]
Get:5 http://security.debian.org jessie/updates/main amd64 Packages [643 kB]
Get:6 http://deb.debian.org jessie-updates/main amd64 Packages [23.1 kB]
Get:7 http://deb.debian.org jessie/main amd64 Packages [9064 kB]
Fetched 10.1 MB in 38s (265 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  open-iscsi
0 upgraded, 1 newly installed, 0 to remove and 39 not upgraded.
Need to get 296 kB of archives.
After this operation, 2052 kB of additional disk space will be used.
Get:1 http://deb.debian.org/debian/ jessie/main open-iscsi amd64 2.0.873+git0.3b4b4500-8+deb8u2 [296 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 296 kB in 6s (48.5 kB/s)
Selecting previously unselected package open-iscsi.
(Reading database ... 14826 files and directories currently installed.)
Preparing to unpack .../open-iscsi_2.0.873+git0.3b4b4500-8+deb8u2_amd64.deb ...
Unpacking open-iscsi (2.0.873+git0.3b4b4500-8+deb8u2) ...
Processing triggers for systemd (215-17+deb8u7) ...
Running in chroot, ignoring request.
Setting up open-iscsi (2.0.873+git0.3b4b4500-8+deb8u2) ...
invoke-rc.d: policy-rc.d denied execution of start.
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Running in chroot, ignoring request.
update-rc.d: warning: start and stop actions are no longer supported; falling back to defaults
Running in chroot, ignoring request.
Processing triggers for systemd (215-17+deb8u7) ...
Running in chroot, ignoring request.
Deploying OpenEBS operator...
Deploying OpenEBS Storage classes
Checking Pod status....
kubectl get pods --all-namespaces
NAMESPACE     NAME                                    READY     STATUS    RESTARTS   AGE
kube-system   heapster-2574232661-8bkfd               2/2       Running   0          1m
kube-system   kube-dns-v20-2253765213-2hjkj           3/3       Running   0          3m
kube-system   kube-dns-v20-2253765213-hwnc7           3/3       Running   0          3m
kube-system   kube-proxy-f1hz1                        1/1       Running   0          3m
kube-system   kube-proxy-lvz3b                        1/1       Running   0          3m
kube-system   kube-svc-redirect-92s8s                 1/1       Running   0          3m
kube-system   kube-svc-redirect-mpjpj                 1/1       Running   0          3m
kube-system   kubernetes-dashboard-2898242510-6gxwq   1/1       Running   0          3m
kube-system   tunnelfront-2851197899-tmssw            1/1       Running   0          3m
```