### PR TITLE
Fix README.md of openebs/k8s/openebs-monitoring/

### DIFF
--- a/k8s/openebs-monitoring/README.md
+++ b/k8s/openebs-monitoring/README.md
@@ -29,7 +29,7 @@
 
 **alertmanager.yaml:** This file is for creating deployment and alertmanager service.
 
-**alertmanager-config.yaml:** This is q configuration file for alertmanager, used to load templates and to set alerts in slack. This can be configured to set alerts at various platforms like e-mail, slack and so on.
+**alertmanager-config.yaml:** This is a configuration file for alertmanager, used to load templates and to set alerts in slack. This can be configured to set alerts at various platforms like e-mail, slack and so on.
 
 **alertmanager-templates.yaml:** This file is used to customize notifications sent to slack.
 


### PR DESCRIPTION
On line 32, it was written 'This is q configuration file ...'  instead of 'This is a configuration file ...'. Fixed.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Minor fix in README.md

![image](https://user-images.githubusercontent.com/29581152/38194912-36b18b92-3698-11e8-89a5-956b9dbe74f0.png)

