### PR TITLE
Increased retry count in helm ansible role to overcome the network slowness

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -20,7 +20,7 @@
   register: tiller_out
   until: "'Happy Helming' in tiller_out.stdout"
   delay: 10
-  retries: 3
+  retries: 6
 
 - name: Check if tiller is configured
   shell: helm version
@@ -28,8 +28,8 @@
     executable: /bin/bash
   register: tiller_version
   until: "'Server: &version.Version' in tiller_version.stdout"
-  delay: 10
-  retries: 3
+  delay: 20
+  retries: 5
 
 - name: Creating service account
   shell: kubectl -n kube-system create sa tiller
@@ -37,8 +37,8 @@
     executable: /bin/bash
   register: tiller
   until: "'serviceaccount \"tiller\" created' in tiller.stdout"
-  delay: 5
-  retries: 2
+  delay: 10
+  retries: 6
 
 - name: Create cluster rolebinding
   shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
@@ -46,8 +46,8 @@
     executable: /bin/bash
   register: crb
   until: "'clusterrolebinding \"tiller\" created' in crb.stdout"
-  delay: 5
-  retries: 2
+  delay: 20
+  retries: 5
 
 - name: Getting home directory in kubernetes master
   shell: source ~/.profile; echo $HOME
@@ -66,8 +66,8 @@
     executable: /bin/bash
   register: tiller_deploy
   until: "'deployment \"tiller-deploy\" patched' in tiller_deploy.stdout"
-  delay: 5
-  retries: 2
+  delay: 20
+  retries: 6
 
 - name: Adding OpenEBS charts to repo
   shell: helm repo add openebs-charts "{{ charts }}"
@@ -75,8 +75,8 @@
     executable: /bin/bash
   register: repos
   until: "'\"openebs-charts\" has been added to your repositories' in repos.stdout"
-  delay: 5
-  retries: 2
+  delay: 20
+  retries: 6
 
 - name: Update the repo
   shell: helm repo update
@@ -84,8 +84,8 @@
     executable: /bin/bash
   register: update
   until: "'Update Complete' in update.stdout"
-  delay: 5
-  retries: 2
+  delay: 20
+  retries: 6
  
 - name: Install openebs
   shell: helm install openebs-charts/openebs
@@ -93,8 +93,8 @@
     executable: /bin/bash
   register: openebs_out
   until: "'The OpenEBS has been installed' in openebs_out.stdout"
-  delay: 10
-  retries: 3  
+  delay: 20
+  retries: 6  
 
 - name: Check if provisioner is deployed
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner" 
@@ -102,8 +102,8 @@
     executable: /bin/bash
   register: deployment
   until: "'Running' in deployment.stdout"
-  delay: 10
-  retries: 5
+  delay: 20
+  retries: 6
 
 - name: Check if maya-apiserver is deployed
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-maya-apiserver"
@@ -111,8 +111,8 @@
     executable: /bin/bash
   register: api_server
   until: "'Running' in api_server.stdout"
-  delay: 10
-  retries: 5
+  delay: 20
+  retries: 6
 
 - name: Check if storage classes are created
   shell: kubectl get sc
@@ -120,7 +120,7 @@
     executable: /bin/bash
   register: storage_classes
   until: "'openebs-cassandra' in storage_classes.stdout"
-  delay: 5
+  delay: 10
   retries: 3
 
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
When the network is slow, the existing ansible helm role fails to deploy openebs.  Increased the retry count in main.yaml.

