### PR TITLE
Enhance the e2e cleanup routines to check for volume pod deletion (Hyperconverged test suite)

### DIFF
--- a/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete the iSCSI target
   shell: source ~/.profile; kubectl delete -f {{ volume_def }}
   args:
@@ -26,13 +33,6 @@
   until: "'percona' not in result.stdout"
   delay: 120
   retries: 6
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
@@ -27,3 +27,20 @@
   delay: 120
   retries: 6
 
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retried: 10
+

--- a/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-cleanup.yml
@@ -42,5 +42,5 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 

--- a/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-vars.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot-vars.yml
@@ -11,3 +11,11 @@ snap_name: quicksnap
 
 deb_packages:
   - mysql-client
+
+replace_item:
+  - demo-vol1-claim
+  - demo-vol1
+
+replace_with:
+  - mysql-snap-claim
+  - mysql-snap

--- a/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/percona-mysql/mysql-snapshot.yml
@@ -33,6 +33,16 @@
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
+       - name: Replace volume-claim name with test parameters
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+           regexp: '{{ item.0 }}'
+           replace: '{{ item.1 }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_together:
+           - "{{replace_item}}"
+           - "{{replace_with}}"
+
        - name: Start the log aggregator to capture test pod logs
          shell: >
            source ~/.profile;

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -141,9 +141,6 @@
          delay: 60
          retries: 5
       
-       - include: k8s-cassandra-pod-cleanup.yml
-         when: clean | bool 
-
        - name: Terminate the log aggregator
          shell: source {{ profile }}; killall stern
          args:
@@ -158,6 +155,9 @@
            flag: "Fail"
 
      always:
+       - include: k8s-cassandra-pod-cleanup.yml
+         when: clean | bool
+
        - name: Send slack notification
          slack: 
            token: "{{ lookup('env','SLACK_TOKEN') }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
@@ -50,5 +50,5 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc pgdata-pgset-0 -o custom-columns=:spec.volumeName --no-headers
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Get $HOME of K8s master for kubernetes user
   shell: source ~/.profile; echo $HOME
   args:
@@ -34,13 +41,6 @@
   until: "'pgset' not in result.stdout"
   delay: 120
   retries: 6
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc pgdata-pgset-0 -o custom-columns=:spec.volumeName --no-headers
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg-cleanup.yml
@@ -25,5 +25,30 @@
   delay: 120 
   retries: 6
 
+- name: Confirm postgres pods have been deleted
+  shell: source ~/.profile; kubectl get pods
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "'pgset' not in result.stdout"
+  delay: 120
+  retries: 6
 
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc pgdata-pgset-0 -o custom-columns=:spec.volumeName --no-headers
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retried: 10
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -105,9 +105,6 @@
          register: result_service
          failed_when: "'pgset-master' and 'pgset-replica' not in result_service.stdout"
 
-       - include: k8s-crunchy-pg-cleanup.yml
-         when: clean | bool
-
        - name: Terminate the log aggregator
          shell: source ~/.profile; killall stern
          args:
@@ -122,6 +119,9 @@
            flag: "Fail"
 
      always:
+       - include: k8s-crunchy-pg-cleanup.yml
+         when: clean | bool
+
        - name: Send slack notification
          slack:
            token: "{{ lookup('env','SLACK_TOKEN') }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
@@ -15,5 +15,21 @@
   delay: 120 
   retries: 6
 
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ volume_claim }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retried: 10
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
@@ -30,6 +30,6 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ volume_claim }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete jupyter server pod 
   shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
   args:
@@ -14,13 +21,6 @@
   until: "'jupyter' not in result.stdout"
   delay: 120 
   retries: 6
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ volume_claim }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
@@ -4,6 +4,8 @@ test_name: hyperconverged_jupyter_server_on_k8s
 jupyter_plugin_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/jupyter/demo-jupyter-openebs.yaml 
 pod_yaml_alias: demo-jupyter-openebs.yaml
 
+volume_claim: jupyter-data-vol-claim
+
 jupyter_server_vol_size: 5G
 
  

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
@@ -31,3 +31,9 @@
   delay: 120
   retries: 6
 
+- name: Remove test artifacts
+  file:  
+    path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
@@ -6,4 +6,4 @@ block_size: [512k,1M]
 py_file: test-mem.py
 count_num: 10000
 mount_point: /mnt/jiva
-
+volume_claim: memleak-test

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -31,6 +31,13 @@
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"       
 
+       - name: Replace volume-claim name with test parameters
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+           regexp: 'vut'
+           replace: '{{ volume_claim }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
        - name: Create a storage volume via a pvc
          shell: source ~/.profile; kubectl apply -f "{{ volume_def }}"
          args:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -34,6 +34,6 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -19,5 +19,21 @@
   delay: 120 
   retries: 6
 
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retried: 10
 
    

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -20,7 +20,7 @@
   retries: 6
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Wait {{ mysql_load_duration }} sec for I/O completion
   wait_for:
     timeout: "{{ mysql_load_duration }}" 
@@ -18,13 +25,6 @@
   until: "'percona' not in result.stdout"
   delay: 120 
   retries: 6
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
@@ -11,6 +11,14 @@ pod_yaml_alias: demo-percona-mysql-pvc.yaml
 
 percona_mysql_vol_size: 5G
 
+replace_item:
+  - demo-vol1-claim
+  - demo-vol1
+
+replace_with:
+  - percona-db-claim
+  - percona-db
+
 files: 
   - Dockerfile
   - MySQLLoadGenerate.sh

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -36,6 +36,16 @@
          delay: 120
          retries: 5
 
+       - name: Replace volume-claim name with test parameters
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: '{{ item.0 }}'
+           replace: '{{ item.1 }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_together:
+           - "{{replace_item}}"
+           - "{{replace_with}}"
+
        - name: Replace volume size in plugin YAML
          lineinfile:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -120,9 +120,6 @@
          become: true
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-       - include: k8s-percona-pod-cleanup.yml
-         when: clean | bool 
-
        - name: Terminate the log aggregator
          shell: source ~/.profile; killall stern
          args:
@@ -137,6 +134,9 @@
            flag: "Fail"
 
      always:
+       - include: k8s-percona-pod-cleanup.yml
+         when: clean | bool
+
        - name: Send slack notification
          slack: 
            token: "{{ lookup('env','SLACK_TOKEN') }}"

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete percona mysql pod 
   shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
   args:
@@ -14,13 +21,6 @@
   until: "'percona' not in result.stdout"
   delay: 30 
   retries: 10
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -30,7 +30,7 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 
 - name: Remove the percona liveness check config map 
   shell: source ~/.profile; kubectl delete cm sqltest 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -16,7 +16,7 @@
   retries: 10
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -75,7 +75,14 @@
   register: result
   failed_when: "'chaoskube' in result.stdout"
 
-
+- name: Remove test artifacts
+  shell: rm -rf {{ item.0 }}; rm -rf {{ item.1 }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_together:
+    - "{{percona_files}}"
+    - "{{chaoskube_files}}"
   
  
  

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -16,7 +16,7 @@
   retries: 10
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -32,7 +32,7 @@
   retries: 10
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -56,7 +56,13 @@
   register: result
   failed_when: "'configmap' and 'deleted' not in result.stdout"
 
-
+- name: Remove test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
+    - "{{percona_files}}"
   
  
  

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -32,7 +32,7 @@
   retries: 10
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete pumba infrastructure
   shell: source ~/.profile; kubectl delete daemonset  pumba
   args:
@@ -30,13 +37,6 @@
   until: "'percona' not in result.stdout"
   delay: 30
   retries: 10
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete percona mysql pod 
   shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
   args:
@@ -15,13 +22,6 @@
   delay: 30 
   retries: 6
 
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
-
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
   args:
@@ -30,7 +30,7 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 
 - name: Remove the percona liveness check config map 
   shell: source ~/.profile; kubectl delete cm sqltest 

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
@@ -16,7 +16,7 @@
   retries: 6
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
@@ -16,7 +16,7 @@
   retries: 6
 
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -46,6 +46,13 @@
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+- name: Remove test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
+    - "{{percona_files}}"
 
   
  

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
@@ -15,6 +15,23 @@
   delay: 120 
   retries: 6
 
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retried: 10
+
 - name: Remove the percona liveness check config map 
   shell: source ~/.profile; kubectl delete cm sqltest 
   args:
@@ -58,7 +75,14 @@
   register: result
   failed_when: "'chaoskube' in result.stdout"
 
-
+- name: Remove test artifacts
+  shell: rm -rf {{ item.0 }}; rm -rf {{ item.1 }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_together:
+    - "{{percona_files}}"
+    - "{{chaoskube_files}}"
   
  
  

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
@@ -30,7 +30,7 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
 
 - name: Remove the percona liveness check config map 
   shell: source ~/.profile; kubectl delete cm sqltest 

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
@@ -1,4 +1,11 @@
 ---
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+
 - name: Delete percona mysql pod 
   shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
   args:
@@ -14,13 +21,6 @@
   until: "'percona' not in result.stdout"
   delay: 120 
   retries: 6
-
-- name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: pvc
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-vars.yml
@@ -9,6 +9,14 @@ chaoskube_files:
   - rbac.yaml
   - chaoskube.yaml 
 
+replace_item:
+  - demo-vol1-claim
+  - demo-vol1
+
+replace_with:
+  - test-single-rep
+  - single-rep
+
 chaos_duration: 120
 
 chaos_interval: 20 

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
@@ -26,6 +26,16 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          with_items: "{{ percona_files }}"
 
+       - name: Replace volume-claim name with test parameters
+         replace:
+           path: "{{ result_kube_home.stdout }}/percona.yaml"
+           regexp: '{{ item.0 }}'
+           replace: '{{ item.1 }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_together:
+           - "{{replace_item}}"
+           - "{{replace_with}}
+
        - name: Copy the chaoskube specs to kubemaster  
          copy:
            src: "{{ item }}"
@@ -230,8 +240,6 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          with_items: "{{ result_nodes.stdout_lines }}"
 
-       - include: test-single-replica-failure-cleanup.yml
-         when: clean | bool
 
        - name: Terminate the log aggregator
          shell: source ~/.profile; killall stern
@@ -247,6 +255,9 @@
            flag: "Fail"
 
      always:
+       - include: test-single-replica-failure-cleanup.yml
+         when: clean | bool
+
        - name: Send slack notification
          slack: 
            token: "{{ lookup('env','SLACK_TOKEN') }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

  - Enhance the e2e cleanup routines to check for volume pod deletion (Resiliency test suite).
  - The current cleanup routines in e2e ansible playbooks delete the application specs (some check that the pvc are deleted). We need to mandate the check for pvc and corresponding pod deletions (there are possibilities that the pods might continue to exist even after pvc delete)
  - This enhancement checks for successful deletion of volume pods.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1417 

**Special notes for your reviewer**:
@ksatchit @yudaykiran  Can you please review this PR?
