### PR TITLE
(WIP) Modularizing redundant tasks for resiliency test suite.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -7,20 +7,14 @@
   register: pvc
 
 - name: Delete percona mysql pod 
-  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_files.0 }}"
 
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l name=percona 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 30 
-  retries: 10
+- name: Check status of percona
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
@@ -41,29 +35,9 @@
   failed_when: "'configmap' and 'deleted' not in result.stdout"
 
 - name: Delete the chaoskube infrastructure
-  shell: source ~/.profile; kubectl delete -f {{ item }}
-  args: 
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  with_items: "{{ chaoskube_files }}"
-
-- name: Confirm that the chaoskube pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l app=chaoskube
-  args: 
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'chaoskube' not in result.stdout"
-
-- name: Confirm the chaoskube sa has been deleted
-  shell: >
-    source ~/.profile; 
-    kubectl get sa --no-headers -o custom-columns=:metadata.name
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  failed_when: "'chaoskube' in result.stdout"
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ chaoskube_files }}"
 
 - name: Confirm the chaoskube clusterrolebinding has been deleted
   shell: >

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
@@ -21,6 +21,8 @@ replace_with:
   - test-ctrl-failure
   - test-ctrl
 
+utils_path: openebs/e2e/ansible/playbooks/utils
+
 chaos_duration: 120
 
 chaos_interval: 20 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -1,6 +1,18 @@
 # test-ctrl-failure.yml
 # Author: Karthik
 # Description: Include resiliency test suite in OpenEBS e2e (Test: periodic controller failures)
+###############################################################################################
+#Test Steps:
+#1. Copy Test artifacts to Kubemaster.
+#2. Deploy Percona application with liveness probe running db queries continuously.
+#3. Create chaoskube infrastructer to induce failures.
+#4. Gather Node,Replica Container and chaoskube pod details required for test.
+#5. Initiate periodic controller failures from chaoskube
+#6. Check percona application status to veriy openebs replica sustain network failures.
+#7. Verify successful Fault Injection via end marker
+#8. Perform cleanup of test artifacts.
+###############################################################################################
+
 - hosts: localhost
  
   vars_files: 
@@ -21,6 +33,12 @@
            executable: /bin/bash
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      
+       - name: Get $HOME of localhost
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: localhost_home
 
        - name: Get percona spec and liveness scripts
          get_url:
@@ -30,21 +48,16 @@
          with_items: "{{ percona_links }}"
 
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
        - name: Copy the chaoskube specs to kubemaster  
-         copy:
-           src: "{{ item }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_items: "{{ chaoskube_files }}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/copy_task.yml"
+         vars:
+           files_to_copy: "{{ chaoskube_files }}"            
 
        - name: Start the log aggregator to capture test pod logs
          shell: >
@@ -54,16 +67,11 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args: 
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
-         until: "'Running' in result.stdout"
-         delay: 30 
-         retries: 10
-      
+       - name: Check status of maya-api server
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
+
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup chaoskube deployment with an empty policy,#
@@ -71,21 +79,18 @@
        ####################################################
 
        - name: Setup the chaoskube infrastructure
-         shell: source ~/.profile; kubectl apply -f {{ item }} 
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         with_items: "{{ chaoskube_files }}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ chaoskube_files }}"
 
-       - name: Confirm that the chaoskube deployment is running 
-         shell: source ~/.profile; kubectl get pods --no-headers -l app=chaoskube
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result_chaoskube 
-         until: "'chaoskube' and 'Running' in result_chaoskube.stdout"
-         delay: 30
-         retries: 15        
+       - name: Check whether chaoskube infrastructure is created
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: chaoskube
+
+       - name: Set chaoskube pod name to variable 
+         set_fact: 
+           chaospod: "{{ result.stdout_lines[0].split()[0] }}"
 
        - name: Create a configmap with the liveness sql script 
          shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
@@ -96,29 +101,19 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
+
+       - name: Check whether percona application is running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
 
        - name: Wait for 120s to ensure liveness check starts 
          wait_for:
            timeout: 120
          
-       - name: Confirm percona pod is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
-
-       - name: Set chaoskube pod name to variable 
-         set_fact: 
-           chaospod: "{{ result_chaoskube.stdout_lines[0].split()[0] }}"
-
        - name: Get the name of the volume ctrl deployment 
          shell: > 
            source ~/.profile; kubectl get deployments 
@@ -182,15 +177,10 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona application is still running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
+       - name: Confirm percona pod is still running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/status_running.yml"
+         vars:
+            app: percona
 
        ########################################################
        #                        CLEANUP                       #			      

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
@@ -7,36 +7,19 @@
   register: pvc
 
 - name: Delete pumba infrastructure
-  shell: source ~/.profile; kubectl delete daemonset  pumba
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-- name: Confirm pumba pod has been deleted
-  shell: source ~/.profile; kubectl get pods --no-headers -l app=pumba
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'pumba' not in result.stdout"
-  delay: 30
-  retries: 10
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ pumba_file }}"
 
 - name: Delete percona mysql pod
-  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_files.0 }}"
 
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l name=percona
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 30
-  retries: 10
+- name: Confirm percona pod deletion
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
@@ -46,10 +29,10 @@
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retries: 10
+  retried: 10
 
-- name: Remove the percona liveness check config map
-  shell: source ~/.profile; kubectl delete cm sqltest
+- name: Remove the percona liveness check config map 
+  shell: source ~/.profile; kubectl delete cm sqltest 
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -63,6 +46,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
     - "{{percona_files}}"
-
-
-
+  
+ 
+ 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
@@ -1,6 +1,8 @@
 ---
 test_name: test_nw_failure
 
+utils_path: openebs/e2e/ansible/playbooks/utils
+
 percona_links:
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/sql-test.sh

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -33,6 +33,12 @@
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Get $HOME of localhost
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: localhost_home
+
        - name: Get percona spec and liveness scripts
          get_url:
            url: "{{ item }}"
@@ -41,14 +47,11 @@
          with_items: "{{ percona_links }}"
 
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
        - name: Start the log aggregator to capture test pod logs
          shell: >
@@ -58,15 +61,10 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 30
-         retries: 15
+       - name: Check status of maya-api server
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
 
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
@@ -75,20 +73,14 @@
        ####################################################
 
        - name: Setup the pumba infrastructure
-         shell: source ~/.profile; kubectl apply -f {{ pumba_file }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ pumba_file }}"
 
-       - name: Confirm that the pumba deployment is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l app=pumba
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result_pumba
-         until: "'pumba' and 'Running' in result_pumba.stdout"
-         delay: 30
-         retries: 15
+       - name: Check whether pumba infrastructure is created
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: pumba
 
        - name: Create a configmap with the liveness sql script
          shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }}
@@ -99,24 +91,18 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
 
        - name: Wait for 120s to ensure liveness check starts
          wait_for:
            timeout: 120
 
-       - name: Confirm percona pod is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30
-         retries: 15
+       - name: Check whether percona application is running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
 
        - name: Get the node details on which pvc-rep is scheduled
          shell: kubectl get pods -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
@@ -171,15 +157,10 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona application is still running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30
-         retries: 15
+       - name: Confirm percona pod is still running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/status_running.yml"
+         vars:
+            app: percona
 
        ########################################################
        #                        CLEANUP                       #

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -7,36 +7,19 @@
   register: pvc
 
 - name: Delete pumba infrastructure
-  shell: source ~/.profile; kubectl delete daemonset  pumba
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ pumba_file }}"
 
-- name: Confirm pumba pod has been deleted
-  shell: source ~/.profile; kubectl get pods --no-headers -l app=pumba
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'pumba' not in result.stdout"
-  delay: 30
-  retries: 10
+- name: Delete percona mysql pod
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_files.0 }}"
 
-- name: Delete percona mysql pod 
-  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l name=percona 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 30
-  retries: 10
+- name: Confirm percona pod deletion
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
@@ -17,6 +17,8 @@ replace_with:
   - test-nw-failure
   - test-nw
 
+utils_path: openebs/e2e/ansible/playbooks/utils
+
 delay_interavals: 
   - 3000
   - 6000

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
@@ -1,6 +1,18 @@
 # test-network-failure.yml
 # Author: Sudarshan
 # Description: Include resiliency test suite in OpenEBS e2e (Test: periodic network failures)
+
+###############################################################################################
+#Test Steps:
+#1. Copy Test artifacts to Kubemaster.
+#2. Deploy Percona application with liveness probe running db queries continuously.
+#3. Deploy Pumba netem daemonset on all the nodes.
+#4. Gather Node,Replica Container and Pumba netem details required for test.
+#5. Induce periodic network failures on OpenEBS volume controller.
+#6. Check percona application status to veriy openebs controller can sustain network failures.
+#7. Perform cleanup of test artifacts.
+###############################################################################################
+
 - hosts: localhost
  
   vars_files: 
@@ -22,6 +34,12 @@
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Get $HOME of localhost
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: localhost_home
+
        - name: Get percona spec and liveness scripts
          get_url:
            url: "{{ item }}"
@@ -30,15 +48,12 @@
          with_items: "{{ percona_links }}"
 
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
-         
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
+
        - name: Start the log aggregator to capture test pod logs
          shell: >
            source ~/.profile;
@@ -47,16 +62,11 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args: 
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
-         until: "'Running' in result.stdout"
-         delay: 30 
-         retries: 15
-      
+       - name: Check status of maya-api server
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
+ 
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup pumba deployment with an empty policy,    #
@@ -64,20 +74,14 @@
        ####################################################
 
        - name: Setup the pumba infrastructure
-         shell: source ~/.profile; kubectl apply -f {{ pumba_file }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ pumba_file }}"
 
-       - name: Confirm that the pumba deployment is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l app=pumba
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result_pumba
-         until: "'pumba' and 'Running' in result_pumba.stdout"
-         delay: 30
-         retries: 15
+       - name: Check whether pumba infrastructure is created
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: pumba
 
        - name: Create a configmap with the liveness sql script
          shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
@@ -88,24 +92,18 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
 
        - name: Wait for 120s to ensure liveness check starts 
          wait_for:
            timeout: 120
          
-       - name: Confirm percona pod is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
+       - name: Check whether percona application is running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
 
        - name: Get the node details on which pvc-ctrl is scheduled 
          shell: kubectl get pods -o wide | grep ctrl | awk {'print $7'}
@@ -160,15 +158,10 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona application is still running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
+       - name: Confirm percona pod is still running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/status_running.yml"
+         vars:
+            app: percona
 
        ########################################################
        #                        CLEANUP                       #			      

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-cleanup.yml
@@ -6,21 +6,15 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: pvc
 
-- name: Delete percona mysql pod 
-  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+- name: Delete percona mysql pod
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_files.0 }}"
 
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l name=percona 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 30 
-  retries: 6
+- name: Confirm percona pod deletion
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure-vars.yml
@@ -1,6 +1,8 @@
 ---
 test_name: test_replica_quorum_failure
 
+utils_path: openebs/e2e/ansible/playbooks/utils
+
 percona_links:
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/sql-test.sh

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
@@ -1,3 +1,18 @@
+# test-single-replica-failure.yml
+# Author: UdayKiran
+# Description: Replica failure test(Quorun met).
+
+###############################################################################################
+#Test Steps:
+#1. Copy Test artifacts to Kubemaster.
+#2. Deploy Percona application with liveness probe running db queries continuously.
+#3. Setup ChaosKube infrastructure.
+#4. Gather Node,Replica Container and Pumba netem details required for test.
+#5. Initiate single replica failure using ChaosKube.
+#6. Check percona application status to veriy openebs controller can sustain failures.
+#7. Perform cleanup of test artifacts.
+###############################################################################################
+
 - hosts: localhost
  
   vars_files: 
@@ -19,6 +34,12 @@
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Get $HOME of localhost
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: localhost_home
+
        - name: Get percona spec and liveness scripts
          get_url:
            url: "{{ item }}"
@@ -27,14 +48,11 @@
          with_items: "{{ percona_links }}"
 
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
        - name: Copy the fault injection specs to kubemaster  
          copy:
@@ -56,16 +74,11 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args: 
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
-         until: "'Running' in result.stdout"
-         delay: 30 
-         retries: 15
-      
+       - name: Check status of maya-api server
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
+ 
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup chaoskube deployment with an empty policy,#
@@ -73,10 +86,9 @@
        ####################################################
 
        - name: Setup the storage class
-         shell: source ~/.profile; kubectl apply -f {{ storage_class_file }} 
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ storage_class_file }}"
 
        - name: Create a configmap with the liveness sql script 
          shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
@@ -87,24 +99,18 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
 
-       - name: Wait for 120s to ensure liveness check starts 
+       - name: Wait for 120s to ensure liveness check starts
          wait_for:
            timeout: 120
-         
-       - name: Confirm percona pod is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
+
+       - name: Check whether percona application is running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
 
        - name: Get the name of the volume replica deployment 
          shell: > 
@@ -124,6 +130,7 @@
        # (Obtain begin marker before fault-inject(FI),do ctrl # 
        # failures, verify successful FI via end marker)       # 
        ########################################################
+
        - name: Populate the iterator with the values to loop
          shell: >
            shuf -i 1-100 -n {{interval}}
@@ -140,24 +147,16 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona application is still running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 30 
-         retries: 15
+       - name: Confirm percona pod is still running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/status_running.yml"
+         vars:
+            app: percona
 
        ########################################################
        #                        CLEANUP                       #			      
        # (Tear down application, liveness configmap as well as#
        # the FI (chaoskube) infrastructure. Also stop logger) # 
        ########################################################
-
-       - include: test-replica-quorum-failure-cleanup.yml
-         when: clean | bool
 
        - name: Terminate the log aggregator
          shell: source ~/.profile; killall stern
@@ -173,6 +172,10 @@
            flag: "Fail"
 
      always:
+  
+       - include: test-replica-quorum-failure-cleanup.yml
+         when: clean | bool
+
        - name: Send slack notification
          slack: 
            token: "{{ lookup('env','SLACK_TOKEN') }}"

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
@@ -6,21 +6,15 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: pvc
 
-- name: Delete percona mysql pod 
-  shell: source ~/.profile; kubectl delete -f {{ percona_files.0 }} 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+- name: Delete percona mysql pod
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_files.0 }}"
 
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods -l name=percona 
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 120 
-  retries: 6
+- name: Check status of percona
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
@@ -41,11 +35,9 @@
   failed_when: "'configmap' and 'deleted' not in result.stdout"
 
 - name: Delete the chaoskube infrastructure
-  shell: source ~/.profile; kubectl delete -f {{ item }}
-  args: 
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  with_items: "{{ chaoskube_files }}"
+  include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ chaoskube_files }}"
 
 - name: Confirm that the chaoskube pod has been deleted
   shell: source ~/.profile; kubectl get pods -l app=chaoskube

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-vars.yml
@@ -1,6 +1,10 @@
 ---
 test_name: test_single_replica_failure
 
+percona_links:
+  - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml
+  - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/sql-test.sh
+
 percona_files: 
   - percona.yaml
   - sql-test.sh
@@ -20,6 +24,8 @@ replace_with:
 chaos_duration: 120
 
 chaos_interval: 20 
+
+utils_path: openebs/e2e/ansible/playbooks/utils
 
 test_pod_regex: maya*|openebs*|pvc*|percona*|chaos*
 

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
@@ -1,3 +1,17 @@
+# test-single-replica-failure.yml
+# Author: UdayKiran
+# Description: Single replica failure test.
+
+###############################################################################################
+#Test Steps:
+#1. Copy Test artifacts to Kubemaster.
+#2. Deploy Percona application with liveness probe running db queries continuously.
+#3. Setup ChaosKube infrastructure.
+#4. Gather Node,Replica Container and Pumba netem details required for test.
+#5. Initiate single replica failure using ChaosKube.
+#6. Check percona application status to veriy openebs controller can sustain failures.
+#7. Perform cleanup of test artifacts.
+###############################################################################################
 - hosts: localhost
  
   vars_files: 
@@ -19,29 +33,30 @@
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Copy the percona spec and liveness script to kubemaster 
-         copy:
-           src: "{{ item }}"
+       - name: Get $HOME of localhost
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: localhost_home
+
+       - name: Get percona spec and liveness scripts
+         get_url:
+           url: "{{ item }}"
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_items: "{{ percona_files }}"
+         with_items: "{{ percona_links }}"
 
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
-       - name: Copy the chaoskube specs to kubemaster  
-         copy:
-           src: "{{ item }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_items: "{{ chaoskube_files }}"
+       - name: Copy the chaoskube specs to kubemaster
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/copy_task.yml"
+         vars:
+           files_to_copy: "{{ chaoskube_files }}"
 
        - name: Start the log aggregator to capture test pod logs
          shell: >
@@ -51,16 +66,11 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args: 
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"    
-         until: "'Running' in result.stdout"
-         delay: 120 
-         retries: 5
-      
+       - name: Check status of maya-api server
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
+ 
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup chaoskube deployment with an empty policy,#
@@ -68,21 +78,14 @@
        ####################################################
 
        - name: Setup the chaoskube infrastructure
-         shell: source ~/.profile; kubectl apply -f {{ item }} 
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         with_items: "{{ chaoskube_files }}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ chaoskube_files }}"
 
-       - name: Confirm that the chaoskube deployment is running 
-         shell: source ~/.profile; kubectl get pods --no-headers -l app=chaoskube
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result_chaoskube 
-         until: "'chaoskube' and 'Running' in result_chaoskube.stdout"
-         delay: 120
-         retries: 15        
+       - name: Check whether chaoskube infrastructure is created
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: chaoskube
 
        - name: Create a configmap with the liveness sql script 
          shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
@@ -93,28 +96,22 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         shell: source ~/.profile; kubectl apply -f {{ percona_files.0 }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
 
-       - name: Wait for 120s to ensure liveness check starts 
+       - name: Check whether percona application is running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
+
+       - name: Wait for 120s to ensure liveness check starts
          wait_for:
            timeout: 120
-         
-       - name: Confirm percona pod is running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 120 
-         retries: 15
 
-       - name: Set chaoskube pod name to variable 
-         set_fact: 
-           chaospod: "{{ result_chaoskube.stdout_lines[0].split()[0] }}"
+       - name: Set chaoskube pod name to variable
+         set_fact:
+           chaospod: "{{ result.stdout_lines[0].split()[0] }}"
 
        - name: Get the name of the volume single replica deployment 
          shell: > 
@@ -217,15 +214,10 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona application is still running
-         shell: source ~/.profile; kubectl get pods --no-headers -l name=percona   
-         args: 
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 120 
-         retries: 15
+       - name: Confirm percona pod is still running
+         include_tasks: "{{ localhost_home.stdout }}/{{utils_path}}/status_running.yml"
+         vars:
+            app: percona
 
        ########################################################
        #                        CLEANUP                       #			      

--- a/e2e/ansible/playbooks/utils/copy_task.yml
+++ b/e2e/ansible/playbooks/utils/copy_task.yml
@@ -1,0 +1,8 @@
+---
+- name: Copy the chaoskube specs to kubemaster
+  copy:
+    src: "{{ item }}"
+    dest: "{{ result_kube_home.stdout }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  with_items: "{{ files_to_copy }}"
+

--- a/e2e/ansible/playbooks/utils/delete_deploy.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy.yml
@@ -1,0 +1,8 @@
+---
+- name: Delete deployed application files
+  shell: source ~/.profile; kubectl delete -f {{ item }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items: "{{ app_yml }}"
+

--- a/e2e/ansible/playbooks/utils/delete_deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy_check.yml
@@ -1,0 +1,11 @@
+---
+- name: Check pod status
+  shell: source ~/.profile; kubectl get pods | grep {{ app }}
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: "app and 'Running' not in result.stdout"
+  delay: 30
+  retries: 15
+  ignore_errors: True

--- a/e2e/ansible/playbooks/utils/deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/deploy_check.yml
@@ -1,0 +1,10 @@
+---
+- name: Check {{ app }} pod status
+  shell: source ~/.profile; kubectl get pods | grep {{ app }}
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: " app  and 'Running' in result.stdout"
+  delay: 30
+  retries: 15

--- a/e2e/ansible/playbooks/utils/deploy_task.yml
+++ b/e2e/ansible/playbooks/utils/deploy_task.yml
@@ -1,0 +1,9 @@
+---
+- name: Deploy application files
+  shell: source ~/.profile; kubectl apply -f {{ item }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items: "{{ app_yml }}"
+
+

--- a/e2e/ansible/playbooks/utils/regex_task.yml
+++ b/e2e/ansible/playbooks/utils/regex_task.yml
@@ -1,0 +1,11 @@
+---
+- name: Replace volume-claim name with test parameters
+  replace:
+    path: {{ path }}
+    regexp: '{{ item.0 }}'
+    replace: '{{ item.1 }}'
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  with_together:
+    - "{{replace_item}}"
+    - "{{replace_with}}"
+


### PR DESCRIPTION
Signed-off-by: Sudarshan Darga <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR enhance the current test playbooks to use module tasks in the resiliency test-suite.
I have identified few tasks which are redundant across many playbooks, added these tasks as modules and calling them from the test playbook.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@ksatchit @yudaykiran Can you please review this PR and give your comments. And also if you think we can modularize any other tasks, please refer me.