### PR TITLE
Update spec config with xfs fstype support

### DIFF
--- a/k8s/demo/mongodb/mongo-loadgen.yaml
+++ b/k8s/demo/mongodb/mongo-loadgen.yaml
@@ -13,6 +13,6 @@ spec:
       - name: mongo-loadgen
         image: openebs/tests-sysbench-mongo
         command: ["/bin/bash"]
-        args: ["-c", "./sysbench/sysbench --mongo-write-concern=1 --mongo-url='mongodb://10.47.0.3' --mongo-database-name=sbtest --test=./sysbench/tests/mongodb/oltp.lua --oltp_table_size=100 --oltp_tables_count=10 --num-threads=10 --rand-type=pareto --report-interval=10 --max-requests=0 --max-time=600 --oltp-point-selects=10 --oltp-simple-ranges=1 --oltp-sum-ranges=1 --oltp-order-ranges=1 --oltp-distinct-ranges=1 --oltp-index-updates=1 --oltp-non-index-updates=1 --oltp-inserts=1 run"]
-        tty: true 
+        args: ["-c", "./sysbench/sysbench --mongo-write-concern=1 --mongo-url='mongodb://mongo-0.mongo' --mongo-database-name=sbtest --test=./sysbench/tests/mongodb/oltp.lua --oltp_table_size=100 --oltp_tables_count=10 --num-threads=10 --rand-type=pareto --report-interval=10 --max-requests=0 --max-time=600 --oltp-point-selects=10 --oltp-simple-ranges=1 --oltp-sum-ranges=1 --oltp-order-ranges=1 --oltp-distinct-ranges=1 --oltp-index-updates=1 --oltp-non-index-updates=1 --oltp-inserts=1 run"]
+        tty: true
 

--- a/k8s/demo/mongodb/mongo-statefulset.yml
+++ b/k8s/demo/mongodb/mongo-statefulset.yml
@@ -36,6 +36,7 @@ spec:
            - rs0
            - "--smallfiles"
            - "--noprealloc"
+           - "--bind_ip_all"
          ports:
            - containerPort: 27017
          volumeMounts:
@@ -43,7 +44,7 @@ spec:
              mountPath: /data/db
        - name: mongo-sidecar
          image: cvallance/mongo-k8s-sidecar
-         env: 
+         env:
            - name: MONGO_SIDECAR_POD_LABELS
              value: "role=mongo,environment=test"
  volumeClaimTemplates:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -37,7 +37,7 @@ rules:
   verbs: [ "get", "list", "create" ]
 - apiGroups: ["*"]
   resources: ["storagepools"]
-  verbs: ["get", "list"] 
+  verbs: ["get", "list"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
@@ -141,6 +141,13 @@ spec:
         # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_VALID_FSTYPE enables openebs provisioner to provision openebs
+        # volume other then ext4(default fstype). After adding "openebs.io/fstype"
+        # parameters in StorageClasse will provision the volume with specified fstype.
+        # This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.4 onwards
+        #- name: OPENEBS_VALID_FSTYPE
+        #  value: "ext4,xfs"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/k8s/openebs-storageclasses.yaml
+++ b/k8s/openebs-storageclasses.yaml
@@ -42,6 +42,7 @@ parameters:
   openebs.io/jiva-replica-count: "3"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
+  openebs.io/fstype: "xfs"
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will update the following:
1. Operator file to add OPENEBS_VALID_FSTYPE env in provisioner Pod.
2. Add `openebs.io/fstype: "xfs"` in mongodb SC
3. Update mongo stateful specs.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>
