### PR TITLE
Include ansible playbook for test-node-eviction-out-of-disk.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/replica_patch.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/replica_patch.yaml
@@ -1,0 +1,13 @@
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                - nodename_where_replica_pod_1_got_scheduled
+                - nodename_where_replica_pod_2_got_scheduled

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
@@ -3,14 +3,26 @@
   include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
     app_yml: "{{ percona_link }}"
+    ns: nodeeviction
 
 - name: Check status of percona
   include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
+    ns: nodeeviction
     app: percona
 
+- name: Delete nodeeviction ns
+  shell: kubectl delete ns nodeeviction
+  args:
+    executable: /bin/bash
+  register: ns_out
+  until: "'deleted' in ns_out.stdout"
+  delay: 10
+  retries: 5
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods | grep pvc
+  shell: source ~/.profile; kubectl get pods -n nodeeviction | grep pvc
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
@@ -1,0 +1,26 @@
+---
+- name: Delete percona mysql pod
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_link }}"
+
+- name: Check status of percona
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    app: percona
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods | grep pvc
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retries: 10
+
+- name: Remove copied files
+  shell: rm -rf "{{ patch_file }}" "{{ create_sc }}"
+  args:
+    executable: /bin/bash
+

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
@@ -1,12 +1,10 @@
 ---
-- name: Delete percona mysql pod
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
     app_yml: "{{ percona_link }}"
     ns: nodeeviction
 
-- name: Check status of percona
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
     ns: nodeeviction
     app: percona
@@ -27,7 +25,7 @@
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
-  failed_when: "'pvc' and 'Running' in result.stdout"
+  until: "'pvc' not in result.stdout"
   delay: 30
   retries: 10
 

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
@@ -10,7 +10,7 @@
     app: percona
 
 - name: Delete nodeeviction ns
-  shell: kubectl delete ns nodeeviction
+  shell: kubectl delete ns {{ namespace }}
   args:
     executable: /bin/bash
   register: ns_out
@@ -20,14 +20,15 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods -n nodeeviction | grep pvc
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep pvc
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
-  until: "'pvc' not in result.stdout"
+  until: "result.rc!=0"
   delay: 30
   retries: 10
+  ignore_errors: true
 
 - name: Remove copied files
   shell: rm -rf "{{ patch_file }}" "{{ create_sc }}"

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-prereq.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-prereq.yml
@@ -1,0 +1,17 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
@@ -9,8 +9,6 @@ create_sc: storage-class.yaml
 
 percona_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml
 
-replica_count: 2 
-
 replace_item:
   - nodename_where_replica_pod_1_got_scheduled
   - nodename_where_replica_pod_2_got_scheduled

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
@@ -1,6 +1,8 @@
 ---
 test_name: test-node-eviction-out-of-disk
 
+namespace: nodeeviction
+
 utils_path: openebs/e2e/ansible/playbooks/utils
 
 patch_file: replica_patch.yaml
@@ -14,8 +16,8 @@ replace_item:
   - nodename_where_replica_pod_2_got_scheduled
 
 replace_with:
-  - "{{node_details.results[0].stdout}}"
-  - "{{node_details.results[1].stdout}}"
+  - "{{node_details.stdout_lines[0]}}"
+  - "{{node_details.stdout_lines[1]}}"
 
 test_pod_regex: maya*|openebs*|pvc*|percona*
 

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-vars.yml
@@ -1,0 +1,26 @@
+---
+test_name: test-node-eviction-out-of-disk
+
+utils_path: openebs/e2e/ansible/playbooks/utils
+
+patch_file: replica_patch.yaml
+
+create_sc: storage-class.yaml
+
+percona_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml
+
+replica_count: 2 
+
+replace_item:
+  - nodename_where_replica_pod_1_got_scheduled
+  - nodename_where_replica_pod_2_got_scheduled
+
+replace_with:
+  - "{{node_details.results[0].stdout}}"
+  - "{{node_details.results[1].stdout}}"
+
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: setup/logs/test-node-eviction-out-of-disk.log
+
+key: node.kubernetes.io/out-of-disk

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -254,11 +254,11 @@
         
          always:
 
-           #- name: 5) Terminate the log aggregator
-           #  shell: source ~/.profile; killall stern
-           #  args:
-           #    executable: /bin/bash
-           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
            
 
            - name: 6) Send slack notification

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -241,11 +241,11 @@
          delay: 30
          retries: 5
 
-       - name: 4d) Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       #- name: 4d) Terminate the log aggregator
+       #  shell: source ~/.profile; killall stern
+       #  args:
+       #    executable: /bin/bash
+       #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Test Passed
          set_fact:
@@ -258,7 +258,7 @@
 
      always:
 
-       - include: 5) test-node-eviction-out-of-disk-cleanup.yml
+       - include: test-node-eviction-out-of-disk-cleanup.yml
 
        - name: 6) Send slack notification
          slack:

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -22,40 +22,27 @@
 
    - block:
 
+       - include: test-node-eviction-out-of-disk-prereq.yml
+
        ###################################################
        #              1)PREPARE FOR TEST                 #
        # (Place artifacts in kubemaster, start logger &  #
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
 
-       - name: 1a) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: 1b) Check status of maya-api server
+       - name: 1a) Check status of maya-api server
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: openebs
             app: maya-api
 
-       - name: 1c) Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         become: true
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: 1d) Obtaining storage classes yaml
+       - name: 1b) Obtaining storage classes yaml
          shell: kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 1e) Get the Number of nodes count
+       - name: 1c) Get the Number of nodes count
          shell: kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
          args:
            executable: /bin/bash
@@ -66,7 +53,7 @@
          set_fact:
             node_count: " {{ node_out.stdout}}"
 
-       - name: 1f) Replace the replica count in storage classes yaml
+       - name: 1d) Replace the replica count in storage classes yaml
          replace:
            path: "{{ create_sc }}"
            regexp: 'openebs.io/jiva-replica-count: "3"'
@@ -89,14 +76,26 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Create nodeeviction namespace
+         shell: kubectl create ns nodeeviction
+         args:
+           executable: /bin/bash
+         register: ns_out
+         until: "'created' in ns_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
        - name: 2b) Create percona deployment with OpenEBS storage
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_link }}"
+           ns: nodeeviction
 
        - name: Check whether percona application is running
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: nodeeviction
             app: percona
 
        - name: 2c) Check specified number of replica pods are created
@@ -123,7 +122,7 @@
            files_to_copy: "{{ patch_file }}"
 
        - name: 2e) Gather node details for scheduled replicas
-         shell: kubectl get pod --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $8}' | awk 'FNR == {{ item }} {print}'
+         shell: kubectl get pod -n nodeeviction -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}' | awk 'FNR == {{ item }} {print}'
          args:
            executable: /bin/bash
          register: node_details
@@ -143,7 +142,7 @@
            - 1
 
        - name: 3a) Get deployment details to set node affinity
-         shell: kubectl get deploy --all-namespaces |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $2}'
+         shell: kubectl get deploy -n nodeeviction |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $1}'
          args:
            executable: /bin/bash
          register: deploy_name
@@ -154,7 +153,7 @@
            timeout: 120
 
        - name: 3b) Set replica deployment with node affinity policy
-         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -p "$(cat replica_patch.yaml)"
+         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -n nodeeviction -p "$(cat replica_patch.yaml)"
          args:
            executable: /bin/bash
          register: patch_out
@@ -164,7 +163,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3c) Check whether replica pods are re-scheduled and running
-         shell: kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
+         shell: kubectl get pods -n nodeeviction | grep rep | grep -i running |wc -l
          args:
            executable: /bin/bash
          register: rep_count
@@ -180,14 +179,14 @@
        #(Verify replica pod adhering NodeAffinity Policy) #
        ####################################################
 
-       - name: Get node on which replica is scheduled
-         shell: kubectl get pods -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
+       - name: 4a) Get node on which replica is scheduled
+         shell: kubectl get pods -n nodeeviction -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
          args:
            executable: /bin/bash
          register: node_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Taint node with Eviction Condition node.kubernetes.io/out-of-disk
+       - name: 4b) Taint node with Eviction Condition node.kubernetes.io/out-of-disk
          command: kubectl taint nodes {{ node_name.stdout }} {{ key }}=:NoExecute
          args:
            executable: /bin/bash
@@ -197,8 +196,8 @@
          retries: 15
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Verify replica pod remains in Pending state
-         shell: kubectl get pods | grep pvc | grep -i Pending |wc -l
+       - name: 4c) Verify replica pod remains in Pending state
+         shell: kubectl get pods -n nodeeviction | grep pvc | grep -i Pending |wc -l
          args:
            executable: /bin/bash
          register: check_replica
@@ -214,14 +213,14 @@
        # on same node adhering NodeAffinity Policy)       #
        ####################################################
 
-       - name: 4a) Get pod_name to Verify replica pod is scheduled on same node
-         shell: kubectl get pods | grep pvc | grep -i Pending | awk {'print $1'}
+       - name: 5a) Get pod_name to Verify replica pod is scheduled on same node
+         shell: kubectl get pods -n nodeeviction | grep pvc | grep -i Pending | awk {'print $1'}
          args:
            executable: /bin/bash
          register: pod_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 4b) Untaint node with Eviction Condition node.kubernetes.io/out-of-disk
+       - name: 5b) Untaint node with Eviction Condition node.kubernetes.io/out-of-disk
          command: kubectl taint nodes {{ node_name.stdout }} {{ key }}:NoExecute-
          args:
            executable: /bin/bash
@@ -231,8 +230,8 @@
          retries: 15
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 4c) Verify replica pod is scheduled on same node adhering NodeAffinity Policy
-         shell: kubectl get pods | grep {{ pod_name.stdout }}
+       - name: 5c) Verify replica pod is scheduled on same node adhering NodeAffinity Policy
+         shell: kubectl get pods -n nodeeviction -o wide | grep {{ node_name.stdout }} | grep {{ pod_name.stdout }}
          args:
            executable: /bin/bash
          register: replica_status
@@ -240,12 +239,6 @@
          until: "'Running' in replica_status.stdout"
          delay: 30
          retries: 5
-
-       #- name: 4d) Terminate the log aggregator
-       #  shell: source ~/.profile; killall stern
-       #  args:
-       #    executable: /bin/bash
-       #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Test Passed
          set_fact:
@@ -257,11 +250,29 @@
            flag: "Fail"
 
      always:
+       - block:
+ 
+           - include: test-node-eviction-out-of-disk-cleanup.yml
 
-       - include: test-node-eviction-out-of-disk-cleanup.yml
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
 
-       - name: 6) Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+        
+         always:
+           #- name: 5) Terminate the log aggregator
+           #  shell: source ~/.profile; killall stern
+           #  args:
+           #    executable: /bin/bash
+           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           
+
+           - name: 6) Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}, {{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -23,51 +23,63 @@
    - block:
 
        ###################################################
-       #                PREPARE FOR TEST                 #
+       #              1)PREPARE FOR TEST                 #
        # (Place artifacts in kubemaster, start logger &  #
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
 
-       - name: Get $HOME of K8s master for kubernetes user
+       - name: 1a) Get $HOME of K8s master for kubernetes user
          shell: source ~/.profile; echo $HOME
          args:
            executable: /bin/bash
          register: result_kube_home
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check status of maya-api server
+       - name: 1b) Check status of maya-api server
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             app: maya-api
 
-       - name: Start the log aggregator to capture test pod logs
+       - name: 1c) Start the log aggregator to capture test pod logs
          shell: >
            source ~/.profile;
            nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
          args:
            executable: /bin/bash
+         become: true
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Obtaining storage classes yaml
+       - name: 1d) Obtaining storage classes yaml
          shell: kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Replace the replica count in storage classes yaml
+       - name: 1e) Get the Number of nodes count
+         shell: kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_out
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Fetch the node count from stdout
+         set_fact:
+            node_count: " {{ node_out.stdout}}"
+
+       - name: 1f) Replace the replica count in storage classes yaml
          replace:
            path: "{{ create_sc }}"
            regexp: 'openebs.io/jiva-replica-count: "3"'
-           replace: 'openebs.io/jiva-replica-count: "2"'
+           replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        ####################################################
-       #              Deploy Application                  #
+       #           2) Deploy Application                  #
        # (Apply replica patch and set NodeAffinity and    #
        # verify replica pods are re-scheduled and running)#
        ####################################################
 
-       - name: Delete the existing storage class and create new one
+       - name: 2a) Delete the existing storage class and create new one
          shell: kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
          args:
            executable: /bin/bash
@@ -77,7 +89,7 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Create percona deployment with OpenEBS storage
+       - name: 2b) Create percona deployment with OpenEBS storage
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_link }}"
@@ -87,7 +99,7 @@
          vars:
             app: percona
 
-       - name: Check specified number of replica pods are created
+       - name: 2c) Check specified number of replica pods are created
          shell: kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
          args:
            executable: /bin/bash
@@ -105,12 +117,12 @@
          register: pv_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Copy the replica patch specs to kubemaster
+       - name: 2d) Copy the replica patch specs to kubemaster
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
          vars:
            files_to_copy: "{{ patch_file }}"
 
-       - name: Gather node details for scheduled replicas
+       - name: 2e) Gather node details for scheduled replicas
          shell: kubectl get pod --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $8}' | awk 'FNR == {{ item }} {print}'
          args:
            executable: /bin/bash
@@ -120,7 +132,7 @@
            - 2
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Update replica patch spec with node details
+       - name: 2f) Update replica patch spec with node details
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
          vars:
            path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
@@ -130,7 +142,7 @@
            - 0
            - 1
 
-       - name: Get deployment details to set node affinity
+       - name: 3a) Get deployment details to set node affinity
          shell: kubectl get deploy --all-namespaces |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $2}'
          args:
            executable: /bin/bash
@@ -141,7 +153,7 @@
          wait_for:
            timeout: 120
 
-       - name: Set replica deployment with node affinity policy
+       - name: 3b) Set replica deployment with node affinity policy
          shell: kubectl patch deployment "{{ deploy_name.stdout }}" -p "$(cat replica_patch.yaml)"
          args:
            executable: /bin/bash
@@ -151,7 +163,7 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Check whether replica pods are re-scheduled and running
+       - name: 3c) Check whether replica pods are re-scheduled and running
          shell: kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
          args:
            executable: /bin/bash
@@ -202,14 +214,14 @@
        # on same node adhering NodeAffinity Policy)       #
        ####################################################
 
-       - name: Get pod_name to Verify replica pod is scheduled on same node
-         shell: kubectl get pods | grep pvc | grep -i Pending
+       - name: 4a) Get pod_name to Verify replica pod is scheduled on same node
+         shell: kubectl get pods | grep pvc | grep -i Pending | awk {'print $1'}
          args:
            executable: /bin/bash
          register: pod_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Untaint node with Eviction Condition node.kubernetes.io/out-of-disk
+       - name: 4b) Untaint node with Eviction Condition node.kubernetes.io/out-of-disk
          command: kubectl taint nodes {{ node_name.stdout }} {{ key }}:NoExecute-
          args:
            executable: /bin/bash
@@ -219,7 +231,7 @@
          retries: 15
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Verify replica pod is scheduled on same node adhering NodeAffinity Policy
+       - name: 4c) Verify replica pod is scheduled on same node adhering NodeAffinity Policy
          shell: kubectl get pods | grep {{ pod_name.stdout }}
          args:
            executable: /bin/bash
@@ -229,7 +241,7 @@
          delay: 30
          retries: 5
 
-       - name: Terminate the log aggregator
+       - name: 4d) Terminate the log aggregator
          shell: source ~/.profile; killall stern
          args:
            executable: /bin/bash
@@ -246,9 +258,9 @@
 
      always:
 
-       - include: test-node-eviction-out-of-disk-cleanup.yml
+       - include: 5) test-node-eviction-out-of-disk-cleanup.yml
 
-       - name: Send slack notification
+       - name: 6) Send slack notification
          slack:
            token: "{{ lookup('env','SLACK_TOKEN') }}"
            msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -30,8 +30,7 @@
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
 
-       - name: 1a) Check status of maya-api server
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             ns: openebs
             app: maya-api
@@ -86,14 +85,12 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 2b) Create percona deployment with OpenEBS storage
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_link }}"
            ns: nodeeviction
 
-       - name: Check whether percona application is running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             ns: nodeeviction
             app: percona
@@ -116,8 +113,7 @@
          register: pv_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 2d) Copy the replica patch specs to kubemaster
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
          vars:
            files_to_copy: "{{ patch_file }}"
 
@@ -131,8 +127,7 @@
            - 2
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 2f) Update replica patch spec with node details
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
          vars:
            path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
            regex1: "{{replace_item}}"
@@ -264,11 +259,12 @@
                cflag: cleanup_fail
         
          always:
-           #- name: 5) Terminate the log aggregator
-           #  shell: source ~/.profile; killall stern
-           #  args:
-           #    executable: /bin/bash
-           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
            
 
            - name: 6) Send slack notification

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -76,7 +76,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Create nodeeviction namespace
-         shell: kubectl create ns nodeeviction
+         shell: kubectl create ns {{ namespace }}
          args:
            executable: /bin/bash
          register: ns_out
@@ -88,11 +88,11 @@
        - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_link }}"
-           ns: nodeeviction
+           ns: "{{ namespace }}"
 
        - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
-            ns: nodeeviction
+            ns: "{{ namespace }}"
             app: percona
 
        - name: 2c) Check specified number of replica pods are created
@@ -100,7 +100,7 @@
          args:
            executable: /bin/bash
          register: rep_count
-         until: "'2' in rep_count.stdout"
+         until: "'{{ (node_count) |int-1 }}' in rep_count.stdout"
          delay: 30
          retries: 15
          ignore_errors: true
@@ -118,26 +118,20 @@
            files_to_copy: "{{ patch_file }}"
 
        - name: 2e) Gather node details for scheduled replicas
-         shell: kubectl get pod -n nodeeviction -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}' | awk 'FNR == {{ item }} {print}'
+         shell: kubectl get pod -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}'
          args:
            executable: /bin/bash
          register: node_details
-         with_items:
-           - 1
-           - 2
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
          vars:
            path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
            regex1: "{{replace_item}}"
-           regex2: "{{node_details[{{ item }}].stdout}}"
-         with_items:
-           - 0
-           - 1
+           regex2: "{{replace_with}}"
 
        - name: 3a) Get deployment details to set node affinity
-         shell: kubectl get deploy -n nodeeviction |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $1}'
+         shell: kubectl get deploy -n {{ namespace }} |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $1}'
          args:
            executable: /bin/bash
          register: deploy_name
@@ -148,7 +142,7 @@
            timeout: 120
 
        - name: 3b) Set replica deployment with node affinity policy
-         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -n nodeeviction -p "$(cat replica_patch.yaml)"
+         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -n {{ namespace }} -p "$(cat replica_patch.yaml)"
          args:
            executable: /bin/bash
          register: patch_out
@@ -158,7 +152,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3c) Check whether replica pods are re-scheduled and running
-         shell: kubectl get pods -n nodeeviction | grep rep | grep -i running |wc -l
+         shell: kubectl get pods -n {{ namespace }} | grep rep | grep -i running |wc -l
          args:
            executable: /bin/bash
          register: rep_count
@@ -175,7 +169,7 @@
        ####################################################
 
        - name: 4a) Get node on which replica is scheduled
-         shell: kubectl get pods -n nodeeviction -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
+         shell: kubectl get pods -n {{ namespace }} -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
          args:
            executable: /bin/bash
          register: node_name
@@ -192,7 +186,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 4c) Verify replica pod remains in Pending state
-         shell: kubectl get pods -n nodeeviction | grep pvc | grep -i Pending |wc -l
+         shell: kubectl get pods -n {{ namespace }} | grep pvc | grep -i Pending |wc -l
          args:
            executable: /bin/bash
          register: check_replica
@@ -209,7 +203,7 @@
        ####################################################
 
        - name: 5a) Get pod_name to Verify replica pod is scheduled on same node
-         shell: kubectl get pods -n nodeeviction | grep pvc | grep -i Pending | awk {'print $1'}
+         shell: kubectl get pods -n {{ namespace }} | grep pvc | grep -i Pending | awk {'print $1'}
          args:
            executable: /bin/bash
          register: pod_name
@@ -226,7 +220,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 5c) Verify replica pod is scheduled on same node adhering NodeAffinity Policy
-         shell: kubectl get pods -n nodeeviction -o wide | grep {{ node_name.stdout }} | grep {{ pod_name.stdout }}
+         shell: kubectl get pods -n {{ namespace }} -o wide | grep {{ node_name.stdout }} | grep {{ pod_name.stdout }}
          args:
            executable: /bin/bash
          register: replica_status
@@ -260,11 +254,11 @@
         
          always:
 
-           - name: 5) Terminate the log aggregator
-             shell: source ~/.profile; killall stern
-             args:
-               executable: /bin/bash
-             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           #- name: 5) Terminate the log aggregator
+           #  shell: source ~/.profile; killall stern
+           #  args:
+           #    executable: /bin/bash
+           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
            
 
            - name: 6) Send slack notification

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -1,0 +1,255 @@
+# test-node-eviction-out-of-disk-vars.yml
+# Author: Sudarshan Darga
+# Description: Verify volume replica pods patched with NodeAffinity are not evicted by Kubernetes (out-of-disk)
+###############################################################################################
+#Test Steps:
+#1. Copy/Gather Test artifacts to Kubemaster.
+#2. Deploy Percona application with one replica less than available nodes.
+#3. Patch NodeAffinity to stick replica to a specific node.
+#4. Configure Eviction taint on sticky node with node.kubernetes.io/out-of-disk condition.
+#5. Verify evicted replica pod stays in 'Pending' state adhering NodeAffinity policy.
+#6. Re-Configure/Remove Eviction taint on sticky node.
+#7. Verify replica pod is scheduled and Running on the sticky node adhering NodeAffinity policy.
+#8. Perform cleanup of test artifacts.
+###############################################################################################
+
+- hosts: localhost
+
+  vars_files:
+    - test-node-eviction-out-of-disk-vars.yml
+
+  tasks:
+
+   - block:
+
+       ###################################################
+       #                PREPARE FOR TEST                 #
+       # (Place artifacts in kubemaster, start logger &  #
+       # confirm OpenEBS operator is ready for requests. #
+       ###################################################
+
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check status of maya-api server
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: maya-api
+
+       - name: Start the log aggregator to capture test pod logs
+         shell: >
+           source ~/.profile;
+           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Obtaining storage classes yaml
+         shell: kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Replace the replica count in storage classes yaml
+         replace:
+           path: "{{ create_sc }}"
+           regexp: 'openebs.io/jiva-replica-count: "3"'
+           replace: 'openebs.io/jiva-replica-count: "2"'
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       ####################################################
+       #              Deploy Application                  #
+       # (Apply replica patch and set NodeAffinity and    #
+       # verify replica pods are re-scheduled and running)#
+       ####################################################
+
+       - name: Delete the existing storage class and create new one
+         shell: kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         register: sc_out
+         until: "'created' in sc_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Create percona deployment with OpenEBS storage
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_link }}"
+
+       - name: Check whether percona application is running
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            app: percona
+
+       - name: Check specified number of replica pods are created
+         shell: kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
+         args:
+           executable: /bin/bash
+         register: rep_count
+         until: "'2' in rep_count.stdout"
+         delay: 30
+         retries: 15
+         ignore_errors: true
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Get pv name associated with percona application
+         shell: kubectl get pv | grep openebs-percona | awk '{print $1}'
+         args:
+           executable: /bin/bash
+         register: pv_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Copy the replica patch specs to kubemaster
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
+         vars:
+           files_to_copy: "{{ patch_file }}"
+
+       - name: Gather node details for scheduled replicas
+         shell: kubectl get pod --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $8}' | awk 'FNR == {{ item }} {print}'
+         args:
+           executable: /bin/bash
+         register: node_details
+         with_items:
+           - 1
+           - 2
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Update replica patch spec with node details
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         vars:
+           path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
+           regex1: "{{replace_item}}"
+           regex2: "{{node_details[{{ item }}].stdout}}"
+         with_items:
+           - 0
+           - 1
+
+       - name: Get deployment details to set node affinity
+         shell: kubectl get deploy --all-namespaces |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $2}'
+         args:
+           executable: /bin/bash
+         register: deploy_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Wait for 120s before applying patch
+         wait_for:
+           timeout: 120
+
+       - name: Set replica deployment with node affinity policy
+         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -p "$(cat replica_patch.yaml)"
+         args:
+           executable: /bin/bash
+         register: patch_out
+         until: "'patched' in patch_out.stdout"
+         delay: 20
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Check whether replica pods are re-scheduled and running
+         shell: kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
+         args:
+           executable: /bin/bash
+         register: rep_count
+         until: "'2' in rep_count.stdout"
+         delay: 30
+         retries: 15
+         ignore_errors: true
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       ####################################################
+       # Set out-of-disk eviction taint condition on one  #
+       # of the node where replica is scheduled.          #
+       #(Verify replica pod adhering NodeAffinity Policy) #
+       ####################################################
+
+       - name: Get node on which replica is scheduled
+         shell: kubectl get pods -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
+         args:
+           executable: /bin/bash
+         register: node_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Taint node with Eviction Condition node.kubernetes.io/out-of-disk
+         command: kubectl taint nodes {{ node_name.stdout }} {{ key }}=:NoExecute
+         args:
+           executable: /bin/bash
+         register: taint_output
+         until: "'tainted' in taint_output.stdout"
+         delay: 30
+         retries: 15
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Verify replica pod remains in Pending state
+         shell: kubectl get pods | grep pvc | grep -i Pending |wc -l
+         args:
+           executable: /bin/bash
+         register: check_replica
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'1' in check_replica.stdout"
+         delay: 30
+         retries: 15
+
+       ####################################################
+       # Remove out-of-disk eviction taint condition from #
+       # the node.                                        #
+       #(Verify replica pod is re-scheduled and Running   #
+       # on same node adhering NodeAffinity Policy)       #
+       ####################################################
+
+       - name: Get pod_name to Verify replica pod is scheduled on same node
+         shell: kubectl get pods | grep pvc | grep -i Pending
+         args:
+           executable: /bin/bash
+         register: pod_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Untaint node with Eviction Condition node.kubernetes.io/out-of-disk
+         command: kubectl taint nodes {{ node_name.stdout }} {{ key }}:NoExecute-
+         args:
+           executable: /bin/bash
+         register: untaint_output
+         until: "'untainted' in untaint_output.stdout"
+         delay: 30
+         retries: 15
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Verify replica pod is scheduled on same node adhering NodeAffinity Policy
+         shell: kubectl get pods | grep {{ pod_name.stdout }}
+         args:
+           executable: /bin/bash
+         register: replica_status
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'Running' in replica_status.stdout"
+         delay: 30
+         retries: 5
+
+       - name: Terminate the log aggregator
+         shell: source ~/.profile; killall stern
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Test Passed
+         set_fact:
+            flag: "Pass"
+
+   - rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Fail"
+
+     always:
+
+       - include: test-node-eviction-out-of-disk-cleanup.yml
+
+       - name: Send slack notification
+         slack:
+           token: "{{ lookup('env','SLACK_TOKEN') }}"
+           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+         when: slack_notify | bool and lookup('env','SLACK_TOKEN')

--- a/e2e/ansible/playbooks/utils/delete_deploy.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy.yml
@@ -1,6 +1,6 @@
 ---
-- name: Delete deployed application files
-  shell: source ~/.profile; kubectl delete -f {{ item }}
+- name: Deploy application files
+  shell: source ~/.profile; kubectl delete -f {{ item }} -n {{ ns }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/utils/delete_deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy_check.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check pod status
-  shell: source ~/.profile; kubectl get pods | grep {{ app }}
+  shell: source ~/.profile; kubectl get pods -n {{ ns }} | grep {{ app }}
   args:
     executable: /bin/bash
   register: result
@@ -8,4 +8,4 @@
   until: "app and 'Running' not in result.stdout"
   delay: 30
   retries: 15
-  ignore_errors: True
+  ignore_erros: true

--- a/e2e/ansible/playbooks/utils/deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/deploy_check.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check {{ app }} pod status
-  shell: source ~/.profile; kubectl get pods | grep {{ app }}
+  shell: source ~/.profile; kubectl get pods -n {{ ns }} | grep {{ app }}
   args:
     executable: /bin/bash
   register: result

--- a/e2e/ansible/playbooks/utils/deploy_task.yml
+++ b/e2e/ansible/playbooks/utils/deploy_task.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy application files
-  shell: source ~/.profile; kubectl apply -f {{ item }}
+  shell: source ~/.profile; kubectl apply -f {{ item }} -n {{ ns }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/utils/regex_task.yml
+++ b/e2e/ansible/playbooks/utils/regex_task.yml
@@ -1,7 +1,7 @@
 ---
 - name: Replace volume-claim name with test parameters
   replace:
-    path: {{ path }}
+    path: "{{ path }}"
     regexp: '{{ item.0 }}'
     replace: '{{ item.1 }}'
   delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"


### PR DESCRIPTION
Signed-off-by: Sudarshan Darga <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Includes an ansible playbook test suite to induce taint with Eviction Condition and verify the behavior.
- Configure node affinity to stick pod to a specified node.
- Deploy application with replica's scheduled as per node affinity policy.
- Simulate node evictions by tainting a node with condition "out-of-disk".
> kubectl taint nodes kubeminion-01 node.kubernetes.io/memory-pressure=:NoExecute
- Verify that pod scheduled on tainted node is evicted as per taint condition.
- Also verify that pod is not scheduled on any other nodes as per node affinity policy set.
- Remove the simulated eviction taint condition.
> kubectl taint nodes kubeminion-01 node.kubernetes.io/memory-pressure:NoExecute-
- Verify that pods are scheduled and running successfully again.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@ksatchit Can you please review this PR?