### PR TITLE
deploying openebs-operator with default namespace at the end of the …

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
@@ -64,3 +64,28 @@
          with_items:
              - "{{test_artifacts}}"
 
+       - name: sleep for 50 seconds and continue with play
+         wait_for:
+           timeout: "50"
+
+       - name: Deploy openebs operator with default namespaces
+         shell: source ~/.profile; kubectl apply -f "{{ openebs_operator_link }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         ignore_errors: true
+         changed_when: True
+
+       - name: Check whether maya-apiserver pod is running
+         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'Running' in result.stdout"
+         delay: 40
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         ignore_errors: true
+         changed_when: True
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-storage-pool/deploy-openebs-pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-storage-pool/deploy-openebs-pvc.yml
@@ -107,7 +107,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when: "'namespace' not in result.stdout"
          ignore_errors: true
-         chnaged_when: True
+         changed_when: True
 
        - name: Copy test-pvc yaml to kubemaster
          copy:
@@ -172,8 +172,9 @@
          when: stat_result.stat.exists
 
        - name: Terminate the log aggregator
-         shell: source {{ profile }}; killall stern
+         shell: source ~/.profile; killall stern
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          changed_when: True
+         ignore_errors: True

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-storage-pool/test-storage-pool.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-storage-pool/test-storage-pool.yml
@@ -52,6 +52,27 @@
            operator_namespace=openebs
            namespace=percona
 
+       - name: Deploy openebs operator with default namespaces
+         shell: source ~/.profile; kubectl apply -f "{{ openebs_operator_link }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         ignore_errors: true
+         changed_when: True
+
+       - name: Check whether maya-apiserver pod is running
+         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'Running' in result.stdout"
+         delay: 40
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         ignore_errors: true
+         changed_when: True
+
+
        - name: Set flag to pass if test case is passed
          set_fact:
            flag: "Pass"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/cleanup.yml
@@ -48,25 +48,6 @@
   retries: 6
   changed_when: True
 
-- name: Delete the openebs operator
-  shell: source ~/.profile; kubectl delete -f "{{ openebs_operator_link }}"
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
-
-- name: Confirm pod has been deleted
-  shell: source ~/.profile; kubectl get pods --all-namespaces
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
-  delay: 100
-  retries: 6
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
-
-
 - name: Remove test artifacts
   file:
     path: "{{ result_kube_home.stdout }}/{{ item }}"


### PR DESCRIPTION
…test

Signed-off-by: swarna <swarnalatha@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
In few playbooks deploying openebs-operator with non default namespace and deleting it at the end of the test.
In ci minium requirement is openebs-operator should be running as part this deploying operator with default name space after cleanup.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@ksatchit Please review this PR.
