### PR TITLE
Adds missing space in README file

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@ The source code developed for the OpenEBS Project is licensed
 under Apache 2.0. 
 
 However, the OpenEBS project contains unmodified/modified 
-subcomponents from other OpenSource Projects with separate
+subcomponents from other Open Source Projects with separate
 copyright notices and license terms. 
 
 Your use of the source code for these subcomponents is subject

--- a/README.md
+++ b/README.md
@@ -72,5 +72,5 @@ Please start with the pinned repositories or with [OpenEBS Architecture](./contr
 ## License
 
 OpenEBS is developed under Apache 2.0 License at the project level. 
-Some components of the project are derived from other opensource projects like Nomad, Longhorn 
+Some components of the project are derived from other open source projects like Nomad, Longhorn 
 and are distributed under their respective licenses. 


### PR DESCRIPTION
Signed-off-by: sachinmukherjee <sachinmukherjee29@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- It adds a missing space between open source in README file under License section.
- Earlier there was no space and it was written like this `opensource`.
- Now in this PR, it looks like this `open source`.

**Which issue this PR fixes**: fixes https://github.com/openebs/openebs/issues/1468

