### PR TITLE
Include latest stable openebs images (0.5.4) in helm defaults and K8s operator spec

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-version: 0.5.3
+version: 0.5.4
 name: openebs
-appVersion: 0.5.3
+appVersion: 0.5.4
 description: Containerized Storage for Containers
 icon: https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png
 home: http://www.openebs.io/

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -33,17 +33,17 @@ The following tables lists the configurable parameters of the OpenEBS chart and 
 | `rbacEnable`                         | Enable RBAC Resources                         | `true`                            |
 | `image.pullPolicy`                   | Container pull policy                         | `IfNotPresent`                    |
 | `apiserver.image`                    | Docker Image for API Server                   | `openebs/m-apiserver`             |
-| `apiserver.imageTag`                 | Docker Image Tag for API Server               | `0.5.3`                           |
+| `apiserver.imageTag`                 | Docker Image Tag for API Server               | `0.5.4`                           |
 | `apiserver.replicas`                 | Number of API Server Replicas                 | `2`                               |
 | `apiserver.antiAffinity.enabled`     | Enable anti-affinity for API Server Replicas  | `true`                           |
 | `apiserver.antiAffinity.type`        | Anti-affinity type for API Server             | `Hard`                           |
 | `provisioner.image`                  | Docker Image for Provisioner                  | `openebs/openebs-k8s-provisioner` |
-| `provisioner.imageTag`               | Docker Image Tag for Provisioner              | `0.5.3`                           |
+| `provisioner.imageTag`               | Docker Image Tag for Provisioner              | `0.5.4`                           |
 | `provisioner.replicas`               | Number of Provisioner Replicas                | `2`                               |
 | `provisioner.antiAffinity.enabled`   | Enable anti-affinity for API Server Replicas  | `true`                           |
 | `provisioner.antiAffinity.type`      | Anti-affinity type for Provisioner            | `Hard`                           |
 | `jiva.image`                         | Docker Image for Jiva                         | `openebs/jiva`                    |
-| `jiva.imageTag`                      | Docker Image Tag for Jiva                     | `0.5.3`                           |
+| `jiva.imageTag`                      | Docker Image Tag for Jiva                     | `0.5.4`                           |
 | `jiva.replicas`                      | Number of Jiva Replicas                       | `3`                               |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -14,7 +14,7 @@ image:
 
 apiserver:
   image: "openebs/m-apiserver"
-  imageTag: "0.5.3"
+  imageTag: "0.5.4"
   replicas: 2
   ports:
     externalPort: 5656
@@ -27,7 +27,7 @@ apiserver:
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
-  imageTag: "0.5.3"
+  imageTag: "0.5.4"
   replicas: 2
   mayaportalurl: "https://mayaonline.io/"
   monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
@@ -56,11 +56,11 @@ prometheus:
 
 jiva:
   image: "openebs/jiva"
-  imageTag: "0.5.3"
+  imageTag: "0.5.4"
   replicas: 3
 
 policies:
   monitoring:
     enabled: true
     image: "openebs/m-exporter"
-    imageTag: "0.5.3"
+    imageTag: "0.5.4"

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -3,7 +3,7 @@
 # Launch the maya-apiserver ( deployment )
 # Launch the maya-storagemanager ( deameon set )
 
-# Create Maya Service Account 
+# Create Maya Service Account
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -37,7 +37,7 @@ rules:
   verbs: [ "get", "list", "create" ]
 - apiGroups: ["*"]
   resources: ["storagepools"]
-  verbs: ["get", "list"] 
+  verbs: ["get", "list"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
@@ -76,7 +76,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.5.3
+        image: openebs/m-apiserver:0.5.4
         ports:
         - containerPort: 5656
         env:
@@ -91,11 +91,11 @@ spec:
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.3"
+          value: "openebs/jiva:0.5.4"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.3"
+          value: "openebs/jiva:0.5.4"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.5.3"
+          value: "openebs/m-exporter:0.5.4"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
 ---
@@ -129,7 +129,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.5.3
+        image: openebs/openebs-k8s-provisioner:0.5.4
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -141,6 +141,13 @@ spec:
         # This is supported for openebs provisioner version 0.5.2 onwards
         #- name: OPENEBS_IO_KUBE_CONFIG
         #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_VALID_FSTYPE enables openebs provisioner to provision openebs
+        # volume other then ext4(default fstype). After adding "openebs.io/fstype"
+        # parameters in StorageClasse will provision the volume with specified fstype.
+        # This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.4 onwards
+        #- name: OPENEBS_VALID_FSTYPE
+        #  value: "ext4,xfs"
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -205,6 +212,29 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "2"
+  openebs.io/jiva-replica-count: "3"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: volumepolicies.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: volumepolicies
+    # singular name to be used as an alias on the CLI and for display
+    singular: volumepolicy
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: VolumePolicy
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - vp


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Include latest stable openebs images (0.5.4) in helm defaults and K8s operator spec

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
