### PR TITLE
(WIP) Enhance existing test playbooks to include a check for cleanup pass/fail and set flag.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -56,12 +56,6 @@
 
 - name: Delete namespace
   command: kubectl delete ns {{ namespace }}
-  args:
-    executable: /bin/bash
-  register: ns_out
-  until: "'deleted' in ns_out.stdout"
-  delay: 10
-  retries: 5
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-cleanup.yml
@@ -1,23 +1,24 @@
 ---
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: pvc
+  changed_when: true
 
-- name: Delete percona mysql pod 
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
+    ns: "{{ namespace }}"
     app_yml: "{{ percona_files.0 }}"
 
-- name: Check status of percona
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
+    ns: "{{ namespace }}"
     app: percona
 
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -25,18 +26,21 @@
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
   retries: 10
+  changed_when: true
 
-- name: Remove the percona liveness check config map 
-  shell: source ~/.profile; kubectl delete cm sqltest 
+- name: Remove the percona liveness check config map
+  shell: source ~/.profile; kubectl delete cm sqltest -n {{ namespace }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   failed_when: "'configmap' and 'deleted' not in result.stdout"
+  changed_when: true
 
 - name: Delete the chaoskube infrastructure
   include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
+    ns: default
     app_yml: "{{ chaoskube_files }}"
 
 - name: Confirm the chaoskube clusterrolebinding has been deleted
@@ -48,15 +52,34 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   failed_when: "'chaoskube' in result.stdout"
+  changed_when: true
 
-- name: Remove test artifacts
-  shell: rm -rf {{ item.0 }}; rm -rf {{ item.1 }}
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
   args:
     executable: /bin/bash
+  register: ns_out
+  until: "'deleted' in ns_out.stdout"
+  delay: 10
+  retries: 5
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  with_together:
+  changed_when: true
+
+- name: Remove test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
     - "{{percona_files}}"
+
+- name: Remove chaoskube test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
     - "{{chaoskube_files}}"
-  
- 
- 
+
+
+

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure-vars.yml
@@ -1,7 +1,7 @@
 ---
 test_name: test_ctrl_failure
 
-percona_links: 
+percona_links:
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/sql-test.sh
 
@@ -11,7 +11,7 @@ percona_files:
 
 chaoskube_files:
   - rbac.yaml
-  - chaoskube.yaml 
+  - chaoskube.yaml
 
 replace_item:
   - demo-vol1-claim
@@ -21,11 +21,13 @@ replace_with:
   - test-ctrl-failure
   - test-ctrl
 
+namespace: ctrl-failure
+
 utils_path: openebs/e2e/ansible/playbooks/utils
 
 chaos_duration: 120
 
-chaos_interval: 20 
+chaos_interval: 20
 
 test_pod_regex: maya*|openebs*|pvc*|percona*|chaos*
 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -14,26 +14,21 @@
 ###############################################################################################
 
 - hosts: localhost
- 
-  vars_files: 
-    - test-ctrl-failure-vars.yml 
- 
+
+  vars_files:
+    - test-ctrl-failure-vars.yml
+
   tasks:
    - block:
 
+       - include: test-ctrl-failure-prereq.yml
+
        ###################################################
        #                PREPARE FOR TEST                 #
-       # (Place artifacts in kubemaster, start logger &  # 
+       # (Place artifacts in kubemaster, start logger &  #
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
 
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args: 
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-      
        - name: Get percona spec and liveness scripts
          get_url:
            url: "{{ item }}"
@@ -48,121 +43,124 @@
            regex1: "{{replace_item}}"
            regex2: "{{replace_with}}"
 
-       - name: Copy the chaoskube specs to kubemaster  
+       - name: Copy the chaoskube specs to kubemaster
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
          vars:
            destination_node: "{{groups['kubernetes-kubemasters'].0}}"
-           files_to_copy: "{{ chaoskube_files }}"            
+           files_to_copy: "{{ chaoskube_files }}"
 
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: Check status of maya-api server
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: openebs
             app: maya-api
 
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup chaoskube deployment with an empty policy,#
-       # deploy percona w/ a liveness check for DB writes)# 
+       # deploy percona w/ a liveness check for DB writes)#
        ####################################################
 
-       - name: Setup the chaoskube infrastructure
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       - name: Create test specific namespace
+         command: kubectl create ns {{ namespace }}
+         args:
+           executable: /bin/bash
+         register: ns_out
+         until: "'created' in ns_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ chaoskube_files }}"
+           ns: default
 
        - name: Check whether chaoskube infrastructure is created
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: default
             app: chaoskube
 
-       - name: Set chaoskube pod name to variable 
-         set_fact: 
+       - name: Set chaoskube pod name to variable
+         set_fact:
            chaospod: "{{ result.stdout_lines[0].split()[0] }}"
 
-       - name: Create a configmap with the liveness sql script 
-         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
-         args: 
+       - name: Create a configmap with the liveness sql script
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} -n {{ namespace }}
+         args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result 
+         register: result
          failed_when: "'configmap' and 'created' not in result.stdout"
 
-       - name: Create percona deployment with OpenEBS storage
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_files.0 }}"
+           ns: "{{ namespace }}"
 
-       - name: Check whether percona application is running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
-       - name: Wait for 120s to ensure liveness check starts 
+       - name: Wait for 120s to ensure liveness check starts
          wait_for:
            timeout: 120
-         
-       - name: Get the name of the volume ctrl deployment 
-         shell: > 
-           source ~/.profile; kubectl get deployments 
+
+       - name: Get the name of the volume ctrl deployment
+         shell: >
+           source ~/.profile; kubectl get deployments -n {{ namespace }}
            -l openebs/controller=jiva-controller --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: result_deploy
 
-       - name: Set the ctrl deployment name to variable 
-         set_fact: 
+       - name: Set the ctrl deployment name to variable
+         set_fact:
            ctrl_deploy: "{{ result_deploy.stdout_lines[0].split()[0] }}"
 
        ########################################################
        #        INJECT FAULTS FOR SPECIFIED PERIOD            #
-       # (Obtain begin marker before fault-inject(FI),do ctrl # 
-       # failures, verify successful FI via end marker)       # 
+       # (Obtain begin marker before fault-inject(FI),do ctrl #
+       # failures, verify successful FI via end marker)       #
        ########################################################
 
        - name: Get the resourceVersion of the controller deployment
          shell: >
-           source ~/.profile; kubectl get deploy 
+           source ~/.profile; kubectl get deploy -n {{ namespace }}
            {{ ctrl_deploy }} -o yaml | grep resourceVersion
            | awk '{print $2}' | sed 's|"||g'
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: rv_bef          
- 
+         register: rv_bef
+
        - name: Initiate periodic controller failures from chaoskube
          shell: >
-           source ~/.profile; kubectl exec {{ chaospod }}  
-           -- timeout -t {{ chaos_duration }} chaoskube 
+           source ~/.profile; kubectl exec {{ chaospod }}
+           -- timeout -t {{ chaos_duration }} chaoskube
            --labels 'openebs/controller=jiva-controller'
-           --no-dry-run --interval={{ chaos_interval }}s 
+           --no-dry-run --interval={{ chaos_interval }}s
            --debug
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: chaos_result
-         ignore_errors: true 
+         ignore_errors: true
 
        - name: Get the resourceVersion of the controller deployment
          shell: >
-           source ~/.profile; kubectl get deploy 
+           source ~/.profile; kubectl get deploy
            {{ ctrl_deploy }} -o yaml | grep resourceVersion
            | awk '{print $2}' | sed 's|"||g'
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: rv_aft    
- 
-       - name: Compare resourceVersions of controller deployments 
-         debug: 
+         register: rv_aft
+
+       - name: Compare resourceVersions of controller deployments
+         debug:
            msg: "Verified controller pods were restarted by chaoskube"
          failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"
 
@@ -172,37 +170,51 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona pod is still running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/status_running.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
        ########################################################
-       #                        CLEANUP                       #			      
+       #                        CLEANUP                       #
        # (Tear down application, liveness configmap as well as#
-       # the FI (chaoskube) infrastructure. Also stop logger) # 
+       # the FI (chaoskube) infrastructure. Also stop logger) #
        ########################################################
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash 
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
-
-       - set_fact:
+       - name: Test Passed
+         set_fact:
            flag: "Pass"
 
-     rescue: 
-       - set_fact: 
+     rescue:
+       - name: Test Failed
+         set_fact:
            flag: "Fail"
 
      always:
-       - include: test-ctrl-failure-cleanup.yml
-         when: clean | bool
+       - block:
 
-       - name: Send slack notification
-         slack: 
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - include: test-ctrl-failure-cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           #- name: 5) Terminate the log aggregator
+           #  shell: source ~/.profile; killall stern
+           #  args:
+           #    executable: /bin/bash
+           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -62,12 +62,6 @@
 
        - name: Create test specific namespace
          command: kubectl create ns {{ namespace }}
-         args:
-           executable: /bin/bash
-         register: ns_out
-         until: "'created' in ns_out.stdout"
-         delay: 10
-         retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
@@ -206,11 +200,11 @@
 
          always:
 
-           #- name: 5) Terminate the log aggregator
-           #  shell: source ~/.profile; killall stern
-           #  args:
-           #    executable: /bin/bash
-           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
            - name: Send slack notification
              slack:

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
@@ -1,28 +1,33 @@
 ---
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: pvc
+  changed_when: true
 
 - name: Delete pumba infrastructure
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
-  vars:
-    app_yml: "{{ pumba_file }}"
+  shell: source ~/.profile; kubectl delete ds pumba
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 
 - name: Delete percona mysql pod
   include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
+    ns: "{{ namespace }}"
     app_yml: "{{ percona_files.0 }}"
 
 - name: Confirm percona pod deletion
   include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
+    ns: "{{ namespace }}"
     app: percona
 
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -30,14 +35,22 @@
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
   retries: 10
+  changed_when: true
 
-- name: Remove the percona liveness check config map 
-  shell: source ~/.profile; kubectl delete cm sqltest 
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
+  register: ns_out
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Remove the percona liveness check config map
+  shell: source ~/.profile; kubectl delete cm sqltest -n {{ namespace }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   failed_when: "'configmap' and 'deleted' not in result.stdout"
+  changed_when: true
 
 - name: Remove test artifacts
   file:
@@ -46,6 +59,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
     - "{{percona_files}}"
-  
- 
- 
+
+
+

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
@@ -39,7 +39,6 @@
 
 - name: Delete namespace
   command: kubectl delete ns {{ namespace }}
-  register: ns_out
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
@@ -24,6 +24,8 @@ delay_interavals:
   - 6000
   - 10000
 
+namespace: nw-rep
+
 pumba_file: https://raw.githubusercontent.com/openebs/elves/master/chaos/pumba/pumba_kube.yml 
 
 test_pod_regex: maya*|openebs*|pvc*|percona*|pumba*

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -68,10 +68,6 @@
 
        - name: Create test specific namespace
          command: kubectl create ns {{ namespace }}
-         register: ns_out
-         until: "'created' in ns_out.stdout"
-         delay: 10
-         retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Create a configmap with the liveness sql script

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -20,18 +20,13 @@
   tasks:
    - block:
 
+       - include: test-nw-failure-rep-prereq.yml
+
        ###################################################
        #                PREPARE FOR TEST                 #
        # (Place artifacts in kubemaster, start logger &  #
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
-
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Get percona spec and liveness scripts
          get_url:
@@ -47,17 +42,10 @@
            regex1: "{{replace_item}}"
            regex2: "{{replace_with}}"
 
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
        - name: Check status of maya-api server
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: openebs
             app: maya-api
 
        ####################################################
@@ -70,14 +58,24 @@
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ pumba_file }}"
+           ns: default
 
        - name: Check whether pumba infrastructure is created
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: default
             app: pumba
 
+       - name: Create test specific namespace
+         command: kubectl create ns {{ namespace }}
+         register: ns_out
+         until: "'created' in ns_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
        - name: Create a configmap with the liveness sql script
-         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }}
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} -n {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -88,6 +86,7 @@
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_files.0 }}"
+           ns: "{{ namespace }}"
 
        - name: Wait for 120s to ensure liveness check starts
          wait_for:
@@ -96,24 +95,25 @@
        - name: Check whether percona application is running
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
        - name: Get the node details on which pvc-rep is scheduled
-         shell: kubectl get pods -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
+         shell: kubectl get pods -n {{ namespace }} -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: node_rep
 
        - name: Get the pvc-rep name
-         shell: kubectl get pods | grep rep | awk 'FNR == 1 {print}' | awk {'print $1'}
+         shell: kubectl get pods -n {{ namespace }} | grep rep | awk 'FNR == 1 {print}' | awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: pvc_rep_name
 
        - name: Get the rep container name
-         shell: kubectl describe pod {{ pvc_rep_name.stdout }} | grep rep-con | awk {'print $1'}
+         shell: kubectl describe pod {{ pvc_rep_name.stdout }} -n {{ namespace }} | grep rep-con | awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -154,6 +154,7 @@
        - name: Confirm percona pod is still running
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/status_running.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
        ########################################################
@@ -162,26 +163,40 @@
        # the FI (chaoskube) infrastructure. Also stop logger) #
        ########################################################
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - set_fact:
+       - name: Test Passed
+         set_fact:
            flag: "Pass"
 
      rescue:
-       - set_fact:
+       - name: Test Failed
+         set_fact:
            flag: "Fail"
 
      always:
-       - include: test-nw-failure-rep-cleanup.yml
-         when: clean | bool
+       - block:
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - include: test-nw-failure-rep-cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           - name: Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -1,43 +1,54 @@
 ---
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ replace_with.0 }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: pvc
+  changed_when: true
 
 - name: Delete pumba infrastructure
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
-  vars:
-    app_yml: "{{ pumba_file }}"
+  shell: source ~/.profile; kubectl delete ds pumba
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 
-- name: Delete percona mysql pod
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
+    ns: "{{ namespace }}"
     app_yml: "{{ percona_files.0 }}"
 
-- name: Confirm percona pod deletion
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
+    ns: "{{ namespace }}"
     app: percona
 
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   failed_when: "'pvc' and 'Running' in result.stdout"
   delay: 30
-  retried: 10
+  retries: 10
+  changed_when: true
 
-- name: Remove the percona liveness check config map 
-  shell: source ~/.profile; kubectl delete cm sqltest 
+- name: Remove the percona liveness check config map
+  shell: source ~/.profile; kubectl delete cm sqltest -n {{ namespace }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   failed_when: "'configmap' and 'deleted' not in result.stdout"
+  changed_when: true
+
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
+  register: ns_out
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 
 - name: Remove test artifacts
   file:
@@ -46,6 +57,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
     - "{{percona_files}}"
-  
- 
- 
+
+
+

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -46,7 +46,6 @@
 
 - name: Delete namespace
   command: kubectl delete ns {{ namespace }}
-  register: ns_out
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
@@ -17,6 +17,8 @@ replace_with:
   - test-nw-failure
   - test-nw
 
+namespace: nw-ctrl
+
 utils_path: openebs/e2e/ansible/playbooks/utils
 
 delay_interavals: 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
@@ -14,25 +14,19 @@
 ###############################################################################################
 
 - hosts: localhost
- 
-  vars_files: 
-    - test-nw-failure-vars.yml 
- 
+
+  vars_files:
+    - test-nw-failure-vars.yml
+
   tasks:
    - block:
+       - include: test-nw-failure-prereq.yml
 
        ###################################################
        #                PREPARE FOR TEST                 #
-       # (Place artifacts in kubemaster, start logger &  # 
+       # (Place artifacts in kubemaster, start logger &  #
        # confirm OpenEBS operator is ready for requests. #
        ###################################################
-
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args: 
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Get percona spec and liveness scripts
          get_url:
@@ -48,86 +42,91 @@
            regex1: "{{replace_item}}"
            regex2: "{{replace_with}}"
 
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
        - name: Check status of maya-api server
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: openebs
             app: maya-api
- 
+
        ####################################################
        #          SETUP FAULT-INJECTION ENV               #
        # (Setup pumba deployment with an empty policy,    #
-       # deploy percona w/ a liveness check for DB writes)# 
+       # deploy percona w/ a liveness check for DB writes)#
        ####################################################
 
        - name: Setup the pumba infrastructure
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ pumba_file }}"
+           ns: default
 
        - name: Check whether pumba infrastructure is created
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: default
             app: pumba
 
+       - name: Create test specific namespace
+         command: kubectl create ns {{ namespace }}
+         register: ns_out
+         until: "'created' in ns_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
        - name: Create a configmap with the liveness sql script
-         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} 
-         args: 
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} -n {{ namespace }}
+         args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result 
+         register: result
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_files.0 }}"
+           ns: "{{ namespace }}"
 
-       - name: Wait for 120s to ensure liveness check starts 
+       - name: Wait for 120s to ensure liveness check starts
          wait_for:
            timeout: 120
-         
+
        - name: Check whether percona application is running
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
-       - name: Get the node details on which pvc-ctrl is scheduled 
-         shell: kubectl get pods -o wide | grep ctrl | awk {'print $7'}
+       - name: Get the node details on which pvc-ctrl is scheduled
+         shell: kubectl get pods -n {{ namespace }} -o wide | grep ctrl | awk {'print $7'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: node_cntrl
 
        - name: Get the pvc-cntrl name
-         shell: kubectl get pods | grep ctrl | awk {'print $1'}
+         shell: kubectl get pods -n {{ namespace }} | grep ctrl | awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: pvc_cntrl_name
 
        - name: Get the cntrl container name
-         shell: kubectl describe pod {{ pvc_cntrl_name.stdout }} | grep ctrl-con | awk {'print $1'}
+         shell: kubectl describe pod {{ pvc_cntrl_name.stdout }} -n {{ namespace }} | grep ctrl-con | awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: con_name
-               
+
        - name: Set container name to variable
          set_fact:
-           container: "{{ con_name.stdout }}"        
+           container: "{{ con_name.stdout }}"
 
        ########################################################
        #        INJECT FAULTS FOR SPECIFIED PERIOD            #
-       # (Obtain begin marker before fault-inject(FI),do ctrl # 
-       # failures, verify successful FI via end marker)       # 
+       # (Obtain begin marker before fault-inject(FI),do ctrl #
+       # failures, verify successful FI via end marker)       #
        ########################################################
 
        - name: Get pumba container name
@@ -138,8 +137,8 @@
          register: pumba_name
 
        - name: Initiate periodic network failures from pumba
-         shell: > 
-           kubectl exec {{ pumba_name.stdout }} -- pumba netem --interface eth0 
+         shell: >
+           kubectl exec {{ pumba_name.stdout }} -- pumba netem --interface eth0
            --duration 1m delay --time {{ item }} re2:k8s_{{ container[:-1] }}; sleep 10
          args:
            executable: /bin/bash
@@ -152,37 +151,50 @@
        # pod is still in running state)                       #
        ########################################################
 
-       - name: Confirm percona pod is still running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/status_running.yml"
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
+            ns: "{{ namespace }}"
             app: percona
 
        ########################################################
-       #                        CLEANUP                       #			      
+       #                        CLEANUP                       #
        # (Tear down application, liveness configmap as well as#
-       # the FI (chaoskube) infrastructure. Also stop logger) # 
+       # the FI (chaoskube) infrastructure. Also stop logger) #
        ########################################################
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash 
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
-
-       - set_fact:
+       - name: Test Passed
+         set_fact:
            flag: "Pass"
 
-     rescue: 
-       - set_fact: 
+     rescue:
+       - name: Test Failed
+         set_fact:
            flag: "Fail"
 
      always:
-       - include: test-nw-failure-cleanup.yml
-         when: clean | bool
+       - block:
 
-       - name: Send slack notification
-         slack: 
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - include: test-nw-failure-cleanup.yml
 
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           #- name: Terminate the log aggregator
+           #  shell: source ~/.profile; killall stern
+           #  args:
+           #    executable: /bin/bash
+           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
@@ -68,10 +68,6 @@
 
        - name: Create test specific namespace
          command: kubectl create ns {{ namespace }}
-         register: ns_out
-         until: "'created' in ns_out.stdout"
-         delay: 10
-         retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Create a configmap with the liveness sql script
@@ -187,11 +183,11 @@
 
          always:
 
-           #- name: Terminate the log aggregator
-           #  shell: source ~/.profile; killall stern
-           #  args:
-           #    executable: /bin/bash
-           #  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           - name: Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
            - name: Send slack notification
              slack:

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk-cleanup.yml
@@ -2,11 +2,11 @@
 - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
   vars:
     app_yml: "{{ percona_link }}"
-    ns: nodeeviction
+    ns: "{{ namespace }}"
 
 - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
   vars:
-    ns: nodeeviction
+    ns: "{{ namespace }}"
     app: percona
 
 - name: Delete nodeeviction ns

--- a/e2e/ansible/playbooks/utils/delete_deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy_check.yml
@@ -5,7 +5,7 @@
     executable: /bin/bash
   register: result
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  until: "app and 'Running' not in result.stdout"
+  failed_when: "app and 'Running' in result.stdout"
   delay: 30
   retries: 15
   ignore_erros: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Enhance ansible playbooks to deploy applications on their own namespace and set flag for cleanup result.(Resiliency test-suite)
- Stern logger moved to prereq.yml
- Runs each application on its own namespace
- Performs apply/delete applications using modularization by passing required arguments.
- Cleanup gives out result by setting flag"Cleanup Pass" or "Cleanup Fail"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
