### PR TITLE
Enhance cleanup pass/fail and set flag for hyperconverged test-suite

### DIFF
--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
@@ -1,19 +1,25 @@
 ---
-- name: Delete the iSCSI target 
-  shell: source ~/.profile; kubectl delete -f {{ volume_def }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app_yml: "{{ volume_def }}"
 
 - name: Confirm the iSCSI target has been deleted
-  shell: source ~/.profile; kubectl get pvc
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
   until: "'pvc' not in result.stdout"
-  delay: 120 
+  delay: 120
   retries: 6
+  changed_when: true
+
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 
 
-   
+
+

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml
@@ -1,8 +1,10 @@
 ---
-- name: Run apt-get update via shell
-  shell: apt-get update
+- name: Run apt-get update 
+  apt: >
+    update_cache=yes
+    cache_valid_time=3600
   become: true
-  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
   ignore_errors: true
 
 - name: Install libiscsi on K8S-minion
@@ -10,3 +12,24 @@
   become: true
   with_items: "{{ deb_packages }}"
   delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  tags:
+   - skip_ansible_lint
+
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-vars.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-vars.yml
@@ -12,5 +12,7 @@ test_list: run-tests.out
 deb_packages:
   - libiscsi-bin
   
+namespace: libiscsi-test
 
+utils_path: openebs/e2e/ansible/playbooks/utils
 

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
@@ -157,17 +157,17 @@
              set_fact:
                cflag: "Cleanup Failed"
 
-#         always:
-#
-#           - name: 9) Terminate the log aggregator
-#             shell: source ~/.profile; killall stern
-#             args:
-#               executable: /bin/bash
-#             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-#
-#           - name: Send slack notification
-#             slack:
-#               token: "{{ lookup('env','SLACK_TOKEN') }}"
-#               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
-#             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+         always:
+
+           - name: 9) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
@@ -20,73 +20,62 @@
   vars_files:
     - libiscsi-vars.yml
 
-  tasks: 
-   - block: 
-   
+  tasks:
+   - block:
+
        - name: 1) Install the prerequisites
-         include: libiscsi-prerequisites.yml 
+         include: libiscsi-prerequisites.yml
 
-       - name: 2) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: 2a) Copy the volume claim to kube master
-         copy: 
+       - name: 2) Copy the volume claim to kube master
+         copy:
            src: "{{ volume_def }}"
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-       
-       - name: 2c) Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
- 
-       - name: 3) Create a storage volume via a pvc 
-         shell: source ~/.profile; kubectl apply -f "{{ volume_def }}"
+
+       - name: 3) Create test specific namespace
+         command: kubectl create ns {{ namespace }}
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: 3a) Create a storage volume via a pvc
+         shell: source ~/.profile; kubectl apply -f "{{ volume_def }}" -n {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 3a) Confirm volume container is running 
-         shell: source ~/.profile; kubectl get pods | grep pvc | grep {{item}} | grep Running | wc -l
+       - name: 3b) Confirm volume container is running
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep pvc | grep {{item}} | grep Running | wc -l
          args:
            executable: /bin/bash
          register: result
          until: result.stdout|int >= 1
          delay: 30
-         retries: 10 
-         with_items: 
+         retries: 10
+         with_items:
            - ctrl
            - rep
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-        
+
        - name: 4) Get storage ctrl pod name
-         shell: source ~/.profile; kubectl get pods | grep ctrl
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep ctrl
          args:
            executable: /bin/bash
          register: ctrl_name
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-        
-       - name: 4a) Set ctrl pod name to variable 
-         set_fact: 
+
+       - name: 4a) Set ctrl pod name to variable
+         set_fact:
            ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
 
        - name: 4b) Get IP address of ctrl pod
-         shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} | grep IP
+         shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} -n {{ namespace }} | grep IP
          args:
            executable: /bin/bash
          register: ctrl_IP
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-    
+
        - name: 4c) Set IP of Pod to variable
          set_fact:
-           ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}" 
+           ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
 
        - name: 5) Get $HOME of K8s minion for kubernetes user
          shell: source ~/.profile; echo $HOME
@@ -101,32 +90,34 @@
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-       - name: 6) Discover the iSCSI target using iscsi-ls 
+       - name: 6) Discover the iSCSI target using iscsi-ls
          shell: iscsi-ls iscsi://{{ ctrl_ip }}
          register: target
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+         tags:
+           - skip_ansible_lint
 
-       - name: 6a) Set target iqn to variable 
+       - name: 6a) Set target iqn to variable
          set_fact:
            iqn: "{{ target.stdout.split()[0] | regex_replace('Target:','')}}"
 
        - name: 6b) Create log directory for libiscsi test run
-         file: 
+         file:
            path: "{{ result_kube_home.stdout }}/libiscsi_suite_logs"
            state: directory
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-       - name: 6c) Get test list from test file 
-         command: cat {{ result_kube_home.stdout }}/{{ test_list }}       
+       - name: 6c) Get test list from test file
+         command: cat {{ result_kube_home.stdout }}/{{ test_list }}
          register: tests
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
- 
+
        - name: 7) Run the libiscsi test suites
          shell: >
-           iscsi-test-cu --test={{ item }} 
-           iscsi://{{ ctrl_ip }}/{{ iqn }}/0 
-           --dataloss --allow-sanitize 
-           > {{ result_kube_home.stdout }}/libiscsi_suite_logs/{{ item }}.log 
+           iscsi-test-cu --test={{ item }}
+           iscsi://{{ ctrl_ip }}/{{ iqn }}/0
+           --dataloss --allow-sanitize
+           > {{ result_kube_home.stdout }}/libiscsi_suite_logs/{{ item }}.log
            2>&1
          args:
            executable: /bin/bash
@@ -134,7 +125,7 @@
          with_items: "{{ tests.stdout_lines }}"
          ignore_errors: true
 
-       - name: 8) Generate test summary 
+       - name: 8) Generate test summary
          script: parse.sh {{ result_kube_home.stdout }}/libiscsi_suite_logs
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
          register: summary
@@ -142,37 +133,41 @@
        - name: 8a) Display the test status
          debug:
            msg: "{{ summary.stdout }}"
- 
-       - name: 9) Cleaning up the test artifacts.
-         include: libiscsi-cleanup.yml
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Test Passed
+         set_fact:
+           flag: "Test Passed"
 
-       - set_fact:
-           flag: "Pass"
-           flag_msg: "Ran libiscsi test suite successfully"
+     rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Test Failed"
 
-     rescue: 
-        - set_fact:
-            flag: "Fail" 
-            flag_msg: "Failed to run libiscsi test suite"
-            
      always:
        - block:
 
-           - name: Send test status slack notification
-             slack:
-               token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} {{ flag_msg }}'   
-        
-           - name: Send test details slack notification
-             slack:
-               token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: "{{ summary.stdout }}"
-             when: flag == "Pass"
-         
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - include: libiscsi-cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+#         always:
+#
+#           - name: 9) Terminate the log aggregator
+#             shell: source ~/.profile; killall stern
+#             args:
+#               executable: /bin/bash
+#             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+#
+#           - name: Send slack notification
+#             slack:
+#               token: "{{ lookup('env','SLACK_TOKEN') }}"
+#               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+#             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-cleanup.yml
@@ -1,34 +1,31 @@
 ---
 - name: Delete cassandra service pod
-  shell: source {{ profile }}; kubectl delete -f {{ svc_yaml_alias }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: default
+    app_yml: "{{ svc_yaml_alias }}"
 
 - name: Delete cassandra statefulset pod
-  shell: source {{ profile }}; kubectl delete -f {{ stateful_yaml_alias }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: default
+    app_yml: "{{ stateful_yaml_alias }}"
 
 - name: Delete cassandra loadgen pod
-  shell: source {{ profile }}; kubectl delete -f {{ loadgen_yaml_alias }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: default
+    app_yml: "{{ loadgen_yaml_alias }}"
 
-- name: Get pvcs
-  shell: source {{ profile }}; kubectl get pvc -o custom-columns=:metadata.name --no-headers | grep cassandra-data
+- name: Get cassandra pvcs
+  shell: kubectl get pvc -o custom-columns=:metadata.name --no-headers | grep cassandra-data
   args:
     executable: /bin/bash
   register: result
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 
-- name: Delete pvcs
+- name: Delete cassandra pvcs
   shell: source {{ profile }}; kubectl delete pvc {{ item }}
   args:
     executable: /bin/bash
@@ -47,3 +44,21 @@
   delay: 120
   retries: 6
   changed_when: true
+
+- name: Get cassandra deploy
+  shell: source {{ profile }}; kubectl get deploy --no-headers | awk {'print $1'}
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Delete cassandra deploy
+  shell: source {{ profile }}; kubectl delete deploy {{ item }}
+  args:
+    executable: /bin/bash
+  with_items:
+    - "{{ result.stdout_lines }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-prereq.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-prereq.yml
@@ -1,0 +1,19 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod-vars.yml
@@ -21,3 +21,6 @@ io_minutes: 3
 
 profile: ~/.bash_profile
 
+namespace: cassandra-test
+
+utils_path: openebs/e2e/ansible/playbooks/utils

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -1,4 +1,5 @@
 # k8s-cassandra-pod.yml
+# Author: Sudarshan D
 # Description: Deploy Cassandra application as statefulset
 
 ###############################################################################################
@@ -20,48 +21,31 @@
   tasks:
    - block:
 
-       - name: 1) Get $HOME of K8s master for kubernetes user
-         shell: source {{ profile }}; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: k8s-cassandra-pod-prereq.yml
 
-       - name: 2) Download YAML for cassandra service
-         get_url:
+       - name: 1) Download YAML for cassandra service
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+         vars:
            url: "{{ cassandra_service_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ svc_yaml_alias }}"
-           force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2a) Download YAML for cassandra statefulset
-         get_url:
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+         vars:
            url: "{{ cassandra_stateful_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
-           force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2b) Download YAML for cassandra loadgen
-         get_url:
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+         vars:
            url: "{{ cassandra_loadgen_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ loadgen_yaml_alias }}"
-           force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3) Get the number of nodes in the cluster
-         shell: source {{ profile }}; kubectl get nodes | grep 'Ready' | wc -l
+         shell: source {{ profile }}; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: node_out
@@ -75,7 +59,7 @@
          replace:
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'replicas: 3'
-           replace: 'replicas: {{ (node_count) |int-1 }}'
+           replace: 'replicas: {{ node_count }}'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3c) Replace the io_duration in cassandra loadgen yaml
@@ -86,60 +70,40 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Check whether maya-apiserver pod is deployed
-         shell: source {{ profile }}; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
-
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source {{ profile }};
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: openebs
+            app: maya-api
 
        - name: 4) Deploy cassandra service
-         shell: source {{ profile }}; kubectl create -f {{ svc_yaml_alias }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ svc_yaml_alias }}"
+           ns: default
 
        - name: 4a) Deploy cassandra statefulset
-         shell: source {{ profile }}; kubectl create -f {{ stateful_yaml_alias }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ stateful_yaml_alias }}"
+           ns: default
 
        - name: 5) Confirm cassandra pod status is running
-         shell: source {{ profile }}; kubectl get pods | grep cassandra-0
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'cassandra-0' and 'Running' in result.stdout"
-         delay: 120
-         retries: 15
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: default
+            app: cassandra-0
 
        - name: 6) Start cassandra load generation
-         shell: source {{ profile }}; kubectl create -f {{ loadgen_yaml_alias }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ loadgen_yaml_alias }}"
+           ns: default
 
        - name: 6a) Verify load is running for specified duration
-         shell: source {{ profile }}; kubectl get pods | grep cassandra-loadgen
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 15
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: default
+            app: cassandra-loadgen
 
        - name: Wait for {{ (io_minutes) | int *60 }} secs to run load.
          wait_for:
@@ -155,29 +119,40 @@
          delay: 60
          retries: 5
 
-       - name: Terminate the log aggregator
-         shell: source {{ profile }}; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: setting flag if pass
+       - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
-       - name: setting flag if fail
+       - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
+       - block:
 
-       - name: 7) Cleaning up the test artifacts.
-         include: k8s-cassandra-pod-cleanup.yml
-         when: clean | bool
+           - include: k8s-cassandra-pod-cleanup.yml
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+         always:
+
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc | grep {{ volume_claim }} | awk {'print $3'}
+  shell: source ~/.profile; kubectl get pvc -n | grep {{ volume_claim }} | awk {'print $3'}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -8,25 +8,19 @@
   changed_when: true
 
 - name: Delete jupyter server pod
-  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: default
+    app_yml: "{{ pod_yaml_alias }}"
 
 - name: Confirm jupyter pod has been deleted
-  shell: source ~/.profile; kubectl get pods
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'jupyter' not in result.stdout"
-  delay: 120
-  retries: 6
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    ns: default
+    app: jupyter
 
 - name: Confirm pvc pod has been deleted
-  shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
+  shell: source ~/.profile; kubectl get pods -n | grep {{ pvc.stdout }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-prereq.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-prereq.yml
@@ -1,0 +1,20 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod-vars.yml
@@ -2,9 +2,18 @@
 test_name: hyperconverged_jupyter_server_on_k8s
 
 jupyter_plugin_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/jupyter/demo-jupyter-openebs.yaml
+
 pod_yaml_alias: demo-jupyter-openebs.yaml
 
 volume_claim: jupyter-data-vol-claim
 
 jupyter_server_vol_size: 5G
+
+namespace: jupyter-test
+
+utils_path: openebs/e2e/ansible/playbooks/utils
+
+test_pod_regex: maya*|openebs*|pvc*|jupyter*
+
+test_log_path: setup/logs/jupyter_test.log
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
@@ -20,33 +20,19 @@
 
    - block:
 
-       - name: 1) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: k8s-jupyter-pod-prereq.yml
 
-       - name: 2) Download YAML for jupyter notebook server plugin
-         get_url:
+       - name: a) Download YAML for jupyter notebook server plugin
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+         vars:
            url: "{{ jupyter_plugin_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-           force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2b) Check whether maya-apiserver is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: openebs
+            app: maya-api
 
        - name: 2c) Replace volume size in plugin YAML
          lineinfile:
@@ -56,20 +42,16 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3) Deploy jupyter notebook server pod
-         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ pod_yaml_alias }}"
+           ns: default
 
        - name: 4) Confirm pod status is running
-         shell: source ~/.profile; kubectl get pods | grep jupyter
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'jupyter' and 'Running' in result.stdout"
-         delay: 120
-         retries: 15
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: default
+            app: jupyter
 
        - name: 5) Verify that the jupyter notebook server is a cluster service
          shell: source ~/.profile; kubectl get svc
@@ -79,24 +61,40 @@
          register: result_service
          failed_when: "'jupyter-service' not in result_service.stdout"
 
-       - name: setting flag if pass
+       - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
-       - name: setting flag if fail
+       - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
+       - block:
 
-       - name: 6) Cleaning up the test artifacts
-         include: k8s-jupyter-pod-cleanup.yml
-         when: clean | bool
+           - include: k8s-jupyter-pod-cleanup.yml
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+         always:
+
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-cleanup.yml
@@ -1,4 +1,4 @@
----     
+---
 - name: Logout to iSCSI target
   open_iscsi:
     show_nodes: yes
@@ -9,10 +9,10 @@
   register: result
 
 - name: Delete the iSCSI target
-  shell: source ~/.profile; kubectl delete -f {{ volume_def }}
-  args:
-     executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app_yml: "{{ volume_def }}"
 
 - name: Unmount the ext4 filesystem
   mount:
@@ -22,7 +22,7 @@
   delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
 - name: Confirm the iSCSI target has been deleted
-  shell: source ~/.profile; kubectl get pvc
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }}
   args:
      executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -30,9 +30,15 @@
   until: "'pvc' not in result.stdout"
   delay: 120
   retries: 6
+  changed_when: true
+
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 
 - name: Remove test artifacts
-  file:  
+  file:
     path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
     state: absent
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-prereq.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-prereq.yml
@@ -1,0 +1,20 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak-vars.yml
@@ -7,3 +7,7 @@ py_file: test-mem.py
 count_num: 10000
 mount_point: /mnt/jiva
 volume_claim: memleak-test
+namespace: memleak-test
+utils_path: openebs/e2e/ansible/playbooks/utils
+test_pod_regex: maya*|openebs*|pvc*
+test_log_path: setup/logs/memleak_test.log

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -15,161 +15,173 @@
 #10. Perform cleanup of test artifacts.
 ###############################################################################################
 
-
 - hosts: localhost
 
   vars_files:
-     - memleak-vars.yml
-  
+   - memleak-vars.yml
+
   tasks:
-       - name: 1) Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
-   
-       - name: 2) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   - include: memleak-prereq.yml
+
+   - name: 1) Check whether maya-apiserver pod is deployed
+     include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+     vars:
+       ns: openebs
+       app: maya-api
+
+   - name: 2a) Copy the volume claim to kube master
+     copy:
+       src: "{{ volume_def }}"
+       dest: "{{ result_kube_home.stdout }}"
+     delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+   - name: 2b) Replace volume-claim name with test parameters
+     replace:
+       path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+       regexp: 'vut'
+       replace: '{{ volume_claim }}'
+     delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+   - name: Create test specific namespace
+     command: kubectl create ns {{ namespace }}
+     delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+   - name: 3) Create a storage volume via a pvc
+     include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+     vars:
+       app_yml: "{{ volume_def }}"
+       ns: "{{ namespace }}"
+
+   - name: 3a) Confirm volume container is running
+     shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep pvc | grep {{item}} | grep Running | wc -l
+     args:
+       executable: /bin/bash
+     register: result
+     until: result.stdout|int >= 1
+     delay: 30
+     retries: 20
+     with_items:
+       - ctrl
+       - rep
+     delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+   - name: 4) Get storage ctrl pod name
+     shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep ctrl
+     args:
+       executable: /bin/bash
+     register: ctrl_name
+     delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+   - name: 4a) Set ctrl pod name to variable
+     set_fact:
+       ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
+
+   - name: 4b) Get IP address of ctrl pod
+     shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} -n {{ namespace }} | grep IP
+     args:
+       executable: /bin/bash
+     register: ctrl_IP
+     delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+   - name: 4c) Set IP of Pod to variable
+     set_fact:
+       ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
 
 
-       - name: 2a) Copy the volume claim to kube master
-         copy:
-           src: "{{ volume_def }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"       
+   - name: 5) Establish iSCSI session with volume
+     shell: iscsiadm -m discovery -t st -p {{ ctrl_ip }}:3260
+     become: true
+     delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+     register: result
 
-       - name: 2b) Replace volume-claim name with test parameters
-         replace:
-           path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
-           regexp: 'vut'
-           replace: '{{ volume_claim }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+   - name: 5a) Store target iqn in variable
+     set_fact:
+       iqn: "{{result.stdout.split(',')[1].split()[1]}}"
 
-       - name: 3) Create a storage volume via a pvc
-         shell: source ~/.profile; kubectl apply -f "{{ volume_def }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-       
-       - name: 3a) Confirm volume container is running
-         shell: source ~/.profile; kubectl get pods | grep pvc | grep {{item}} | grep Running | wc -l
-         args:
-           executable: /bin/bash
-         register: result
-         until: result.stdout|int >= 1
-         delay: 30
-         retries: 10
-         with_items:
-           - ctrl
-           - rep
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+   - name: 6) Login to iSCSI target
+     open_iscsi:
+       show_nodes: yes
+       login: yes
+       target: "{{iqn}}"
+     become: true
+     delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+     register: result
 
-       - name: 4) Get storage ctrl pod name
-         shell: source ~/.profile; kubectl get pods | grep ctrl
-         args:
-           executable: /bin/bash
-         register: ctrl_name
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-       
-       - name: 4a) Set ctrl pod name to variable
-         set_fact:
-           ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
+   - name: 6a) Check device nodes
+     set_fact:
+       scsi_device: "{{result.devicenodes[0]}}"
 
-       - name: 4b) Get IP address of ctrl pod
-         shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} | grep IP
-         args:
-           executable: /bin/bash
-         register: ctrl_IP
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+   - name: 7) Create file system on iSCSI disk
+     filesystem:
+       fstype: ext4
+       dev: "{{scsi_device}}"
+       force: no
+     become: true
+     delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
-       - name: 4c) Set IP of Pod to variable
-         set_fact:
-           ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
+   - name: 7a) Mount device by Label
+     mount:
+       name: "{{mount_point}}"
+       src: "{{scsi_device}}"
+       fstype: ext4
+       opts: discard,_netdev
+       state: mounted
+     become: true
+     delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
+   - name: 7b) Place data using dd
+     shell: |
+        timeout 200s dd if=/dev/urandom of={{mount_point}}/f1 bs={{block_size[0]}} count={{count_num}} oflag=dsync &
+        timeout 200s dd if=/dev/urandom of={{mount_point}}/f2 bs={{block_size[1]}} count={{count_num}} oflag=dsync &
+     become: true
+     delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
-       - name: 5) Establish iSCSI session with volume
-         shell: iscsiadm -m discovery -t st -p {{ ctrl_ip }}:3260
-         become: true
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
-         register: result
+   - block:
+         - name: 8) Copy the python script to kubeminion
+           copy:
+              src: "{{ py_file }}"
+              dest: "{{ result_kube_home.stdout }}"
+           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 5a) Store target iqn in variable
-         set_fact:
-           iqn: "{{result.stdout.split(',')[1].split()[1]}}"
+         - name: 9) Run python script for memory usage validation it takes couple of minutes
+           shell: python test-mem.py
+           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           register: result
+           failed_when: "'Pass' not in result.stdout"
 
-       - name: 6) Login to iSCSI target
-         open_iscsi:
-           show_nodes: yes
-           login: yes
-           target: "{{iqn}}"
-         become: true
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
-         register: result
+         - name: Test Passed
+           set_fact:
+                flag: "Test Passed"
+     rescue:
+         - name: Test Failed
+           set_fact:
+                flag: "Test Failed"
 
-       - name: 6a) Check device nodes
-         set_fact:
-           scsi_device: "{{result.devicenodes[0]}}"
-
-       - name: 7) Create file system on iSCSI disk
-         filesystem:
-           fstype: ext4
-           dev: "{{scsi_device}}"
-           force: no
-         become: true
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
-
-       - name: 7a) Mount device by Label
-         mount:
-           name: "{{mount_point}}"
-           src: "{{scsi_device}}"
-           fstype: ext4
-           opts: discard,_netdev
-           state: mounted
-         become: true
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
-
-       - name: 7b) Place data using dd
-         shell: |
-            timeout 200s dd if=/dev/urandom of={{mount_point}}/f1 bs={{block_size[0]}} count={{count_num}} oflag=dsync &
-            timeout 200s dd if=/dev/urandom of={{mount_point}}/f2 bs={{block_size[1]}} count={{count_num}} oflag=dsync &
-         become: true
-         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
-
+     always:
        - block:
-             - name: 8) Copy the python script to kubeminion
-               copy:
-                  src: "{{ py_file }}"
-                  dest: "{{ result_kube_home.stdout }}"
-               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-             - name: 9) Run python script for memory usage validation it takes couple of minutes
-               shell: python test-mem.py
-               delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-               register: result
-               failed_when: "'Pass' not in result.stdout"
-              
-             - set_fact:
-                    flag: "PASS"
+           - include: memleak-cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
          rescue:
-             - set_fact:
-                    flag: "FAIL"         
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
 
          always:
 
-             - include: memleak-cleanup.yml
-               when: clean | bool
+           - name: 5) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-             - name: Send slack notification
-               slack:
-                 token: "{{ lookup('env','SLACK_TOKEN') }}"
-                 msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-               when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/memleak.yml
@@ -144,7 +144,7 @@
            delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
          - name: 9) Run python script for memory usage validation it takes couple of minutes
-           shell: python test-mem.py
+           shell: python test-mem.py {{ namespace }}
            delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
            register: result
            failed_when: "'Pass' not in result.stdout"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -7,7 +7,8 @@ from __future__ import division
 import subprocess
 import time, os, sys
 list = []
-cmd_cntrl_name = "kubectl get pod -n memleak-test -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
+namespace = sys.argv[1]
+cmd_cntrl_name = "kubectl get pod -n %s -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'" %(namespace)
 out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE,shell=True)
 cntrl_name = out.communicate()
 cntrl_pod_name = cntrl_name[0].strip('\n')
@@ -15,7 +16,7 @@ n = cntrl_pod_name.split('-')
 lst = n[:len(n)-2]
 lst.append("con")
 container_name = "-".join(lst)
-used_mem_process = "kubectl exec %s -c %s -n memleak-test -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
+used_mem_process = "kubectl exec %s -c %s -n %s -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name,namespace)
 print used_mem_process
 n = 5
 count = 0

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -7,7 +7,7 @@ from __future__ import division
 import subprocess
 import time, os, sys
 list = []
-cmd_cntrl_name = "kubectl get pod -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
+cmd_cntrl_name = "kubectl get pod -n memleak-test -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'"
 out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE,shell=True)
 cntrl_name = out.communicate()
 cntrl_pod_name = cntrl_name[0].strip('\n')
@@ -15,7 +15,7 @@ n = cntrl_pod_name.split('-')
 lst = n[:len(n)-2]
 lst.append("con")
 container_name = "-".join(lst)
-used_mem_process = "kubectl exec %s -c %s -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
+used_mem_process = "kubectl exec %s -c %s -n memleak-test -- pmap -x 1 | awk ''/total'/ {print $3}'" %(cntrl_pod_name,container_name)
 print used_mem_process
 n = 5
 count = 0

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get pvc name to verify successful pvc deletion
-  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -o custom-columns=:spec.volumeName --no-headers
+  shell: source ~/.profile; kubectl get pvc {{ replace_with.0 }} -n {{ namespace }} -o custom-columns=:spec.volumeName --no-headers
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -12,22 +12,15 @@
     timeout: "{{ mysql_load_duration }}"
 
 - name: Delete percona mysql pod
-  shell: source ~/.profile; kubectl delete -f {{ pod_yaml_alias }}
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app_yml: "{{ pod_yaml_alias }}"
 
-- name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 120
-  retries: 6
-  changed_when: true
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods | grep {{ pvc.stdout }}
@@ -39,3 +32,9 @@
   delay: 30
   retries: 10
   changed_when: true
+
+- name: Delete namespace
+  command: kubectl delete ns {{ namespace }}
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,10 +1,11 @@
 ---
 - name: Run apt-get update via shell
-  shell: apt-get update
+  apt: >
+    update_cache=yes
+    cache_valid_time=3600
   become: true
-  delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
   ignore_errors: true
-  changed_when: true
 
 - name: Install python-pip on K8S-minion
   shell: apt-get install -y {{ item }}
@@ -12,6 +13,8 @@
   with_items: "{{ deb_packages }}"
   delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
   changed_when: true
+  tags:
+   - skip_ansible_lint
 
 - name: Install PIP packages on K8s-minion
   pip:
@@ -20,4 +23,22 @@
   with_items: "{{ pip_packages }}"
   delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
   become: true
+
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-prerequisites.yml
@@ -1,5 +1,5 @@
 ---
-- name: Run apt-get update via shell
+- name: Run apt-get update 
   apt: >
     update_cache=yes
     cache_valid_time=3600

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod-vars.yml
@@ -30,3 +30,7 @@ pip_packages:
   - 'docker-py==1.9.0'
 
 mysql_load_duration: 120
+
+namespace: percona-mysql-test
+
+utils_path: openebs/e2e/ansible/playbooks/utils

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -25,43 +25,25 @@
        - name: 1) Install the prerequisites
          include: k8s-percona-pod-prerequisites.yml
 
-       - name: 2) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: 2a) Download YAML for percona mysql plugin
-         get_url:
+       - name: 2) Download YAML for percona mysql plugin
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+         vars:
            url: "{{ percona_mysql_plugin_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-           force: yes
-         register: result
-         until:  "'OK' in result.msg"
-         delay: 5
-         retries: 3
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3) Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: openebs
+            app: maya-api
 
        - name: 3a) Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
        - name: 3b) Replace volume size in plugin YAML
          lineinfile:
@@ -70,29 +52,21 @@
            line: "      storage: \"{{percona_mysql_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
+       - name: 4) Create test specific namespace
+         command: kubectl create ns {{ namespace }}
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 4) Deploy percona mysql pod
-         shell: source ~/.profile; kubectl create -f {{ pod_yaml_alias }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: 4a) Deploy percona applcation
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ pod_yaml_alias }}"
+           ns: "{{ namespace }}"
 
-       - name: 5) Confirm pod status is running
-         shell: source ~/.profile; kubectl get pods | grep percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 120
-         retries: 15
+       - name: 5) Check application status
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
 
        - name: 6) Get $HOME of K8s minion for kubernetes user
          shell: source ~/.profile; echo $HOME
@@ -102,7 +76,7 @@
          delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
 
        - name: 6a) Get IP address of percona mysql pod
-         shell: source ~/.profile; kubectl describe pod percona
+         shell: source ~/.profile; kubectl describe pod percona -n {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -137,29 +111,39 @@
          become: true
          delegate_to: "{{ groups['kubernetes-kubeminions'].0 }}"
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: setting flag if pass
+       - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
-       - name: setting flag if fail
+       - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
+       - block:
 
-       - name: 9) Cleaning up the test artifacts.
-         include: k8s-percona-pod-cleanup.yml
-         when: clean | bool
+           - include: k8s-percona-pod-cleanup.yml
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+#         always:
+#
+#           - name: 7) Terminate the log aggregator
+#             shell: source ~/.profile; killall stern
+#             args:
+#               executable: /bin/bash
+#             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+#
+#           - name: Send slack notification
+#             slack:
+#               token: "{{ lookup('env','SLACK_TOKEN') }}"
+#               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -134,16 +134,16 @@
              set_fact:
                cflag: "Cleanup Failed"
 
-#         always:
-#
-#           - name: 7) Terminate the log aggregator
-#             shell: source ~/.profile; killall stern
-#             args:
-#               executable: /bin/bash
-#             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-#
-#           - name: Send slack notification
-#             slack:
-#               token: "{{ lookup('env','SLACK_TOKEN') }}"
-#               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+         always:
+
+           - name: 7) Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
 

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -177,12 +177,12 @@
 
        - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -191,12 +191,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 
@@ -209,6 +209,6 @@
            - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-vars.yml
@@ -1,5 +1,5 @@
 ---
-test_name: test_nw_failure
+test_name: test_nw_failure_rep
 
 utils_path: openebs/e2e/ansible/playbooks/utils
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -148,7 +148,7 @@
        ########################################################
 
        - name: Confirm percona pod is still running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/status_running.yml"
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ namespace }}"
             app: percona
@@ -161,12 +161,12 @@
 
        - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -175,12 +175,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 
@@ -193,6 +193,6 @@
            - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-vars.yml
@@ -1,5 +1,5 @@
 ---
-test_name: test_nw_failure
+test_name: test_nw_failure_ctrl
 
 percona_links:
   - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure.yml
@@ -160,12 +160,12 @@
 
        - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -174,12 +174,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 
@@ -192,5 +192,5 @@
            - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -231,27 +231,27 @@
 
        - name: Test Passed
          set_fact:
-            flag: "Pass"
+           flag: "Test Passed"
 
-   - rescue:
+     rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
- 
+
            - include: test-node-eviction-out-of-disk-cleanup.yml
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
-        
+               cflag: "Cleanup Failed"
+
          always:
 
            - name: 5) Terminate the log aggregator
@@ -259,10 +259,10 @@
              args:
                executable: /bin/bash
              delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-           
 
-           - name: 6) Send slack notification
+           - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}, {{ cflag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
@@ -150,12 +150,12 @@
 
        - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -164,12 +164,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 
@@ -182,6 +182,6 @@
            - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
@@ -231,12 +231,12 @@
 
        - name: Test Passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test Failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -245,12 +245,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 
@@ -263,6 +263,6 @@
            - name: Send slack notification
              slack:
                token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/utils/delete_deploy.yml
+++ b/e2e/ansible/playbooks/utils/delete_deploy.yml
@@ -1,5 +1,5 @@
 ---
-- name: Deploy application files
+- name: Delete application 
   shell: source ~/.profile; kubectl delete -f {{ item }} -n {{ ns }}
   args:
     executable: /bin/bash

--- a/e2e/ansible/playbooks/utils/get_url.yml
+++ b/e2e/ansible/playbooks/utils/get_url.yml
@@ -1,0 +1,12 @@
+- name: Download files
+  get_url:
+    url: "{{ url }}"
+    dest: "{{ dest }}"
+    force: yes
+  register: result
+  until:  "'OK' in result.msg"
+  delay: 5
+  retries: 3
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+


### PR DESCRIPTION
Signed-off-by: Sudarshan Darga <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Enhance ansible playbooks to deploy applications on their own namespace and set flag for cleanup result.(Hyperconverged test-suite)
- Stern logger moved to prereq.yml
- Runs each application on its own namespace
- Performs apply/delete applications using modularization by passing required arguments.
- Cleanup gives out result by setting flag"Cleanup Pass" or "Cleanup Fail"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
- @ksatchit Updated changes for 4 test playbooks. Can you please review this PR?