### PR TITLE
gh-1524: Fix mix-indent in openebs/k8s/vagrant/1.10.0/ubuntu/Vagrantfile

### DIFF
--- a/k8s/vagrant/1.10.0/ubuntu/Vagrantfile
+++ b/k8s/vagrant/1.10.0/ubuntu/Vagrantfile
@@ -1,52 +1,52 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-#This is parameterized Vagrantfile, that can used for any of the following:
-#- Launch VMs auto-configured with kubernetes cluster with dedicated openebs
-#- Launch VMs auto-configured with kubernetes cluster with hyperconverged openebs
-#- Launch VMs for manual installation of kubernetes or maya clusters or both 
+# This is parameterized Vagrantfile, that can used for any of the following:
+#   - Launch VMs auto-configured with kubernetes cluster with dedicated openebs
+#   - Launch VMs auto-configured with kubernetes cluster with hyperconverged openebs
+#   - Launch VMs for manual installation of kubernetes or maya clusters or both
 #
-#The configurable options include:
-#- Specify the number of VMs / node types 
-#- Specify the CPU/RAM for each type of node
-#- Specify the desired kubernetes cluster installation option - kubeadm, kargo, manual
-#- Specify the base operating system - Ubuntu, CentOS, etc., 
-#- Specify the kubernetes pod network - flannel, weave, calico, etc,. 
-#- In case of dedicated, specify the storage network - host, etc.,
+# The configurable options include:
+#   - Specify the number of VMs / node types
+#   - Specify the CPU/RAM for each type of node
+#   - Specify the desired kubernetes cluster installation option - kubeadm, kargo, manual
+#   - Specify the base operating system - Ubuntu, CentOS, etc.,
+#   - Specify the kubernetes pod network - flannel, weave, calico, etc,.
+#   - In case of dedicated, specify the storage network - host, etc.,
 
-#Specify the OpenEBS Deployment Mode - dedicated=1 (default) or hyperconverged=2
+# Specify the OpenEBS Deployment Mode - dedicated=1 (default) or hyperconverged=2
 DEPLOY_MODE_NONE = 0 
 DEPLOY_MODE_DEDICATED = 1
 DEPLOY_MODE_HC = 2
 
 distro=ENV['DISTRIBUTION'] || "ubuntu"
-#Changed DEPLOY_MODE from Constant to Local variable deploy_Mode to avoid rewrite warnings on constants.
+# Changed DEPLOY_MODE from Constant to Local variable deploy_Mode to avoid rewrite warnings on constants.
 deploy_Mode=ENV['OPENEBS_DEPLOY_MODE'] || 2
 
-#Specify the release versions to be installed
+# Specify the release versions to be installed
 MAYA_RELEASE_TAG = ENV['MAYA_RELEASE_TAG'] || "0.2"
 
-#TODO - Verify
-#LC_ALL is not set on OsX, it will inherit it from SSH on Linux though,
-#so might want it to be a conditional
+# TODO - Verify
+#   LC_ALL is not set on OsX, it will inherit it from SSH on Linux though,
+#   so might want it to be a conditional
 ENV['LC_ALL']="en_US.UTF-8"
 
-#Specify the number of Kubernetes Master nodes, CPU/RAM per node. 
+# Specify the number of Kubernetes Master nodes, CPU/RAM per node.
 KM_NODES = ENV['KM_NODES'] || 1
 KM_MEM = ENV['KM_MEM'] || 2048
 KM_CPUS = ENV['KM_CPUS'] || 2
 
-#Specify the number of Kubernetes Minion nodes, CPU/RAM per node. 
+# Specify the number of Kubernetes Minion nodes, CPU/RAM per node.
 KH_NODES = ENV['KH_NODES'] || 2
 KH_MEM = ENV['KH_MEM'] || 2048
 KH_CPUS = ENV['KH_CPUS'] || 2
 
-#Specify the number of OpenEBS Master nodes, CPU/RAM per node. (Applicable only for dedicated mode)
+# Specify the number of OpenEBS Master nodes, CPU/RAM per node. (Applicable only for dedicated mode)
 MM_NODES = ENV['MM_NODES'] || 1
 MM_MEM = ENV['MM_MEM'] || 1024
 MM_CPUS = ENV['MM_CPUS'] || 1
 
-#Specify the number of OpenEBS Storage Host nodes, CPU/RAM per node. (Applicable only for dedicated mode)
+# Specify the number of OpenEBS Storage Host nodes, CPU/RAM per node. (Applicable only for dedicated mode)
 MH_NODES = ENV['MH_NODES'] || 2
 MH_MEM = ENV['MH_MEM'] || 1024
 MH_CPUS = ENV['MH_CPUS'] || 1
@@ -57,11 +57,11 @@ MH_CPUS = ENV['MH_CPUS'] || 1
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.9.1"
 
-#Local Variables
+# Local Variables
 machine_ip_address = %Q(ip addr show | grep -oP \
-            "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
-            | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
-            | sort | tail -n 1 | head -n 1)
+  "inet addr:\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+  | grep -oP "\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
+  | sort | tail -n 1 | head -n 1)
 
 master_ip_address = ""
 host_ip_address = ""
@@ -94,21 +94,21 @@ def configureVM(vmCfg, hostname, cpus, mem, distro)
   # The default user is ubuntu for those boxes
   vmCfg.ssh.username = "ubuntu"
   vmCfg.vm.provision "shell", inline: <<-SHELL
-      echo "ubuntu:ubuntu" | sudo chpasswd
+    echo "ubuntu:ubuntu" | sudo chpasswd
   SHELL
 
-  #Adding Vagrant-cachier
+  # Adding Vagrant-cachier
   if Vagrant.has_plugin?("vagrant-cachier")
-     vmCfg.cache.scope = :machine
-     vmCfg.cache.enable :apt
-     vmCfg.cache.enable :gem     
+    vmCfg.cache.scope = :machine
+    vmCfg.cache.enable :apt
+    vmCfg.cache.enable :gem
   end
   
   # Set resources w.r.t Virtualbox provider
   vmCfg.vm.provider "virtualbox" do |vb|
-    #Uncomment the following line, to launch the Virtual Box console. 
-    #Useful for debugging cases, where the VM doesn't allow login into console
-    #vb.gui = true
+    # Uncomment the following line, to launch the Virtual Box console.
+    #   Useful for debugging cases, where the VM doesn't allow login into console
+    # vb.gui = true
     vb.memory = mem
     vb.cpus = cpus
     vb.customize ["modifyvm", :id, "--cableconnected1", "on"]   
@@ -120,167 +120,167 @@ end
 # Entry point of this Vagrantfile
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-    #Dont look for updates
-    if Vagrant.has_plugin?("vagrant-vbguest") then
-        config.vbguest.auto_update = false
-    end
+  # Dont look for updates
+  if Vagrant.has_plugin?("vagrant-vbguest") then
+    config.vbguest.auto_update = false
+  end
 
-    #Check for invalid deployment modes and default to DEDICATED MODE.  
-    if ((deploy_Mode.to_i < DEPLOY_MODE_NONE.to_i) || \
-      (deploy_Mode.to_i > DEPLOY_MODE_HC.to_i))
-        puts "Invalid value set for OPENEBS_DEPLOY_MODE"
-        puts "Usage: OPENEBS_DEPLOY_MODE=0 for NONE"
-        puts "Usage: OPENEBS_DEPLOY_MODE=1 for DEDICATED"
-        puts "Usage: OPENEBS_DEPLOY_MODE=2 for HYPERCONVERGED"
-        puts "Defaulting to DEDICATED MODE..."
-        puts "Do you want to continue?(y/n):"
+  # Check for invalid deployment modes and default to DEDICATED MODE.
+  if ((deploy_Mode.to_i < DEPLOY_MODE_NONE.to_i) || \
+    (deploy_Mode.to_i > DEPLOY_MODE_HC.to_i))
+    puts "Invalid value set for OPENEBS_DEPLOY_MODE"
+    puts "Usage: OPENEBS_DEPLOY_MODE=0 for NONE"
+    puts "Usage: OPENEBS_DEPLOY_MODE=1 for DEDICATED"
+    puts "Usage: OPENEBS_DEPLOY_MODE=2 for HYPERCONVERGED"
+    puts "Defaulting to DEDICATED MODE..."
+    puts "Do you want to continue?(y/n):"
+    input = STDIN.gets.chomp
+    while 1 do
+      if (input == "n")
+        Kernel.exit!(0)
+      elsif (input == "y")
+        break
+      else
+        puts "Invalid input: type 'y' or 'n'"
         input = STDIN.gets.chomp
-        while 1 do
-           if(input == "n")
-             Kernel.exit!(0)
-           elsif(input == "y")
-             break
-           else
-             puts "Invalid input: type 'y' or 'n'"
-             input = STDIN.gets.chomp
-           end
-        end
-        deploy_Mode = 1
-    end   
-  
-    # K8s Master related only !!
-    1.upto(KM_NODES.to_i) do |i|
-      hostname = "kubemaster-%02d" % [i]
-      cpus = KM_CPUS
-      mem = KM_MEM            
-      config.vm.define hostname do |vmCfg|
-        vmCfg.vm.box = "openebs/k8s-1.10.0-ubuntu"
-	      vmCfg.vm.provider "virtualbox" do |vb|
-           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "kubemaster-%02d-console.log" % [i] )]
-        end
-        vmCfg = configureVM(vmCfg, hostname, cpus, mem, distro)
-
-        # Run in dedicated deployment mode or hyperconverged mode
-        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
-          (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
-
-          vmCfg.vm.provision :shell,
-          inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/prepare_network.sh",
-          run: "always",
-          privileged: true
-          
-          # Install Kubernetes Master.
-          vmCfg.vm.provision :shell, 
-          inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_master.sh", 
-          privileged: true          
-
-          # Setup K8s Credentials
-          vmCfg.vm.provision :shell, 
-          inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_cred.sh", 
-          privileged: false          
-
-          # Setup Weave
-          vmCfg.vm.provision :shell, 
-          inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_cni.sh", 
-          privileged: false          
-          
-          # Setup Dashboard
-          vmCfg.vm.provision :shell, 
-          inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_dashboard.sh", 
-          privileged: false          
-        end
-      end           
+      end
     end
-    
-    # K8s Minions related only !!
-    1.upto(KH_NODES.to_i) do |i|
-      hostname = "kubeminion-%02d" % [i]
-      cpus = KH_CPUS
-      mem = KH_MEM            
-      config.vm.define hostname do |vmCfg|
-        vmCfg.vm.box = "openebs/k8s-1.10.0-ubuntu"
-	      vmCfg.vm.provider "virtualbox" do |vb|
-           vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "kubeminion-%02d-console.log" % [i] )]
-        end
-        vmCfg = configureVM(vmCfg, hostname, cpus, mem, distro)
+    deploy_Mode = 1
+  end
+  
+  # K8s Master related only !!
+  1.upto(KM_NODES.to_i) do |i|
+    hostname = "kubemaster-%02d" % [i]
+    cpus = KM_CPUS
+    mem = KM_MEM
+    config.vm.define hostname do |vmCfg|
+      vmCfg.vm.box = "openebs/k8s-1.10.0-ubuntu"
+	  vmCfg.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "kubemaster-%02d-console.log" % [i] )]
+      end
+      vmCfg = configureVM(vmCfg, hostname, cpus, mem, distro)
+
+      # Run in dedicated deployment mode or hyperconverged mode
+      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+        (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
 
         vmCfg.vm.provision :shell,
         inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/prepare_network.sh",
         run: "always",
         privileged: true
 
-        # Run in dedicated deployment mode or hyperconverged mode
-        if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
-          (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
+        # Install Kubernetes Master.
+        vmCfg.vm.provision :shell,
+        inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_master.sh",
+        privileged: true
 
-          # This runs only when the VM is first provisioned.
-          # Get the Master IP to join the cluster.
-          vmCfg.vm.provision :trigger, 
-          :force => true, 
-          :stdout => true, 
-          :stderr => true do |trigger|
-            trigger.fire do
-              info"Getting the Master IP and Token to join the cluster..."
-              master_hostname = "kubemaster-01"
-              
-              get_ip_address = %Q(vagrant ssh \
+        # Setup K8s Credentials
+        vmCfg.vm.provision :shell,
+        inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_cred.sh",
+        privileged: false
+
+        # Setup Weave
+        vmCfg.vm.provision :shell,
+        inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_cni.sh",
+        privileged: false
+
+        # Setup Dashboard
+        vmCfg.vm.provision :shell,
+        inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_dashboard.sh",
+        privileged: false
+      end
+    end
+  end
+
+  # K8s Minions related only !!
+  1.upto(KH_NODES.to_i) do |i|
+    hostname = "kubeminion-%02d" % [i]
+    cpus = KH_CPUS
+    mem = KH_MEM
+    config.vm.define hostname do |vmCfg|
+      vmCfg.vm.box = "openebs/k8s-1.10.0-ubuntu"
+	  vmCfg.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "kubeminion-%02d-console.log" % [i] )]
+      end
+      vmCfg = configureVM(vmCfg, hostname, cpus, mem, distro)
+
+      vmCfg.vm.provision :shell,
+      inline: "/bin/bash /home/#{vmCfg.ssh.username}/setup/k8s/prepare_network.sh",
+      run: "always",
+      privileged: true
+
+      # Run in dedicated deployment mode or hyperconverged mode
+      if ((deploy_Mode.to_i == DEPLOY_MODE_DEDICATED.to_i) || \
+        (deploy_Mode.to_i == DEPLOY_MODE_HC.to_i))
+
+        # This runs only when the VM is first provisioned.
+        # Get the Master IP to join the cluster.
+        vmCfg.vm.provision :trigger,
+        :force => true,
+        :stdout => true,
+        :stderr => true do |trigger|
+          trigger.fire do
+            info"Getting the Master IP and Token to join the cluster..."
+            master_hostname = "kubemaster-01"
+
+            get_ip_address = %Q(vagrant ssh \
               #{master_hostname} \
               -c 'ip addr show | grep -oP \
               "inet \\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
               | grep -oP \"\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}" \
               | sort | tail -n 1 | head -n 1')
-              
-              master_ip_address = `#{get_ip_address}`            
-              if master_ip_address == ""            
-                  info"The Kubernetes Master is down, \
-                  bring it up and manually run: \
-                  configure_k8s_host.sh script on Kubernetes Minion."
-              else                           
-                  get_token_name = %Q(vagrant ssh \
-                  #{master_hostname} -c \
-                  'kubectl -n kube-system get secrets \
-                  | grep bootstrap-token | cut -d " " -f1\
-                  | cut -d "-" -f3\
-                  | sed "s|\r||g" \
-                  ')
-                  
-                  token_name = `#{get_token_name}`               
 
-                  get_token = %Q(vagrant ssh \
-                  #{master_hostname} -c \
-                  'kubectl -n kube-system get secrets bootstrap-token-#{token_name.strip} \
-                  -o yaml | grep token-secret | cut -d ":" -f2 \
-                  | cut -d " " -f2 | base64 -d \
-                  | sed "s|{||g;s|}||g" \
-                  | sed "s|:|.|g" | xargs echo')
-                  
-                  token = `#{get_token}`                  
-                  
-                  if token != ""
-                    get_token_sha = %Q(vagrant ssh \
-                    #{master_hostname} \
-                    -c 'openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt \
-                    | openssl rsa -pubin -outform der 2>/dev/null \
-                    | openssl dgst -sha256 -hex \
-                    | sed "s/^.* //"')
+            master_ip_address = `#{get_ip_address}`
+            if master_ip_address == ""
+              info"The Kubernetes Master is down, \
+              bring it up and manually run: \
+              configure_k8s_host.sh script on Kubernetes Minion."
+            else
+              get_token_name = %Q(vagrant ssh \
+                #{master_hostname} -c \
+                'kubectl -n kube-system get secrets \
+                | grep bootstrap-token | cut -d " " -f1\
+                | cut -d "-" -f3\
+                | sed "s|\r||g" \
+                ')
 
-                    token_sha = `#{get_token_sha}`
-                    info"Using Master IP  - #{master_ip_address.strip}"
-                    info"Using Token -  #{token_name.strip}.#{token.strip}"
-                    info"Using Discovery Token SHA - #{token_sha.strip}"
-                    
-                    @machine.communicate.sudo("bash \
-                    /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_host.sh \
-                    --masterip=#{master_ip_address.strip} \
-                    --token=#{token_name.strip}.#{token.strip} \
-                    --token-sha=#{token_sha.strip}")
-                  else
-                    info"Invalid Token. Check your Kubernetes setup."
-                  end
-              end  
+              token_name = `#{get_token_name}`
+
+              get_token = %Q(vagrant ssh \
+                #{master_hostname} -c \
+                'kubectl -n kube-system get secrets bootstrap-token-#{token_name.strip} \
+                -o yaml | grep token-secret | cut -d ":" -f2 \
+                | cut -d " " -f2 | base64 -d \
+                | sed "s|{||g;s|}||g" \
+                | sed "s|:|.|g" | xargs echo')
+
+              token = `#{get_token}`
+
+              if token != ""
+                get_token_sha = %Q(vagrant ssh \
+                  #{master_hostname} \
+                  -c 'openssl x509 -pubkey -in /etc/kubernetes/pki/ca.crt \
+                  | openssl rsa -pubin -outform der 2>/dev/null \
+                  | openssl dgst -sha256 -hex \
+                  | sed "s/^.* //"')
+
+                token_sha = `#{get_token_sha}`
+                info"Using Master IP  - #{master_ip_address.strip}"
+                info"Using Token -  #{token_name.strip}.#{token.strip}"
+                info"Using Discovery Token SHA - #{token_sha.strip}"
+
+                @machine.communicate.sudo("bash \
+                  /home/#{vmCfg.ssh.username}/setup/k8s/configure_k8s_host.sh \
+                  --masterip=#{master_ip_address.strip} \
+                  --token=#{token_name.strip}.#{token.strip} \
+                  --token-sha=#{token_sha.strip}")
+              else
+                info"Invalid Token. Check your Kubernetes setup."
+              end
             end
           end
         end
-      end      
+      end
     end
   end
+end


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated openebs/k8s/vagrant/1.10.0/ubuntu/Vagrantfile following Ruby Style Guide indentation best practice:

- Use two spaces per indentation level (aka soft tabs). No hard tabs.
- Align the parameters of a method call if they span more than one line. When aligning parameters is not appropriate due to line-length constraints, single indent for the lines after the first is also acceptable.
- If multiple lines are required to describe the problem, subsequent lines should be indented three spaces after the # (one general plus two for indentation purpose).

**Which issue this PR fixes** 
This fixes #1524