### PR TITLE
Add deprecate note to local helm charts

### DIFF
--- a/k8s/charts/openebs/Chart.yaml
+++ b/k8s/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.5.4
+version: 0.5.5
 name: openebs
 appVersion: 0.5.4
 description: Containerized Storage for Containers

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -5,7 +5,7 @@ DEPRECATION NOTICE:
 
 The support for this chart will be discontinued soon. Please plan to migrate
 and use stable/openebs chart located at:
- https://github.com/kubernetes/charts/tree/master/stable/openebs
+ [https://github.com/kubernetes/charts/tree/master/stable/openebs](https://github.com/kubernetes/charts/tree/master/stable/openebs)
 
 ------------------------------------------------------------------------------
 
@@ -13,7 +13,7 @@ and use stable/openebs chart located at:
 - Kubernetes 1.7.5+ with RBAC enabled
 - iSCSI PV support in the underlying infrastructure
 - helm is installed and the tiller has admin privileges. To assign admin
-  to tiller, you can use the following instructions:
+  to tiller, login as admin and use the following instructions:
   ```
   kubectl -n kube-system create sa tiller
   kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller

--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -1,20 +1,53 @@
+------------------------------------------------------------------------------
+IMPORTANT!!
+
+DEPRECATION NOTICE:
+
+The support for this chart will be discontinued soon. Please plan to migrate
+and use stable/openebs chart located at:
+ https://github.com/kubernetes/charts/tree/master/stable/openebs
+
+------------------------------------------------------------------------------
 
 ## Prerequisites
 - Kubernetes 1.7.5+ with RBAC enabled
 - iSCSI PV support in the underlying infrastructure
+- helm is installed and the tiller has admin privileges. To assign admin
+  to tiller, you can use the following instructions:
+  ```
+  kubectl -n kube-system create sa tiller
+  kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+  kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}'
+  kubectl -n kube-system patch deployment tiller-deploy -p '{"spec": {"template": {"spec": {"automountServiceAccountToken": true}}}}'
+  ``` 
+- A namespace called "openebs" is created in the Cluster for running the
+  below instructions: `kubectl create namespace openebs`
 
-## Installing OpenEBS 
+## Installing OpenEBS Charts Repository 
 ```
 helm repo add openebs-charts https://openebs.github.io/charts/
 helm repo update
 helm install openebs-charts/openebs --name openebs --namespace openebs
 ```
 
-## Installing OpenEBS from Chart codebase
+## Installing OpenEBS from this codebase
 ```
 git clone https://github.com/openebs/openebs.git
 cd openebs/k8s/charts/openebs/
 helm install --name openebs --namespace openebs .
+```
+
+## Verify that OpenEBS Volumes can be created
+```
+#Check the OpenEBS Management Pods are running
+kubectl get pods -n openebs
+#Create a test PVC
+kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/pvc.yaml
+#Check the OpenEBS Volume Pods are created. 
+kubectl get pods
+#Delete the test volume and associated Volume Pods. 
+kubectl delete -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/pvc.yaml
+
 ```
 
 ## Unistalling OpenEBS from Chart codebase
@@ -34,14 +67,10 @@ The following tables lists the configurable parameters of the OpenEBS chart and 
 | `image.pullPolicy`                   | Container pull policy                         | `IfNotPresent`                    |
 | `apiserver.image`                    | Docker Image for API Server                   | `openebs/m-apiserver`             |
 | `apiserver.imageTag`                 | Docker Image Tag for API Server               | `0.5.4`                           |
-| `apiserver.replicas`                 | Number of API Server Replicas                 | `2`                               |
-| `apiserver.antiAffinity.enabled`     | Enable anti-affinity for API Server Replicas  | `true`                           |
-| `apiserver.antiAffinity.type`        | Anti-affinity type for API Server             | `Hard`                           |
+| `apiserver.replicas`                 | Number of API Server Replicas                 | `1`                               |
 | `provisioner.image`                  | Docker Image for Provisioner                  | `openebs/openebs-k8s-provisioner` |
 | `provisioner.imageTag`               | Docker Image Tag for Provisioner              | `0.5.4`                           |
-| `provisioner.replicas`               | Number of Provisioner Replicas                | `2`                               |
-| `provisioner.antiAffinity.enabled`   | Enable anti-affinity for API Server Replicas  | `true`                           |
-| `provisioner.antiAffinity.type`      | Anti-affinity type for Provisioner            | `Hard`                           |
+| `provisioner.replicas`               | Number of Provisioner Replicas                | `1`                               |
 | `jiva.image`                         | Docker Image for Jiva                         | `openebs/jiva`                    |
 | `jiva.imageTag`                      | Docker Image Tag for Jiva                     | `0.5.4`                           |
 | `jiva.replicas`                      | Number of Jiva Replicas                       | `3`                               |

--- a/k8s/charts/openebs/templates/NOTES.txt
+++ b/k8s/charts/openebs/templates/NOTES.txt
@@ -1,6 +1,19 @@
-The OpenEBS has been installed. Check its status by running:
-  kubectl get pods -l "name=maya-apiserver"
+------------------------------------------------------------------------------
+IMPORTANT!!
 
-To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
-Please visit http://docs.openebs.io/ for usage instructions
+DEPRECATION NOTICE:
+
+The support for this chart will be discontinued soon. Please plan to migrate
+and use stable/openebs chart located at:
+ https://github.com/kubernetes/charts/tree/master/stable/openebs
+
+------------------------------------------------------------------------------
+
+The OpenEBS has been installed. Check its status by running:
+  kubectl get pods -n {{ .Release.Namespace }}
+
+Please note that, OpenEBS uses iSCSI for connecting applications with the 
+OpenEBS Volumes and your nodes should have the iSCSI initiator installed. 
+
+For more information, please visit http://docs.openebs.io/.
 

--- a/k8s/charts/openebs/templates/_helpers.tpl
+++ b/k8s/charts/openebs/templates/_helpers.tpl
@@ -9,8 +9,35 @@ Expand the name of the chart.
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "openebs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openebs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openebs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "openebs.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "openebs.fullname". }}
+  name: {{ template "openebs.fullname" . }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ template "openebs.chart" . }}

--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -2,9 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.operator.name }}
+  name: {{ template "openebs.fullname". }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 rules:
 - apiGroups: ["*"]
   resources: ["nodes","nodes/proxy"]

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "openebs.fullname". }}
+  name: {{ template "openebs.fullname" . }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ template "openebs.chart" . }}
@@ -11,9 +11,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "openebs.fullname". }}
+  name: {{ template "openebs.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "openebs.serviceAccountName". }}
+  name: {{ template "openebs.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/clusterrolebinding.yaml
+++ b/k8s/charts/openebs/templates/clusterrolebinding.yaml
@@ -2,15 +2,18 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.operator.name }}
+  name: {{ template "openebs.fullname". }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.operator.name }}
+  name: {{ template "openebs.fullname". }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.operator.name }}
+  name: {{ template "openebs.serviceAccountName". }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-config.yaml
@@ -5,11 +5,10 @@ metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-config
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: prometheus-config
+    component: prometheus-config
 data:
   prometheus.yml: |-
     global:

--- a/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
+++ b/k8s/charts/openebs/templates/cm-openebs-prometheus-tunables.yaml
@@ -5,11 +5,10 @@ metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-tunables
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: prometheus-tunables
+    component: prometheus-tunables
 data:
   storage-retention: 24h
 {{- end }}

--- a/k8s/charts/openebs/templates/crd-sp.yaml
+++ b/k8s/charts/openebs/templates/crd-sp.yaml
@@ -4,7 +4,10 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepools.openebs.io
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io

--- a/k8s/charts/openebs/templates/crd-spc.yaml
+++ b/k8s/charts/openebs/templates/crd-spc.yaml
@@ -4,7 +4,10 @@ metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepoolclaims.openebs.io
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -17,7 +17,7 @@ spec:
         release: {{ .Release.Name }}
         component: apiserver
     spec:
-      serviceAccountName: {{ template "openebs.serviceAccountName". }}
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-apiserver
         image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -1,14 +1,13 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "openebs.fullname" . }}-maya-apiserver
+  name: {{ template "openebs.fullname" . }}-apiserver
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: apiserver
+    component: apiserver
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   template:
@@ -16,12 +15,11 @@ spec:
       labels:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
-        component: {{ template "openebs.fullname" . }}
-        role: apiserver
+        component: apiserver
     spec:
-      serviceAccountName: {{ .Values.operator.name }}
+      serviceAccountName: {{ template "openebs.serviceAccountName". }}
       containers:
-      - name: {{ template "openebs.name" . }}-maya-apiserver
+      - name: {{ template "openebs.name" . }}-apiserver
         image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
@@ -45,34 +43,15 @@ spec:
           value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "{{ .Values.jiva.replicas }}"
-
 {{- if .Values.apiserver.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.apiserver.nodeSelector | indent 8 }}
 {{- end }}
-
 {{- if .Values.apiserver.tolerations }}
       tolerations:
 {{ toYaml .Values.apiserver.tolerations | indent 8 }}
 {{- end }}
-
-{{- if .Values.apiserver.antiAffinity.enabled }}
+{{- if .Values.apiserver.affinity }}
       affinity:
-        podAntiAffinity:
-  {{- $antiAffinityType := .Values.apiserver.antiAffinity.type | lower -}}
-  {{- if eq $antiAffinityType "hard" }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  name: {{ template "openebs.fullname" . }}-maya-apiserver
-  {{- else if eq $antiAffinityType "soft" }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchLabels:
-                    name: {{ template "openebs.fullname" . }}-maya-apiserver
-  {{- end }}
+{{ toYaml .Values.apiserver.affinity | indent 8 }}
 {{- end }}

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -17,7 +17,7 @@ spec:
         release: {{ .Release.Name }}
         component: provisioner
     spec:
-      serviceAccountName: {{ template "openebs.serviceAccountName". }}
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-provisioner
         image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -4,11 +4,10 @@ metadata:
   name: {{ template "openebs.fullname" . }}-provisioner
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: provisioner
+    component: provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   template:
@@ -16,10 +15,9 @@ spec:
       labels:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
-        component: {{ template "openebs.fullname" . }}
-        role: provisioner
+        component: provisioner
     spec:
-      serviceAccountName: {{ .Values.operator.name }}
+      serviceAccountName: {{ template "openebs.serviceAccountName". }}
       containers:
       - name: {{ template "openebs.name" . }}-provisioner
         image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
@@ -37,10 +35,8 @@ spec:
         #  value: "/home/ubuntu/.kube/config"
         # OPENEBS_NAMESPACE is the namespace that this provisioner will
         # lookup to find maya api service
-{{- if .Values.rbac.create }}
         - name: OPENEBS_NAMESPACE
           value: "{{ .Release.Namespace }}"
-{{- end }}
         - name: NODE_NAME
           valueFrom:
             fieldRef:
@@ -50,43 +46,24 @@ spec:
         # If not present, "maya-apiserver-service" will be used for lookup.
         # This is supported for openebs provisioner version 0.5.3-RC1 onwards
         - name: OPENEBS_MAYA_SERVICE_NAME
-          value: "{{ template "openebs.fullname" . }}-maya-apiservice"
+          value: "{{ template "openebs.fullname" . }}-apiservice"
         # The following values will be set as annotations to the PV object.
         # Refer : https://github.com/openebs/external-storage/pull/15
         #- name: OPENEBS_MONITOR_URL
-        #  value: "{{ .Values.provisioner.monitorurl }}"
+        #  value: "{{ .Values.provisioner.monitorUrl }}"
         #- name: OPENEBS_MONITOR_VOLKEY
-        #  value: "{{ .Values.provisioner.monitorvolkey }}"
+        #  value: "{{ .Values.provisioner.monitorVolumeKey }}"
         #- name: MAYA_PORTAL_URL
-        #  value: "{{ .Values.provisioner.mayaportalurl }}"
-
+        #  value: "{{ .Values.provisioner.mayaPortalUrl }}"
 {{- if .Values.provisioner.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.provisioner.nodeSelector | indent 8 }}
 {{- end }}
-
 {{- if .Values.provisioner.tolerations }}
       tolerations:
 {{ toYaml .Values.provisioner.tolerations | indent 8 }}
 {{- end }}
-
-{{- if .Values.provisioner.antiAffinity.enabled }}
-      affinity:
-        podAntiAffinity:
-  {{- $antiAffinityType := .Values.provisioner.antiAffinity.type | lower -}}
-  {{- if eq $antiAffinityType "hard" }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  name: {{ template "openebs.fullname" . }}-provisioner
-  {{- else if eq $antiAffinityType "soft" }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                topologyKey: "kubernetes.io/hostname"
-                labelSelector:
-                  matchLabels:
-                    name: {{ template "openebs.fullname" . }}-provisioner
-  {{- end }}
+{{- if .Values.provisioner.affinity }}
+      tolerations:
+{{ toYaml .Values.provisioner.affinity | indent 8 }}
 {{- end }}

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -5,11 +5,10 @@ metadata:
   name: {{ template "openebs.fullname" . }}-grafana
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: grafana
+    component: grafana
 spec:
   replicas: 1
   revisionHistoryLimit: 2
@@ -18,9 +17,9 @@ spec:
       labels:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
-        component: {{ template "openebs.fullname" . }}
-        role: grafana
+        component: grafana
     spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName". }}
       containers:
       - name: {{ template "openebs.name" . }}-grafana
         image: "{{ .Values.grafana.image }}:{{ .Values.grafana.imageTag }}"

--- a/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-grafana.yaml
@@ -19,7 +19,7 @@ spec:
         release: {{ .Release.Name }}
         component: grafana
     spec:
-      serviceAccountName: {{ template "openebs.serviceAccountName". }}
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
       - name: {{ template "openebs.name" . }}-grafana
         image: "{{ .Values.grafana.image }}:{{ .Values.grafana.imageTag }}"

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -18,7 +18,7 @@ spec:
         release: {{ .Release.Name }}
         component: prometheus
     spec:
-      serviceAccountName: {{ template "openebs.serviceAccountName". }}
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
         - name: {{ template "openebs.name" . }}-prometheus
           image: "{{ .Values.prometheus.image }}:{{ .Values.prometheus.imageTag }}"

--- a/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/deployment-openebs-prometheus.yaml
@@ -5,11 +5,10 @@ metadata:
   name: {{ template "openebs.fullname" . }}-prometheus
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    component: {{ template "openebs.fullname" . }}
-    role: prometheus
+    component: prometheus
 spec:
   replicas: 1
   template:
@@ -17,10 +16,9 @@ spec:
       labels:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
-        component: {{ template "openebs.fullname" . }}
-        role: prometheus
+        component: prometheus
     spec:
-      serviceAccountName: {{ .Values.operator.name }}
+      serviceAccountName: {{ template "openebs.serviceAccountName". }}
       containers:
         - name: {{ template "openebs.name" . }}-prometheus
           image: "{{ .Values.prometheus.image }}:{{ .Values.prometheus.imageTag }}"

--- a/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-cassandra.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-cassandra
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-es-data-sc.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-es-data-sc
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-jupyter.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-jupyter
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-kafka.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-kafka
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -14,3 +14,4 @@ parameters:
   openebs.io/jiva-replica-count: "{{ .Values.jiva.replicas }}"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
+  openebs.io/fstype: "xfs"

--- a/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-mongodb.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-mongodb
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-percona.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-percona.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-percona
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-redis.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-redis.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-redis
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standalone.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-standalone
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-standard.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-standard.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-standard
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/sc-openebs-zk.yaml
+++ b/k8s/charts/openebs/templates/sc-openebs-zk.yaml
@@ -4,7 +4,10 @@ kind: StorageClass
 metadata:
   name: openebs-zk
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -1,13 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "openebs.fullname" . }}-maya-apiservice
+  name: {{ template "openebs.fullname" . }}-apiservice
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    role: apiserver
 spec:
   ports:
   - name: api
@@ -17,6 +16,5 @@ spec:
   selector:
     app: {{ template "openebs.name" . }}
     release: {{ .Release.Name }}
-    component: {{ template "openebs.fullname" . }}
-    role: apiserver
+    component: apiserver
   sessionAffinity: None

--- a/k8s/charts/openebs/templates/service-openebs-grafana.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-grafana.yaml
@@ -2,13 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "openebs.fullname" . }}-grafana
+  name: {{ template "openebs.fullname" . }}-grafana-service
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    role: grafana
 spec:
   type: NodePort
   ports:
@@ -18,6 +17,5 @@ spec:
   selector:
     app: {{ template "openebs.name" . }}
     release: {{ .Release.Name }}
-    component: {{ template "openebs.fullname" . }}
-    role: grafana
+    component: grafana
 {{- end }}

--- a/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
+++ b/k8s/charts/openebs/templates/service-openebs-prometheus.yaml
@@ -5,10 +5,9 @@ metadata:
   name: {{ template "openebs.fullname" . }}-prometheus-service
   labels:
     app: {{ template "openebs.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    role: prometheus
 spec:
   type: NodePort
   ports:
@@ -19,6 +18,5 @@ spec:
   selector:
     app: {{ template "openebs.name" . }}
     release: {{ .Release.Name }}
-    component: {{ template "openebs.fullname" . }}
-    role: prometheus
+    component: prometheus
 {{- end }}

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "openebs.serviceAccountName". }}
+  name: {{ template "openebs.serviceAccountName" . }}
   labels:
     app: {{ template "openebs.name" . }}
     chart: {{ template "openebs.chart" . }}

--- a/k8s/charts/openebs/templates/serviceaccount.yaml
+++ b/k8s/charts/openebs/templates/serviceaccount.yaml
@@ -1,6 +1,11 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.operator.name }}
+  name: {{ template "openebs.serviceAccountName". }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -1,12 +1,14 @@
-# Default values for OpenEBS
+# Default values for openebs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
 
-## If true, create & use RBAC resources
-##
 rbac:
+  # Specifies whether RBAC resources should be created
   create: true
 
-operator:
-  name: "openebs-maya-operator"
+serviceAccount:
+  create: true
+  name:
 
 image:
   pullPolicy: IfNotPresent
@@ -14,28 +16,26 @@ image:
 apiserver:
   image: "openebs/m-apiserver"
   imageTag: "0.5.4"
-  replicas: 2
+  replicas: 1
   ports:
     externalPort: 5656
     internalPort: 5656
   nodeSelector: {}
   tolerations: {}
-  antiAffinity:
-    enabled: true
-    type: Hard
+  affinity: {}
 
 provisioner:
   image: "openebs/openebs-k8s-provisioner"
   imageTag: "0.5.4"
-  replicas: 2
-  mayaportalurl: "https://mayaonline.io/"
-  monitorurl: "http://127.0.0.1:32515/dashboard/db/openebs-volume-stats?orgId=1"
-  monitorvolkey: "&var-OpenEBS"
+  replicas: 1
   nodeSelector: {}
   tolerations: {}
-  antiAffinity:
-    enabled: true
-    type: Hard
+  affinity: {}
+
+jiva:
+  image: "openebs/jiva"
+  imageTag: "0.5.4"
+  replicas: 3
 
 grafana:
   image: "grafana/grafana"
@@ -52,11 +52,6 @@ prometheus:
     externalPort: 80
     internalPort: 9090
     nodePort: 32514
-
-jiva:
-  image: "openebs/jiva"
-  imageTag: "0.5.4"
-  replicas: 3
 
 policies:
   monitoring:


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

This PR adds a deprecate notice to the README of the openebs/charts in favor of using the kubernetes stable/openebs helm charts https://github.com/kubernetes/charts/tree/master/stable/openebs. 

This repository is still maintained, until:
- release process is set in motion to automatically update the kubernetes stable charts
- all the documentation around installing via helm charts has been updated to refer to kubernetes stable/openebs charts 

Along with deprecate notice, the chart YAMLs are also updated to be in sync with the charts in the kubernetes stable/openebs. The major changes involved are to keep the charts in sync with the best practices around naming and RBAC policies. 

The local repository includes additional configuration, which is not part of the kubernetes stable/openebs like:
- storage classes
- prometheus and grafana installations