### PR TITLE
Included cleanup check in hyperconverged test-suite

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
@@ -1,33 +1,29 @@
 
 
        - name: Get pvc name to verify successful pvc deletion
-         shell: source ~/.profile; kubectl get pvc --all-namespaces | grep {{ replace_with.0 }} | awk {'print $3'}
+         shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: pvc
          changed_when: True
 
-       - name: Delete percona mysql pod
-         shell: source ~/.profile; kubectl delete -f "{{ percona_file }}" -n percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         changed_when: True
+
+       - name: Delete percona deployment
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+         vars:
+           app_yml: "{{ percona_file }}"
+           ns: "{{namespace}}"
 
        - name: Confirm percona pod has been deleted
-         shell: source ~/.profile; kubectl get pods --all-namespaces -l name=percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' not in result.stdout"
-         delay: 30
-         retries: 10
-         changed_when: True
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+         vars:
+           ns: "{{namespace}}"
+           app: percona
+
 
        - name: Confirm percona pvc pod has been deleted
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep {{ pvc.stdout }}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -37,24 +33,17 @@
          retries: 10
          changed_when: True
 
-       - name: Delete the openebs operator
-         shell: source ~/.profile; kubectl delete -f "{{ openebs_operator }}"
+       - name: Delete namespace
+         shell: source ~/.profile; kubectl delete ns {{ namespace }}
          args:
            executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         ignore_errors: true
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         register: result
+         until: "'deleted' in result.stdout"
+         delay: 10
+         retries: 5
          changed_when: True
 
-       - name: Confirm pod has been deleted
-         shell: source ~/.profile; kubectl get pods --all-namespaces
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
-         delay: 10
-         retries: 6
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         changed_when: True
 
        - name: Remove test artifacts
          file:

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-ns-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-ns-vars.yml
@@ -7,6 +7,7 @@ openebs_operator_alias: openebs-operator.yaml
 
 openebs_storageclass: openebs-storageclasses.yaml
 
+utils_path: openebs/e2e/ansible/playbooks/utils
 
 openebs_storageclasses_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
 
@@ -43,4 +44,4 @@ test_artifacts:
    - demo-percona-mysql-pvc.yaml
    - openebs-operator-ns-openebs.yaml
 
-
+namespace: percona-app

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
@@ -115,12 +115,12 @@
 
        - name: Test playbook passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test playbook failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -130,12 +130,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
@@ -21,118 +21,51 @@
 
    - block:
 
-       - name: Check whether maya-apiserver pod is running
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 20
-         retries: 2
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         ignore_errors: true
-         become: true
-
-       - block:
-
-           - name: Delete the openebs operator
-             shell: source ~/.profile; kubectl delete -f "{{ openebs_operator_link }}"
-             args:
-               executable: /bin/bash
-             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-           - name: Confirm pod has been deleted
-             shell: source ~/.profile; kubectl get pods
-             args:
-               executable: /bin/bash
-             register: result
-             until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
-             delay: 30
-             retries: 3
-             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-         when: "result.rc == 0"
-
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: pre-requisites.yml
 
 
-       - name: Copy the openebs-operator to kube master
-         copy:
-           src: "{{ openebs_operator }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
-
-       - name: Deploy openebs-operator with openebs namespace
-         shell: source ~/.profile; kubectl apply -f "{{ openebs_operator }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source ~/.profile;
-           nohup stern --all-namespaces "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 250
-         retries: 5
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Check status of maya-apiserver
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: openebs
+           app: maya-apiserver
 
        - name: Creating  percona namespace to deploy percona application
-         shell: source ~/.profile; kubectl create namespace  percona
+         shell: source ~/.profile; kubectl create ns {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: Get percona spec and liveness scripts
+       - name: Get percona spec
          get_url:
            url: "{{ percona_mysql_plugin_link }}"
            dest: "{{ result_kube_home.stdout }}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
+
        - name: Replace volume-claim name with test parameters
-         replace:
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         vars:
            path: "{{ result_kube_home.stdout }}/demo-percona-mysql-pvc.yaml"
-           regexp: '{{ item.0 }}'
-           replace: '{{ item.1 }}'
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-         with_together:
-           - "{{replace_item}}"
-           - "{{replace_with}}"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
 
 
-       - name: Deploy Percona application with percona namespace
-         shell: source ~/.profile; kubectl apply -f "{{ percona_file }}" -n percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       - name: Create percona deployment with OpenEBS storage
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_file }}"
+           ns: "{{namespace}}"
 
-       - name: Confirm pod status is running
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 300
-         retries: 15
+       - name: Check percona pod is running
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: "{{namespace}}"
+           app: percona
+
 
        - name: Get IP address of percona mysql pod
-         shell: source ~/.profile; kubectl get pod percona -n percona -o wide --no-headers
+         shell: source ~/.profile; kubectl get pod percona -n {{ namespace }} -o wide --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -147,11 +80,16 @@
          become: true
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          ignore_errors: true
+         tags:
+           - skip_ansible_lint
 
        - name: Install mysql-client on K8S-master
          shell: apt-get install -y mysql-client
          become: true
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         tags:
+           - skip_ansible_lint
+
 
        - name: Write a test database into percona mysql
          shell: |
@@ -174,31 +112,45 @@
          register: result
          failed_when: "result.rc != 0"
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Set flag tp pass if test case is passed
+       - name: Test playbook passed
          set_fact:
            flag: "Pass"
 
      rescue:
-       - name: Set flag to fail if test case is failed
+       - name: Test playbook failed
          set_fact:
            flag: "Fail"
 
      always:
+       - block:
 
-       - include: k8s-percona-openebs-pod-cleanup.yml
-         when: clean | bool
+           - include: k8s-percona-openebs-pod-cleanup.yml
+             when: clean | bool
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           - name: Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 
 
 

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/pre-requisites.yml
@@ -1,0 +1,17 @@
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+
+       - name: Start the log aggregator to capture test pod logs
+         shell: >
+           source ~/.profile;
+           nohup stern --all-namespaces "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -1,25 +1,17 @@
 ---
-- name: Delete Percona deployment
-  shell: source ~/.profile; kubectl delete -f "{{ percona_link }}"
-  args:
-    executable: /bin/bash
-  register: del_out
-  until: "'percona' and 'deleted' in del_out.stdout"
-  delay: 30
-  retries: 5
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
+
+- name: Delete percona deployment
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    app_yml: "{{ percona_link }}"
+    ns: "{{namespace}}"
 
 - name: Confirm percona pod has been deleted
-  shell: source ~/.profile; kubectl get pods --all-namespaces -l name=percona
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  register: result
-  until: "'percona' not in result.stdout"
-  delay: 30
-  retries: 10
-  changed_when: True
+  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    ns: "{{namespace}}"
+    app: percona
+
 
 - name: uncordon the node which is drained
   shell: source ~/.profile; kubectl uncordon {{ node1.stdout }}
@@ -30,6 +22,17 @@
   until: "'uncordoned' in result.stdout"
   delay: 5
   retries: 10
+  changed_when: True
+
+- name: Delete namespace
+  shell: source ~/.profile; kubectl delete ns {{ namespace }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+  register: result
+  until: "'deleted' in result.stdout"
+  delay: 10
+  retries: 5
   changed_when: True
 
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
@@ -1,5 +1,6 @@
 test_name: verifiy_kubectl_drain_behaviour
 
+utils_path: openebs/e2e/ansible/playbooks/utils
 
 test_log_path: setup/logs/kubectl-drain-behaviour.log
 
@@ -17,3 +18,4 @@ test_artifacts:
   -  storage-class.yml
   -  replica_patch.yaml
 
+namespace: drain-node

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/pre-requisites.yml
@@ -1,0 +1,16 @@
+      - name: Get $HOME of K8s master for kubernetes user
+        shell: source ~/.profile; echo $HOME
+        args:
+          executable: /bin/bash
+        register: result_kube_home
+        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+        changed_when: True
+
+      - name: Start the log aggregator to capture test pod logs
+        shell: >
+          source ~/.profile;
+          nohup stern --all-namespaces "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+        args:
+          executable: /bin/bash
+        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+        changed_when: True

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -196,12 +196,12 @@
 
        - name: Test playbook passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test playbook failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -211,12 +211,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -24,13 +24,7 @@
    - block:
 
 
-
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source {{ profile }}; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - include: pre-requisites.yml
 
        - name: Get the Number of nodes count
          shell: source {{ profile }}; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
@@ -44,23 +38,12 @@
             node_count: " {{ node_out.stdout}}"
 
 
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Check status of maya-apiserver
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: openebs
+           app: maya-apiserver
 
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source {{ profile }};
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Obtaining storage classes yaml
          shell: kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
@@ -85,26 +68,28 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Create namespace to deploy application
+         shell: source ~/.profile; kubectl create ns {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 
        - name: Deploy percona application
-         shell: source {{ profile }}; kubectl apply -f {{ percona_link }}
+         shell: source {{ profile }}; kubectl apply -f {{ percona_link }} -n {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Confirm if the percona pod is running
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep percona
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         register: result
-         until: "'percona' and 'Running' in result.stdout"
-         delay: 120
-         retries: 10
+       - name: Check percona pod is running
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: "{{namespace}}"
+           app: percona
+
 
        - name: Check if the replica pods are created and running
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep rep | grep -i running |wc -l
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | grep -i running |wc -l
          args:
            executable: /bin/bash
          register: rep_count
@@ -116,7 +101,7 @@
 
 
        - name: Get PV name
-         shell: source ~/.profile; kubectl get pv | grep openebs-percona | awk '{print $1}'
+         shell: source ~/.profile; kubectl get pv -n {{ namespace }}| grep openebs-percona | awk '{print $1}'
          args:
            executable: /bin/bash
          register: pv_name
@@ -130,7 +115,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Get the node name where replica1 is scheduled
-         shell: source ~/.profile; kubectl get po --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $8}' | awk 'FNR == 1 {print}'
+         shell: source ~/.profile; kubectl get po -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}' | awk 'FNR == 1 {print}'
          args:
            executable: /bin/bash
          register: node1
@@ -138,7 +123,7 @@
 
 
        - name: Get the node name where replica2 is scheduled
-         shell: source ~/.profile; kubectl get po --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $8}' | awk 'FNR == 2 {print}'
+         shell: source ~/.profile; kubectl get po -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}' | awk 'FNR == 2 {print}'
          args:
            executable: /bin/bash
          register: node2
@@ -161,8 +146,8 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 
-       - name: Get the deployment namee
-         shell: source ~/.profile; kubectl get deploy --all-namespaces |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $2}'
+       - name: Get the deployment name
+         shell: source ~/.profile; kubectl get deploy -n {{ namespace }} |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $1}'
          args:
            executable: /bin/bash
          register: deploy_name
@@ -170,7 +155,7 @@
 
 
        - name: Apply the node affinity property
-         shell: source ~/.profile; kubectl patch deployment "{{ deploy_name.stdout }}" -p "$(cat replica_patch.yaml)"
+         shell: source ~/.profile; kubectl patch deployment "{{ deploy_name.stdout }}" -n {{ namespace }} -p "$(cat replica_patch.yaml)"
          args:
            executable: /bin/bash
          register: patch_out
@@ -188,7 +173,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Check the available replicas in deployment
-         shell: kubectl get deploy --all-namespaces | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $6}'
+         shell: kubectl get deploy -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $6}'
          args:
            executable: /bin/bash
          register: available_pods
@@ -200,7 +185,7 @@
 
 
        - name: Check if the replica is in pending state after node drain
-         shell: kubectl get pods --all-namespaces -o wide | grep "{{ pv_name.stdout }}" | grep rep | grep Pending
+         shell: kubectl get pods -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | grep Pending
          args:
            executable: /bin/bash
          register: result
@@ -209,30 +194,44 @@
          retries: 15
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Terminate the log aggregator
-         shell: source ~/.profile; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: Set flag to pass if test case is passed
+       - name: Test playbook passed
          set_fact:
            flag: "Pass"
 
      rescue:
-       - name: Set flag to fail if test case is failed
+       - name: Test playbook failed
          set_fact:
            flag: "Fail"
 
      always:
+       - block:
 
-       - include: cleanup.yml
-         when: clean | bool
+           - include: cleanup.yml
+             when: clean | bool
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           - name: Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+
 
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/cleanup.yml
@@ -48,25 +48,6 @@
   retries: 6
   changed_when: True
 
-- name: Delete the openebs operator
-  shell: source ~/.profile; kubectl delete -f "{{ openebs_operator_link }}"
-  args:
-    executable: /bin/bash
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
-
-- name: Confirm pod has been deleted
-  shell: source ~/.profile; kubectl get pods --all-namespaces
-  args:
-    executable: /bin/bash
-  register: result
-  until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
-  delay: 100
-  retries: 6
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
-
-
 - name: Remove test artifacts
   file:
     path: "{{ result_kube_home.stdout }}/{{ item }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/pre-requisites.yml
@@ -1,0 +1,19 @@
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+       - name: Start the log aggregator to capture test pod logs
+         shell: >
+           source ~/.profile;
+           nohup stern --all-namespaces "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/scaleup-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/scaleup-vars.yml
@@ -17,6 +17,8 @@ loadgen_yaml_alias: cassandra-loadgen.yaml
 
 io_minutes: 3
 
+namespace: scaleup-pods
+
 profile: ~/.profile
 
 cassandra_artifacts:
@@ -31,3 +33,6 @@ test_artifacts:
   -  cassandra-service.yaml
   -  cassandra-statefulset.yaml
   -  cassandra-loadgen.yaml
+
+utils_path: openebs/e2e/ansible/playbooks/utils
+

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -195,12 +195,12 @@
 
        - name: Test playbook passed
          set_fact:
-           flag: "Pass"
+           flag: "Test Passed"
 
      rescue:
        - name: Test playbook failed
          set_fact:
-           flag: "Fail"
+           flag: "Test Failed"
 
      always:
        - block:
@@ -210,12 +210,12 @@
 
            - name: Test Cleanup Passed
              set_fact:
-               cflag: cleanup_pass
+               cflag: "Cleanup Passed"
 
          rescue:
            - name: Test Cleanup Failed
              set_fact:
-               cflag: cleanup_fail
+               cflag: "Cleanup Failed"
 
          always:
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -26,45 +26,8 @@
   tasks:
    - block:
 
+       - include: pre-requisites.yml
 
-
-       - name: Check whether maya-apiserver pod is running
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 20
-         retries: 2
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         ignore_errors: true
-
-       - block:
-
-           - name: Delete the openebs operator
-             shell: source ~/.profile; kubectl delete -f "{{ openebs_operator_link }}"
-             args:
-               executable: /bin/bash
-             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-           - name: Confirm pod has been deleted
-             shell: source ~/.profile; kubectl get pods
-             args:
-               executable: /bin/bash
-             register: result
-             until: "'maya-apiserver' or 'openebs-provisioner' not in result.stdout"
-             delay: 30
-             retries: 3
-             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-         when: "result.rc == 0"
-
-       - name: Get $HOME of K8s master for kubernetes user
-         shell: source {{ profile }}; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Download YAML for cassandra service
          get_url:
@@ -125,31 +88,11 @@
            replace: 'duration={{ io_minutes }}'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-
-       - name: Deploy openebs-operator
-         shell: source ~/.profile; kubectl apply -f "{{ openebs_operator_link }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
-
-       - name: Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods --all-namespaces | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-       - name: Start the log aggregator to capture test pod logs
-         shell: >
-           source {{ profile }};
-           nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Check status of maya-apiserver
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: openebs
+           app: maya-apiserver
 
        - name: Deploy cassandra service and statefulset
          shell: source {{ profile }}; kubectl apply -f {{ item }}
@@ -249,31 +192,45 @@
            msg: "Data is distributed on all the cassandra application pods"
          when: "result.rc == 0"
 
-       - name: Terminate the log aggregator
-         shell: source {{ profile }}; killall stern
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Set flag to pass if test case is passed
+       - name: Test playbook passed
          set_fact:
            flag: "Pass"
 
      rescue:
-       - name: Set flag to fail if test case is failed
+       - name: Test playbook failed
          set_fact:
            flag: "Fail"
 
      always:
+       - block:
 
-       - include: cleanup.yml
-         when: clean | bool
+           - include: cleanup.yml
+             when: clean | bool
 
-       - name: Send slack notification
-         slack:
-           token: "{{ lookup('env','SLACK_TOKEN') }}"
-           msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-         when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: cleanup_pass
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: cleanup_fail
+
+         always:
+
+           - name: Terminate the log aggregator
+             shell: source ~/.profile; killall stern
+             args:
+               executable: /bin/bash
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 
 
 


### PR DESCRIPTION
Signed-off-by: swarna <swarnalatha@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Enhance ansible playbooks to deploy applications on their own namespace and set flag for cleanup result.(Hyperconverged test-suite)
- Stern logger moved to prereq.yml
- Runs each application on its own namespace
- Performs apply/delete applications using modularization by passing required arguments.
-Cleanup gives out result by setting flag"Cleanup Pass" or "Cleanup Fail" 

 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@ksatchit Updated the changes for percona-diff-NS and drain-node and scaleup-cassandra-pods playbooks. Can you please review it.
