### PR TITLE
Upload yaml files for cstor-pool

### DIFF
--- a/k8s/crd-samples/deployment-cstor-pool.yaml
+++ b/k8s/crd-samples/deployment-cstor-pool.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: cstor-pool
-        image: openebs/cstor-main:ci
+        image: openebs/cstor-pool:ci
         ports:
         - containerPort: 80
         securityContext: 
@@ -30,9 +30,13 @@ spec:
         - name: tmp
           mountPath: /tmp
           mountPropagation: Bidirectional
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
 
       - name:    cstor-pool-mgmt
-        image: openebs/cstor-pool-mgmt:ci
+        image: gkganeshr/cstor-pool-mgmt:v1
         ports:
         - containerPort: 80
         securityContext: 
@@ -43,6 +47,14 @@ spec:
         - name: tmp
           mountPath: /tmp
           mountPropagation: Bidirectional
+        env:
+        - name: cstorid
+          value: "878c7a8d-5cf2-11e8-b0f5-54e1ad4a9dd4"
+
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/sh", "-c", "sleep 15"]
 
       volumes:
       - name: device
@@ -53,5 +65,5 @@ spec:
           type: Directory
       - name: tmp
         hostPath:
-          path: /tmp
+          path: /var/openebs/shared-a2b
           type: Directory

--- a/k8s/crd-samples/deployment-cstor-pool.yaml
+++ b/k8s/crd-samples/deployment-cstor-pool.yaml
@@ -29,7 +29,7 @@ spec:
           mountPath: /dev     
         - name: tmp
           mountPath: /tmp
-          mountPropagation: Bidirectional
+#         mountPropagation: Bidirectional
         lifecycle:
           postStart:
             exec:
@@ -46,10 +46,10 @@ spec:
           mountPath: /dev
         - name: tmp
           mountPath: /tmp
-          mountPropagation: Bidirectional
+#          mountPropagation: Bidirectional
         env:
         - name: cstorid
-          value: "878c7a8d-5cf2-11e8-b0f5-54e1ad4a9dd4"
+          value: "9368bb1c-5cfc-11e8-b6fb-54e1ad4a9dd4"
 
         lifecycle:
           postStart:

--- a/k8s/crd-samples/pool-resource-cluster-1.yaml
+++ b/k8s/crd-samples/pool-resource-cluster-1.yaml
@@ -8,7 +8,7 @@ metadata:
   finalizers: ["openebs"]
 spec:
   disks:
-   diskList: ["/tmp/img1.img"]
+   diskList: ["/dev/sdb1"]
   poolSpec:
    cacheFile: /tmp/pool1.cache
    poolType: striped

--- a/k8s/crd-samples/pool-resource-cluster-1.yaml
+++ b/k8s/crd-samples/pool-resource-cluster-1.yaml
@@ -1,13 +1,17 @@
 apiVersion: openebs.io/v1alpha1
 kind: CStorPool
 metadata:
-  name: pool1
+  name: pool1-abc
   node: node-host-label
+  labels:
+    "kubernetes.io/hostname": "node-host-label"
+  finalizers: ["openebs"]
 spec:
   disks:
-   diskList: ["/dev/sdb1"]
+   diskList: ["/tmp/img1.img"]
   poolSpec:
-   poolName: pool1
    cacheFile: /tmp/pool1.cache
-   poolType: mirror
-
+   poolType: striped
+   overProvisioning: false
+status:
+  phase: init


### PR DESCRIPTION
1. Why is this change necessary ?
fixes: openebs/openebs#1539

2. How does this change address the issue ?
The initial version of cstor-pool deployment and custom resource yaml
is updated.

3. How to verify this change ?
Make sure /var/openebs/shared-<a2b> dir is present in deploy yaml.
kubectl apply -f pool-resource-cluster-1.yaml
Get UID of the corresponding pool
Make sure the same UID is passed as env variable to deployment yaml.
Make sure the disk specified on CR is present
kubectl apply -f deployment-cstor-pool.yaml
To verify,
kubectl logs cstor-pool-deploy-<guid> -c cstor-pool-mgmt
Can also verify by kubectl exec into pod,
Check status of CR if it is online for successful pool creation,
offline for failure.
To delete,
kubectl delete -f pool-resource-cluster-1.yaml
If successful deletion,
CR is deleted, Can also verify from zpool status by kubectl exec into pod
If deletion is failed,
cstorpool Status field shows deletion-failed.

**Special notes for your reviewer**: The image name here will be changed to openebs once the business logic pr is raised, reviewed and merged in openebs/maya.
Status should always be init to create pool.
This is developed and verified on minikube environment.
Start k8s cluster like this,

Reference: https://docs.google.com/document/d/1Q5W3uHktHa-vOm8oGp-3kpAQ3V1tvyk5AYmxxtf57Rg/edit?usp=sharing

Signed-off-by: gkGaneshR <gkganesh126@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->
