### PR TITLE
Using stable helm chart to install OpenEBS

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -24,6 +24,15 @@ weave_version_list:
   - 1.9.4
   - 2.0.4 
 
+#######################################
+#     OpenEBS deployment type         #
+#######################################
+#Option to specify OpenEBS deployment type
+# It can be either kubectl or helm based installation
+
+openebs_deploy: kubectl
+
+
 #########################################
 # OpenEBS Deployment Specifications     #
 #########################################
@@ -80,3 +89,4 @@ logging: true
 #normal builds upon vanilla VMs
 
 build_type: normal
+

--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -30,7 +30,7 @@ weave_version_list:
 #Option to specify OpenEBS deployment type
 # It can be either kubectl or helm based installation
 
-openebs_deploy: kubectl
+openebs_deploy: helm
 
 
 #########################################

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -2,3 +2,4 @@
 #charts: https://openebs.github.io/charts/
 namespace: openebs
 update_deploy_file: update.json
+storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -1,4 +1,4 @@
 ---
-charts: https://openebs.github.io/charts/
+#charts: https://openebs.github.io/charts/
 namespace: openebs
 update_deploy_file: update.json

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -1,5 +1,4 @@
 ---
-#charts: https://openebs.github.io/charts/
 namespace: openebs
 update_deploy_file: update.json
 storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -1,10 +1,20 @@
 ---
-- name: Install helm
+# Steps
+# 1) Downloading helm
+# 2) Initialising helm
+# 3) Check if the tiller is deployed
+# 4) Create service account for tiller
+# 5) Create cluster role binding
+# 6) Update the deployment with the service account
+# 7) Install OpenEBS using stable helm chart
+# 8) Check if the installation is successful
+
+- name: 1) Install helm
   shell: curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x  /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/
   args:
     executable: /bin/bash
 
-- name: Tiller setup
+- name: 2) Tiller setup
   shell: helm init
   args:
     executable: /bin/bash
@@ -13,7 +23,7 @@
   delay: 30
   retries: 15
 
-- name: Check if tiller is configured
+- name: 3) Check if tiller is configured
   shell: helm version
   args:
     executable: /bin/bash
@@ -22,7 +32,7 @@
   delay: 30
   retries: 5
 
-- name: Creating service account
+- name: 4) Creating service account
   shell: kubectl -n kube-system create sa tiller
   args:
     executable: /bin/bash
@@ -31,7 +41,7 @@
   delay: 60
   retries: 5
 
-- name: Create cluster rolebinding
+- name: 5) Create cluster rolebinding
   shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
   args:
     executable: /bin/bash
@@ -40,18 +50,18 @@
   delay: 20
   retries: 5
 
-- name: Getting home directory in kubernetes master
+- name: 6) Getting home directory in kubernetes master
   shell: source ~/.profile; echo $HOME
   args:
     executable: /bin/bash
   register: result_kube_home
 
-- name: Copying the patch yaml file to kubernetes master
+- name: 6a) Copying the patch yaml file to kubernetes master
   copy:
     src: "{{ update_deploy_file }}"
     dest: "{{ result_kube_home.stdout }}"
 
-- name : Update the deployment
+- name : 6b) Update the deployment
   shell: kubectl -n kube-system patch deploy/tiller-deploy -p "$(cat {{ update_deploy_file }})"
   args:
     executable: /bin/bash
@@ -78,7 +88,7 @@
 #  delay: 20
 #  retries: 6
 
-- name: Install openebs
+- name: 7) Install openebs
   shell: helm install stable/openebs --name openebs --namespace openebs
   args:
     executable: /bin/bash
@@ -87,7 +97,7 @@
   delay: 120
   retries: 5
 
-- name: Check if provisioner is deployed
+- name: 8) Check if provisioner is deployed
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner"
   args:
     executable: /bin/bash
@@ -96,7 +106,7 @@
   delay: 60
   retries: 15
 
-- name: Check if maya-apiserver is deployed
+- name: 8a) Check if maya-apiserver is deployed
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-maya-apiserver"
   args:
     executable: /bin/bash
@@ -105,7 +115,7 @@
   delay: 60
   retries: 15
 
-- name: Check if storage classes are created
+- name: 8b) Check if storage classes are created
   shell: kubectl get sc
   args:
     executable: /bin/bash

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -8,6 +8,7 @@
 # 6) Update the deployment with the service account
 # 7) Install OpenEBS using stable helm chart
 # 8) Check if the installation is successful
+# 9) Create the default storage classes
 
 - name: 1) Install helm
   shell: curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x  /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/
@@ -107,7 +108,7 @@
   retries: 15
 
 - name: 8a) Check if maya-apiserver is deployed
-  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-maya-apiserver"
+  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-apiserver"
   args:
     executable: /bin/bash
   register: api_server
@@ -115,13 +116,9 @@
   delay: 60
   retries: 15
 
-- name: 8b) Check if storage classes are created
-  shell: kubectl get sc
+- name: 9) Create the default storage classes
+  shell: kubectl apply -f "{{ storage_classes }}"
   args:
     executable: /bin/bash
-  register: storage_classes
-  until: "'openebs-cassandra' in storage_classes.stdout"
-  delay: 10
-  retries: 3
 
 

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -3,15 +3,6 @@
   shell: curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x  /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/
   args:
     executable: /bin/bash
-  
-#- name: Check if helm is installed
-#  shell: helm version
-#  args:
-#    executable: /bin/bash
-#  register: helm_version
-#  until: "'version.Version' in helm_version.stdout"
-#  delay: 10
-#  retries: 3
 
 - name: Tiller setup
   shell: helm init
@@ -19,16 +10,16 @@
     executable: /bin/bash
   register: tiller_out
   until: "'Happy Helming' in tiller_out.stdout"
-  delay: 10
-  retries: 6
+  delay: 30
+  retries: 15
 
 - name: Check if tiller is configured
   shell: helm version
-  args: 
+  args:
     executable: /bin/bash
   register: tiller_version
   until: "'Server: &version.Version' in tiller_version.stdout"
-  delay: 20
+  delay: 30
   retries: 5
 
 - name: Creating service account
@@ -37,8 +28,8 @@
     executable: /bin/bash
   register: tiller
   until: "'serviceaccount \"tiller\" created' in tiller.stdout"
-  delay: 10
-  retries: 6
+  delay: 60
+  retries: 5
 
 - name: Create cluster rolebinding
   shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
@@ -55,7 +46,7 @@
     executable: /bin/bash
   register: result_kube_home
 
-- name: Copy yaml file to kubernetes master
+- name: Copying the patch yaml file to kubernetes master
   copy:
     src: "{{ update_deploy_file }}"
     dest: "{{ result_kube_home.stdout }}"
@@ -69,41 +60,41 @@
   delay: 20
   retries: 6
 
-- name: Adding OpenEBS charts to repo
-  shell: helm repo add openebs-charts "{{ charts }}"
-  args:
-    executable: /bin/bash
-  register: repos
-  until: "'\"openebs-charts\" has been added to your repositories' in repos.stdout"
-  delay: 20
-  retries: 6
+#- name: Adding OpenEBS charts to repo
+#  shell: helm repo add openebs-charts "{{ charts }}"
+#  args:
+#    executable: /bin/bash
+#  register: repos
+#  until: "'\"openebs-charts\" has been added to your repositories' in repos.stdout"
+#  delay: 20
+#  retries: 6
 
-- name: Update the repo
-  shell: helm repo update
-  args:
-    executable: /bin/bash
-  register: update
-  until: "'Update Complete' in update.stdout"
-  delay: 20
-  retries: 6
- 
+#- name: Update the repo
+#  shell: helm repo update
+#  args:
+#    executable: /bin/bash
+#  register: update
+#  until: "'Update Complete' in update.stdout"
+#  delay: 20
+#  retries: 6
+
 - name: Install openebs
-  shell: helm install openebs-charts/openebs
+  shell: helm install stable/openebs --name openebs --namespace openebs
   args:
     executable: /bin/bash
   register: openebs_out
   until: "'The OpenEBS has been installed' in openebs_out.stdout"
-  delay: 20
-  retries: 6  
+  delay: 120
+  retries: 5
 
 - name: Check if provisioner is deployed
-  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner" 
+  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner"
   args:
     executable: /bin/bash
   register: deployment
   until: "'Running' in deployment.stdout"
-  delay: 20
-  retries: 6
+  delay: 60
+  retries: 15
 
 - name: Check if maya-apiserver is deployed
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-maya-apiserver"
@@ -111,8 +102,8 @@
     executable: /bin/bash
   register: api_server
   until: "'Running' in api_server.stdout"
-  delay: 20
-  retries: 6
+  delay: 60
+  retries: 15
 
 - name: Check if storage classes are created
   shell: kubectl get sc

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -30,8 +30,8 @@
     executable: /bin/bash
   register: tiller_version
   until: "'Server: &version.Version' in tiller_version.stdout"
-  delay: 30
-  retries: 5
+  delay: 120
+  retries: 10
 
 - name: 4) Creating service account
   shell: kubectl -n kube-system create sa tiller

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -71,24 +71,6 @@
   delay: 20
   retries: 6
 
-#- name: Adding OpenEBS charts to repo
-#  shell: helm repo add openebs-charts "{{ charts }}"
-#  args:
-#    executable: /bin/bash
-#  register: repos
-#  until: "'\"openebs-charts\" has been added to your repositories' in repos.stdout"
-#  delay: 20
-#  retries: 6
-
-#- name: Update the repo
-#  shell: helm repo update
-#  args:
-#    executable: /bin/bash
-#  register: update
-#  until: "'Update Complete' in update.stdout"
-#  delay: 20
-#  retries: 6
-
 - name: 7) Install openebs
   shell: helm install stable/openebs --name openebs --namespace openebs
   args:

--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
+openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-operator-ns-openebs.yaml
 
 openebs_operator_alias: openebs-operator.yaml 
 
@@ -9,4 +9,6 @@ openebs_storageclasses_alias: openebs-storageclasses.yaml
 
 # Image tag for openebs containers
 # Accepted entries (ci, latest): Default: latest
-test_tag: latest
+test_tag: ci
+
+namespace: openebs

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -60,7 +60,7 @@
   register: labels
 
 - name: Confirm provisioner & apiserver are running
-  shell: source ~/.profile; kubectl get pods --selector=name={{item}} | grep Running |wc -l 
+  shell: source ~/.profile; kubectl get pods --selector=name={{item}} -n {{ namespace }} | grep Running |wc -l 
   args:
     executable: /bin/bash
   register: result_pod
@@ -70,7 +70,7 @@
   with_items: "{{ labels.stdout_lines }}"
 
 - name: Get maya-apiserver pod name
-  shell: source ~/.profile; kubectl get pods --selector=name=maya-apiserver 
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} --selector=name=maya-apiserver
   args:
     executable: /bin/bash
   register: result_name
@@ -80,11 +80,11 @@
     pod_name: "{{ result_name.stdout_lines[1].split()[0] }}"
 
 - name: Confirm that maya-cli is available in the maya-apiserver pod
-  shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -- mayactl version
+  shell: source ~/.profile; kubectl exec {{pod_name}} -c maya-apiserver -n {{ namespace }} -- mayactl version
   args:
     executable: /bin/bash
   register: result_vers
-  failed_when: "'Maya' not in result_vers.stdout"
+  failed_when: "'m-apiserver status:  running' not in result_vers.stdout"
 
 - name: Download YAML for openebs storage classes
   get_url:

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -11,5 +11,9 @@
 
 - hosts: kubernetes-kubemasters 
   roles: 
-    - {role: k8s-openebs-operator-helm, when: deployment_mode == "hyperconverged"}
+    - {role: k8s-openebs-operator-helm, when: deployment_mode == "hyperconverged" and openebs_deploy == "helm"}
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - {role: k8s-openebs-operator, when: deployment_mode == "hyperconverged" and openebs_deploy == "kubectl"}
 

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -11,5 +11,5 @@
 
 - hosts: kubernetes-kubemasters 
   roles: 
-    - {role: k8s-openebs-operator, when: deployment_mode == "hyperconverged"}
+    - {role: k8s-openebs-operator-helm, when: deployment_mode == "hyperconverged"}
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
Installs OpenEBS using stable helm chart.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1546 

**Special notes for your reviewer**:

- Modified the ansible role to use stable chart for deploying OpenEBS.
- Modified the role in setup-openebs.yaml to use the k8s-openebs-operator-helm role.
- Validated the role against ansible lint.
