### PR TITLE
Implemented cleanup portion in test-pvc-deletion test case and deploying pvc in different namespace

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/cleanup.yml
@@ -9,6 +9,12 @@
   delay: 60
   retries: 5
 
+- name: Delete the storage class
+  shell: source ~/.profile; kubectl delete sc {{ storage_class }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
 - name: Remove the test artifacts
   file:
     path: "{{ result_kube_home.stdout }}/{{ item }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/cleanup.yml
@@ -1,0 +1,19 @@
+---
+- name: Delete the namespace
+  shell: source ~/.profile; kubectl delete ns {{ namespace }}
+  args:
+    executable: /bin/bash
+  register: result
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: "'deleted' in result.stdout"
+  delay: 60
+  retries: 5
+
+- name: Remove the test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
+    - "{{ sc_def }}"
+    - "{{ pvc_def }}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
@@ -5,7 +5,9 @@ sc_def: storage-class.yaml
 
 pvc_def: create_pvc.yaml
 
-namespace: pvc-deletion 
+namespace: pvc-deletion
+
+storage_class: openebs-test 
 
 utils_path: openebs/e2e/ansible/playbooks/utils
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s-delete-pvc-vars.yml
@@ -2,5 +2,13 @@
 test_name: Delete_PVC_K8s
 
 sc_def: storage-class.yaml
+
 pvc_def: create_pvc.yaml
- 
+
+namespace: pvc-deletion 
+
+utils_path: openebs/e2e/ansible/playbooks/utils
+
+test_pod_regex: maya*|openebs*|pvc*|
+
+test_log_path: setup/logs/delete_pvc.log

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -213,11 +213,9 @@
        
           always:
         
-            - name: 5) Terminate the log aggregator
-              shell: source ~/.profile; killall stern
-              args:
-                executable: /bin/bash
-              delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+            - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+              vars:
+                status: start
 
             - name: Send slack notification
               slack:
@@ -225,4 +223,3 @@
                 msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
               when: slack_notify | bool and lookup('env','SLACK_TOKEN'
                                                                                                                                                       212,6         98%
-

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -70,10 +70,10 @@
 
 #create the storage class 'openebs-test'
         - name: 6) Create the storage class in K8s master
-          shell: source ~/.profile; kubectl apply -f "{{ sc_def }}"
-          args:
-            executable: /bin/bash
-          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+          vars:
+           app_yml: "{{ sc_def }}"
+           ns: default
 
 #Copying the create_pvc.yaml to k8s master
         - name: 6a) Copy pvc yaml to K8s master
@@ -83,10 +83,10 @@
           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
       
         - name: 6b) Create PVC in k8s cluster
-          shell: kubectl apply -f "{{ pvc_def }}" -n "{{ namespace }}"
-          args:
-            executable: /bin/bash
-          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+          vars:
+           app_yml: "{{ pvc_def }}"
+           ns: "{{ namespace }}"
 
         - name: Wait for few seconds
           wait_for: timeout=30
@@ -147,10 +147,10 @@
           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
  
         - name: 9) Delete PVC
-          shell: source ~/.profile; kubectl delete -f "{{ pvc_def }}" -n {{ namespace }}
-          args:
-            executable: /bin/bash
-          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+          vars:
+           app_yml: "{{ pvc_def }}"
+           ns: "{{ namespace }}"
        
         - name: 10) check if the pods are deleted
           shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep "{{pv_name.stdout}}" | grep {{item}}  | wc -l

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -3,15 +3,18 @@
 
 ###############################################################################################
 #Test Steps:
-#1. Obtain the number of nodes in cluster and ser the replica count accordingly.
-#2. Copy the test artifacts to k8s master
-#3. Check if the OpenEBS components are deployed
-#4. Create storage class and a volume.
-#5. Check if the volume pods are running.
-#6. Check if there is a volume in pending state.
-#7. Delete the volume.
-#8. Check if the volume, pods and service are deleted successfully.
-#9. Perform cleanup of test artifacts.
+
+#1. Run pre-requisites which fetches k8s home and start the log aggregator.
+#2. Obtain the number of nodes in cluster and ser the replica count accordingly.
+#3. Copy the test artifacts to k8s master
+#4. Check if the OpenEBS components are deployed
+#5. Create a namespace
+#6. Create storage class and a volume.
+#7. Check if the volume pods are running.
+#8. Check if there is a volume in pending state.
+#9. Delete the volume.
+#10. Check if the volume, pods and service are deleted successfully.
+#11. Perform cleanup of test artifacts.
 ###############################################################################################
 
 
@@ -21,176 +24,205 @@
     - k8s-delete-pvc-vars.yml
 
   tasks:
+  
+    - block:
+
+        - name: 1) Run pre-requisites
+          include: pre-requisites.yml 
      
-       - name: 1) Get the number of nodes in the cluster
-         shell: kubectl get nodes | grep '<none>' | wc -l
-         args:
-           executable: /bin/bash
-         register: node_out
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+        - name: 2) Get the number of nodes in the cluster
+          shell: kubectl get nodes | grep '<none>' | wc -l
+          args:
+            executable: /bin/bash
+          register: node_out
+          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 1a) Fetch the node count from stdout
-         set_fact:
-            node_count: " {{ node_out.stdout}}"
-
-# Attempting to create more replicas than the number of nodes
-       - name: 1c) Replace the replica count in storage class file
-         replace:
-           path: storage-class.yaml 
-           regexp: 'openebs.io/jiva-replica-count: "1"'
-           replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int+1}}"'
-           backup: yes
-
-       - name: 2) Get $HOME of K8s master for kubernetes user
-         shell: source ~/.profile; echo $HOME
-         args:
-           executable: /bin/bash
-         register: result_kube_home
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+        - name: 2a) Fetch the node count from stdout
+          set_fact:
+             node_count: " {{ node_out.stdout}}"
 
 #Copying openebs-test storage class yaml file to k8s master
-       - name: 2a) Copy the storage classes yaml to k8s master
-         copy:
-           src: "{{ sc_def }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 3) Copy the storage classes yaml to k8s master
+          copy:
+            src: "{{ sc_def }}"
+            dest: "{{ result_kube_home.stdout }}"
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 3) Check whether maya-apiserver pod is deployed
-         shell: source ~/.profile; kubectl get pods | grep maya-apiserver
-         args:
-           executable: /bin/bash
-         register: result
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         until: "'Running' in result.stdout"
-         delay: 120
-         retries: 5
+# Attempting to create more replicas than the number of nodes
+        - name: 3a) Replace the replica count in storage class file
+          replace:
+            path: storage-class.yaml
+            regexp: 'openebs.io/jiva-replica-count: "3"'
+            replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int+1}}"'
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+        - name: 4) Check whether maya-apiserver pod is deployed
+          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+          vars:
+             ns: openebs
+             app: openebs-api
+
+        - name: 5) Create test specific namespace
+          shell: source ~/.profile; kubectl create ns {{ namespace }}
+          args:
+            executable: /bin/bash
+          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 #create the storage class 'openebs-test'
-       - name: 4) Create the storage class in K8s master
-         shell: kubectl apply -f "{{ sc_def }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 6) Create the storage class in K8s master
+          shell: source ~/.profile; kubectl apply -f "{{ sc_def }}"
+          args:
+            executable: /bin/bash
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 #Copying the create_pvc.yaml to k8s master
-       - name: 4a) Copy pvc yaml to K8s master
-         copy:
-           src: "{{ pvc_def }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 6a) Copy pvc yaml to K8s master
+          copy:
+            src: "{{ pvc_def }}"
+            dest: "{{ result_kube_home.stdout }}"
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
       
-       - name: 4b) Create PVC in k8s cluster
-         shell: kubectl apply -f "{{ pvc_def }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-   
+        - name: 6b) Create PVC in k8s cluster
+          shell: kubectl apply -f "{{ pvc_def }}" -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+        - name: Wait for few seconds
+          wait_for: timeout=30
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
 #Find the PV name by referring the storage class 'openebs-test'
-       - name: 5) Finding PV name 
-         shell: source ~/.profile; kubectl get pv | grep "openebs-test" | awk {'print $1'}
-         args:
-           executable: /bin/bash
-         register: pv_name
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 7) Finding PV name 
+          shell: source ~/.profile; kubectl get pv | grep "openebs-test" | awk {'print $1'}
+          args:
+            executable: /bin/bash
+          register: pv_name
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 #Checking pods using the PV name
-       - name: 5a) Confirm whether the volume pods are created
-         shell: source ~/.profile; kubectl get pods | grep "{{ pv_name.stdout }}" | grep {{item}}  | wc -l
-         args:
-           executable: /bin/bash
-         register: result
-         until: result.stdout|int >= 1
-         delay: 30
-         retries: 10
-         with_items:
-           - ctrl
-           - rep
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 7a) Confirm whether the volume pods are created
+          shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep {{item}}  | wc -l
+          args:
+            executable: /bin/bash
+          register: result
+          until: result.stdout|int >= 1
+          delay: 30
+          retries: 10
+          with_items:
+            - ctrl
+            - rep
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 #Check if there is one replica in pending state
  
-       - name: 6) Check if one replica is unscheduled
-         shell: kubectl get pods | grep "{{ pv_name.stdout }}" | grep -i "pending" |wc -l
-         args:
-           executable: /bin/bash
-         register: unscheduled_pod
-         until: unscheduled_pod.stdout|int ==1
-         delay: 10
-         retries: 5
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 8) Check if one replica is unscheduled
+          shell: source ~/.profile; kubectl get pods -n {{ namespace }}| grep "{{ pv_name.stdout }}" | grep -i "pending" |wc -l
+          args:
+            executable: /bin/bash
+          register: unscheduled_pod
+          until: unscheduled_pod.stdout|int ==1
+          delay: 60
+          retries: 5
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 #Checking if there is svc created by grepping pv name
       
-       - name: 6b) Check if the svc is created
-         shell: kubectl get svc | grep "{{ pv_name.stdout }}" |wc -l
-         args:
-           executable: /bin/bash
-         register: svc
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}" 
-         until: svc.stdout|int ==1
-         delay: 10
-         retries: 3
+        - name: 8a) Check if the svc is created
+          shell: source ~/.profile; kubectl get svc -n {{ namespace }} | grep "{{ pv_name.stdout }}" |wc -l
+          args:
+            executable: /bin/bash
+          register: svc
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}" 
+          until: svc.stdout|int ==1
+          delay: 10
+          retries: 3
          
 #Getting service name by greping the pv name
-       - name: 6c) Getting service name
-         shell: kubectl get svc | grep "{{ pv_name.stdout }}" | awk {'print $1'}
-         args:
-           executable: /bin/bash
-         register: svc_name
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 8b) Getting service name
+          shell: source ~/.profile; kubectl get svc -n {{ namespace }}| grep "{{ pv_name.stdout }}" | awk {'print $1'}
+          args:
+            executable: /bin/bash
+          register: svc_name
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
  
-       - name: 7) Delete PVC
-         shell: kubectl delete -f "{{ pvc_def }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 9) Delete PVC
+          shell: source ~/.profile; kubectl delete -f "{{ pvc_def }}" -n {{ namespace }}
+          args:
+            executable: /bin/bash
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
        
-       - block:
-             - name: 8) check if the pods are deleted
-               shell: kubectl get pods | grep "{{pv_name.stdout}}" | grep {{item}}  | wc -l
-               args:
-                 executable: /bin/bash
-               register: pods
-               until: pods.stdout|int == 0
-               delay: 30
-               retries: 10
-               with_items:
-                 - ctrl
-                 - rep
-               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 10) check if the pods are deleted
+          shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep "{{pv_name.stdout}}" | grep {{item}}  | wc -l
+          args:
+            executable: /bin/bash
+          register: pods
+          until: pods.stdout|int == 0
+          delay: 120
+          retries: 10
+          with_items:
+            - ctrl
+            - rep
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
   
-             - name: 8a) Check if the pv is deleted
-               shell: kubectl get pv 
-               args:
-                 executable: /bin/bash
-               register: pv_out
-               until: "'{{ pv_name.stdout }}' not in pv_out.stdout"
-               delay: 10
-               retries: 3
-               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+        - name: 10a) Check if the pv is deleted
+          shell: source ~/.profile; kubectl get pv 
+          args:
+            executable: /bin/bash
+          register: pv_out
+          until: "'{{ pv_name.stdout }}' not in pv_out.stdout"
+          delay: 120
+          retries: 5
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
                
-             - name: 8b) Check if the svc is deleted
-               shell: kubectl get svc | grep "{{ svc_name.stdout }}" | wc -l
-               args:
-               executable: /bin/bash
-               register: delete_svc
-               delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-               until: delete_svc.stdout|int == 0
-               delay: 20
-               retries: 5
+        - name: 10b) Check if the svc is deleted
+          shell: source ~/.profile; kubectl get svc -n {{ namespace }} | grep "{{ svc_name.stdout }}" | wc -l
+          args:
+            executable: /bin/bash
+          register: delete_svc
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          until: delete_svc.stdout|int == 0
+          delay: 20
+          retries: 5
             
-             - set_fact:
-                   flag: "PASS"
-         rescue:
-             - set_fact:
-                   flag: "FAIL"
+        - name: Setting pass flag
+          set_fact:
+            flag: "TEST PASSED"
+         
+      rescue:
+        - name: Setting failed flag
+          set_fact:
+            flag: "TEST FAILED"
 
-         always:
-           - name: Send slack notification
-             slack:
-               token: "{{ lookup('env','SLACK_TOKEN') }}"
-               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
-             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
- 
+      always:
        
+        - block:
+ 
+            - name: 11) Cleaning up the test artifacts
+              include: cleanup.yml
+ 
+            - name: Setting cleanup flag to passed
+              set_fact: 
+                cflag: "CLEANUP PASSED"
+       
+          rescue:
+        
+            - name: Setting cleanup to failed
+              set_fact:
+                cflag: "CLEANUP FAILED"
+       
+          always:
+        
+            - name: 5) Terminate the log aggregator
+              shell: source ~/.profile; killall stern
+              args:
+                executable: /bin/bash
+              delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+            - name: Send slack notification
+              slack:
+                token: "{{ lookup('env','SLACK_TOKEN') }}"
+                msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+              when: slack_notify | bool and lookup('env','SLACK_TOKEN'
+                                                                                                                                                      212,6         98%
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -27,7 +27,7 @@
   
     - block:
 
-        - name: 1) Run pre-requisites
+        - name: 1) Run the pre-requisites
           include: pre-requisites.yml 
      
         - name: 2) Get the number of nodes in the cluster
@@ -51,7 +51,7 @@
 # Attempting to create more replicas than the number of nodes
         - name: 3a) Replace the replica count in storage class file
           replace:
-            path: storage-class.yaml
+            path: "{{ result_kube_home.stdout }}/{{ sc_def }}"
             regexp: 'openebs.io/jiva-replica-count: "3"'
             replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int+1}}"'
           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
@@ -60,7 +60,7 @@
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
           vars:
              ns: openebs
-             app: openebs-api
+             app: apiserver
 
         - name: 5) Create test specific namespace
           shell: source ~/.profile; kubectl create ns {{ namespace }}
@@ -72,7 +72,7 @@
         - name: 6) Create the storage class in K8s master
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
           vars:
-           app_yml: "{{ sc_def }}"
+           app_yml: "{{ result_kube_home.stdout }}/{{ sc_def }}"
            ns: default
 
 #Copying the create_pvc.yaml to k8s master
@@ -85,7 +85,7 @@
         - name: 6b) Create PVC in k8s cluster
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
           vars:
-           app_yml: "{{ pvc_def }}"
+           app_yml: "{{result_kube_home.stdout }}/{{ pvc_def }}"
            ns: "{{ namespace }}"
 
         - name: Wait for few seconds
@@ -102,13 +102,13 @@
 
 #Checking pods using the PV name
         - name: 7a) Confirm whether the volume pods are created
-          shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep {{item}}  | wc -l
+          shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep {{item}} | grep "Running" | wc -l
           args:
             executable: /bin/bash
           register: result
           until: result.stdout|int >= 1
-          delay: 30
-          retries: 10
+          delay: 60
+          retries: 15
           with_items:
             - ctrl
             - rep
@@ -221,5 +221,4 @@
               slack:
                 token: "{{ lookup('env','SLACK_TOKEN') }}"
                 msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
-              when: slack_notify | bool and lookup('env','SLACK_TOKEN'
-                                                                                                                                                      212,6         98%
+              when: slack_notify | bool and lookup('env','SLACK_TOKEN')

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -215,7 +215,7 @@
         
             - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
               vars:
-                status: start
+                status: stop
 
             - name: Send slack notification
               slack:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/pre-requisites.yml
@@ -7,13 +7,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 
-- name: Start the log aggregator to capture test pod logs
-  shell: >
-    source ~/.profile;
-    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
-  args:
-    executable: /bin/bash
-  become: true
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: true
-
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+  vars:
+    status: start

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/pre-requisites.yml
@@ -1,0 +1,19 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Start the log aggregator to capture test pod logs
+  shell: >
+    source ~/.profile;
+    nohup stern "{{test_pod_regex}}" --since 1m > "{{result_kube_home.stdout}}/{{test_log_path}}" &
+  args:
+    executable: /bin/bash
+  become: true
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "4"
+  openebs.io/jiva-replica-count: "3"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/storage-class.yaml
@@ -5,7 +5,7 @@ metadata:
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
-  openebs.io/jiva-replica-count: "3"
+  openebs.io/jiva-replica-count: "4"
   openebs.io/volume-monitor: "true"
   openebs.io/capacity: 5G
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

  - Obtain the number of nodes and deploy one replica more than the node count.
  - Create PVC in non default namespace.
  - Check if there is a replica in pending state.
  - Deleting pvc deployment.
  - Check if the pv and svc are deleted successfully.
  - Clean the remaining resources and test artifacts.

**Special notes for your reviewer**:

  - Creating a namespace pvc-deletion.
  - Deploying app in that namespace.
  - After successful verification, deleting the pvc.
  - Check if the relevant resources are deleted.
  - Cleaning up the resources.