### PR TITLE
Modified ansible helm role to check if the resources are already exis…

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -1,4 +1,8 @@
 ---
 namespace: openebs
+
 update_deploy_file: update.json
+
 storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+
+chart_name: openebs-test

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -10,12 +10,12 @@
 # 8) Check if the installation is successful
 # 9) Create the default storage classes
 
-- name: 1) Install helm
+- name: 1) Install helm.
   shell: curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x  /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/
   args:
     executable: /bin/bash
 
-- name: 2) Tiller setup
+- name: 2) Tiller setup.
   shell: helm init
   args:
     executable: /bin/bash
@@ -24,7 +24,7 @@
   delay: 30
   retries: 15
 
-- name: 3) Check if tiller is configured
+- name: 3) Checking if the tiller pod is created.
   shell: helm version
   args:
     executable: /bin/bash
@@ -33,45 +33,71 @@
   delay: 120
   retries: 10
 
-- name: 4) Creating service account
-  shell: kubectl -n kube-system create sa tiller
-  args:
-    executable: /bin/bash
-  register: tiller
-  until: "'serviceaccount \"tiller\" created' in tiller.stdout"
-  delay: 60
-  retries: 5
+- block:
 
-- name: 5) Create cluster rolebinding
-  shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-  args:
-    executable: /bin/bash
-  register: crb
-  until: "'clusterrolebinding \"tiller\" created' in crb.stdout"
-  delay: 20
-  retries: 5
+    - name: 4) Checking if the tiller service account already exists.
+      shell: kubectl get sa -n kube-system | grep tiller
+      args:
+        executable: /bin/bash
+      register: sa
+      until: "'tiller' in sa.stdout"
+      delay: 20
+      retries: 2
+  
+  rescue:
+     
+    - name: 4a) Creating the service account
+      shell: kubectl -n kube-system create sa tiller
+      args:
+        executable: /bin/bash
+      register: tiller
+      until: "'\"tiller\" created' in tiller.stdout"
+      delay: 60
+      retries: 5
+  
+- block:
 
-- name: 6) Getting home directory in kubernetes master
+     - name: 5) Checking if the tiller cluster role binding already exists.
+       shell: kubectl get clusterrolebinding | grep tiller
+       args:
+         executable: /bin/bash
+       register: cr
+       until: "'tiller' in cr.stdout"
+       delay: 10
+       retries: 2
+
+  rescue:
+
+     - name: 5a) Creating the cluster rolebinding.
+       shell: kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+       args:
+         executable: /bin/bash
+       register: crb
+       until: "'\"tiller\" created' in crb.stdout"
+       delay: 60
+       retries: 5
+
+- name: 6) Getting the home directory of kubernetes master.
   shell: source ~/.profile; echo $HOME
   args:
     executable: /bin/bash
   register: result_kube_home
 
-- name: 6a) Copying the patch yaml file to kubernetes master
+- name: 6a) Copying the patch yaml file to kubernetes master.
   copy:
     src: "{{ update_deploy_file }}"
     dest: "{{ result_kube_home.stdout }}"
 
-- name : 6b) Update the deployment
-  shell: kubectl -n kube-system patch deploy/tiller-deploy -p "$(cat {{ update_deploy_file }})"
+- name : 6b) Updating the tiller-deploy deployment with the service account.
+  shell: kubectl -n kube-system patch deploy/tiller-deploy -p "$(cat {{result_kube_home.stdout}}/{{ update_deploy_file }})"
   args:
     executable: /bin/bash
   register: tiller_deploy
-  until: "'deployment \"tiller-deploy\" patched' in tiller_deploy.stdout"
-  delay: 20
+  until: "'\"tiller-deploy\" patched' in tiller_deploy.stdout"
+  delay: 60
   retries: 6
 
-- name: 7) Install openebs
+- name: 7) Installing openebs using stable charts.
   shell: helm install stable/openebs --name openebs --namespace openebs
   args:
     executable: /bin/bash
@@ -80,7 +106,7 @@
   delay: 120
   retries: 5
 
-- name: 8) Check if provisioner is deployed
+- name: 8) Checking if the provisioner is up.
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner"
   args:
     executable: /bin/bash
@@ -89,7 +115,7 @@
   delay: 60
   retries: 15
 
-- name: 8a) Check if maya-apiserver is deployed
+- name: 8a) Checking if the openebs-apiserver is up.
   shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-apiserver"
   args:
     executable: /bin/bash
@@ -98,7 +124,7 @@
   delay: 60
   retries: 15
 
-- name: 9) Create the default storage classes
+- name: 9) Creating the default storage classes
   shell: kubectl apply -f "{{ storage_classes }}"
   args:
     executable: /bin/bash

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -98,7 +98,7 @@
   retries: 6
 
 - name: 7) Installing openebs using stable charts.
-  shell: helm install stable/openebs --name openebs --namespace openebs
+  shell: helm install stable/openebs --name "{{ chart_name }}" --namespace "{{ namespace }}"
   args:
     executable: /bin/bash
   register: openebs_out
@@ -107,7 +107,7 @@
   retries: 5
 
 - name: 8) Checking if the provisioner is up.
-  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-provisioner"
+  shell: kubectl get pods -n "{{ namespace }}" | grep "provisioner"
   args:
     executable: /bin/bash
   register: deployment
@@ -116,7 +116,7 @@
   retries: 15
 
 - name: 8a) Checking if the openebs-apiserver is up.
-  shell: kubectl get pods -n "{{ namespace }}" | grep "openebs-apiserver"
+  shell: kubectl get pods -n "{{ namespace }}" | grep "apiserver"
   args:
     executable: /bin/bash
   register: api_server


### PR DESCRIPTION
…ting before creating

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- Fails to install openebs if tiller service account and clusterrolebinding already exists.
- Fails in cloud ci, as the strings used in conditions are different.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1566 

**Special notes for your reviewer**:

- Implemented Check to find if the service account and clusterrolebinding already exists in the cluster before creating it.
- Modified the condition strings in order to get executed successfully in the cloud ci. Modified the stings to be more generic now.
- Appending the k8s master's home directory in the deployment patch task as it is seen to fail in cloud ci.
- Implemented a variable for chart name.