### PR TITLE
Removed dedicated deployment tasks in setup-openebs playbook and changed the chart name

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -5,4 +5,4 @@ update_deploy_file: update.json
 
 storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
 
-chart_name: openebs-test
+chart_name: storage-mule

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/defaults/main.yaml
@@ -5,4 +5,3 @@ update_deploy_file: update.json
 
 storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
 
-chart_name: storage-mule

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -97,6 +97,8 @@
   delay: 60
   retries: 6
 
+# Installing openebs using stable chart in openebs namespace. The chart will be created with some random name.
+# We can verify it using "helm ls --all" command.
 - name: 7) Installing openebs using stable charts.
   shell: helm install stable/openebs --namespace "{{ namespace }}"
   args:

--- a/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml
@@ -98,7 +98,7 @@
   retries: 6
 
 - name: 7) Installing openebs using stable charts.
-  shell: helm install stable/openebs --name "{{ chart_name }}" --namespace "{{ namespace }}"
+  shell: helm install stable/openebs --namespace "{{ namespace }}"
   args:
     executable: /bin/bash
   register: openebs_out

--- a/e2e/ansible/setup-openebs.yml
+++ b/e2e/ansible/setup-openebs.yml
@@ -1,14 +1,4 @@
 ---
-- hosts: openebs-mayamasters
-  roles:
-    - {role: master, when: deployment_mode == "dedicated"}
-    - {role: vagrant, when: is_vagrant_vm | bool and deployment_mode == "dedicated"}
-
-- hosts: openebs-mayahosts
-  roles:
-    - {role: hosts, when: deployment_mode == "dedicated"}
-    - {role: vagrant, when: is_vagrant_vm | bool and deployment_mode == "dedicated"}
-
 - hosts: kubernetes-kubemasters 
   roles: 
     - {role: k8s-openebs-operator-helm, when: deployment_mode == "hyperconverged" and openebs_deploy == "helm"}


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**Special notes for your reviewer**:

- Removed the tasks pertaining to dedicated deployment model.
- Changed the chart name.

```
ubuntu@kubemaster-01:~$ helm ls --all
NAME            REVISION        UPDATED                         STATUS          CHART           NAMESPACE
storage-mule    1               Tue Jun 12 16:00:06 2018        DEPLOYED        openebs-0.5.5   openebs
```

```
ubuntu@kubemaster-01:~$ kubectl get deploy -n openebs
NAME                               DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
storage-mule-openebs-apiserver     1         1         1            1           6m
storage-mule-openebs-provisioner   1         1         1            1           6m
```

```
ubuntu@kubemaster-01:~$ kubectl get po -n openebs
NAME                                                READY     STATUS    RESTARTS   AGE
storage-mule-openebs-apiserver-555c87859d-jq9w9     1/1       Running   1          6m
storage-mule-openebs-provisioner-6f58fb8bd6-9f4nd   1/1       Running   0          6m
```

Sample test run output:

```
giri@vagrant-host:~/openebs/e2e/ansible$ ansible-playbook setup-openebs.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/openebs/e2e/ansible/ansible.cfg as config file

PLAYBOOK: setup-openebs.yml ********************************************************************************************************************************************
2 plays in setup-openebs.yml

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-operator-helm : 1) Install helm.] ********************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:13
 [WARNING]: Consider using get_url or uri module rather than running curl

changed: [kubemaster01] => {"changed": true, "cmd": "curl -Lo /tmp/helm-linux-amd64.tar.gz https://kubernetes-helm.storage.googleapis.com/helm-v2.6.2-linux-amd64.tar.gz; tar -xvf /tmp/helm-linux-amd64.tar.gz -C /tmp/; chmod +x /tmp/linux-amd64/helm && sudo mv /tmp/linux-amd64/helm /usr/local/bin/", "delta": "0:00:03.839152", "end": "2018-06-12 15:54:28.696795", "rc": 0, "start": "2018-06-12 15:54:24.857643", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r 62 15.5M   62 9903k    0     0  5764k      0  0:00:02  0:00:01  0:00:01 5767k\r100 15.5M  100 15.5M    0     0  8172k      0  0:00:01  0:00:01 --:--:-- 8177k", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", " 62 15.5M   62 9903k    0     0  5764k      0  0:00:02  0:00:01  0:00:01 5767k", "100 15.5M  100 15.5M    0     0  8172k      0  0:00:01  0:00:01 --:--:-- 8177k"], "stdout": "linux-amd64/\nlinux-amd64/helm\nlinux-amd64/LICENSE\nlinux-amd64/README.md", "stdout_lines": ["linux-amd64/", "linux-amd64/helm", "linux-amd64/LICENSE", "linux-amd64/README.md"]}

TASK [k8s-openebs-operator-helm : 2) Tiller setup.] ********************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:18
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "helm init", "delta": "0:00:01.068713", "end": "2018-06-12 15:54:30.910678", "rc": 0, "start": "2018-06-12 15:54:29.841965", "stderr": "", "stderr_lines": [], "stdout": "$HELM_HOME has been configured at /home/ubuntu/.helm.\n\nTiller (the Helm server-side component) has been installed into your Kubernetes Cluster.\nHappy Helming!", "stdout_lines": ["$HELM_HOME has been configured at /home/ubuntu/.helm.", "", "Tiller (the Helm server-side component) has been installed into your Kubernetes Cluster.", "Happy Helming!"]}

TASK [k8s-openebs-operator-helm : 3) Checking if the tiller pod is created.] *******************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:27
FAILED - RETRYING: 3) Checking if the tiller pod is created. (10 retries left).
changed: [kubemaster01] => {"attempts": 2, "changed": true, "cmd": "helm version", "delta": "0:00:01.335862", "end": "2018-06-12 15:56:41.774310", "rc": 0, "start": "2018-06-12 15:56:40.438448", "stderr": "", "stderr_lines": [], "stdout": "Client: &version.Version{SemVer:\"v2.6.2\", GitCommit:\"be3ae4ea91b2960be98c07e8f73754e67e87963c\", GitTreeState:\"clean\"}\nServer: &version.Version{SemVer:\"v2.6.2\", GitCommit:\"be3ae4ea91b2960be98c07e8f73754e67e87963c\", GitTreeState:\"clean\"}", "stdout_lines": ["Client: &version.Version{SemVer:\"v2.6.2\", GitCommit:\"be3ae4ea91b2960be98c07e8f73754e67e87963c\", GitTreeState:\"clean\"}", "Server: &version.Version{SemVer:\"v2.6.2\", GitCommit:\"be3ae4ea91b2960be98c07e8f73754e67e87963c\", GitTreeState:\"clean\"}"]}

TASK [k8s-openebs-operator-helm : 4) Checking if the tiller service account already exists.] ***************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:38
FAILED - RETRYING: 4) Checking if the tiller service account already exists. (2 retries left).
FAILED - RETRYING: 4) Checking if the tiller service account already exists. (1 retries left).
fatal: [kubemaster01]: FAILED! => {"attempts": 2, "changed": true, "cmd": "kubectl get sa -n kube-system | grep tiller", "delta": "0:00:00.908857", "end": "2018-06-12 15:57:26.491522", "msg": "non-zero return code", "rc": 1, "start": "2018-06-12 15:57:25.582665", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [k8s-openebs-operator-helm : 4a) Creating the service account] ****************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:49
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl -n kube-system create sa tiller", "delta": "0:00:00.435398", "end": "2018-06-12 15:57:28.278127", "rc": 0, "start": "2018-06-12 15:57:27.842729", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount \"tiller\" created", "stdout_lines": ["serviceaccount \"tiller\" created"]}

TASK [k8s-openebs-operator-helm : 5) Checking if the tiller cluster role binding already exists.] **********************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:60
FAILED - RETRYING: 5) Checking if the tiller cluster role binding already exists. (2 retries left).
FAILED - RETRYING: 5) Checking if the tiller cluster role binding already exists. (1 retries left).
fatal: [kubemaster01]: FAILED! => {"attempts": 2, "changed": true, "cmd": "kubectl get clusterrolebinding | grep tiller", "delta": "0:00:00.805980", "end": "2018-06-12 15:57:53.309238", "msg": "non-zero return code", "rc": 1, "start": "2018-06-12 15:57:52.503258", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [k8s-openebs-operator-helm : 5a) Creating the cluster rolebinding.] ***********************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:71
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller", "delta": "0:00:00.531764", "end": "2018-06-12 15:57:54.336851", "rc": 0, "start": "2018-06-12 15:57:53.805087", "stderr": "", "stderr_lines": [], "stdout": "clusterrolebinding.rbac.authorization.k8s.io \"tiller\" created", "stdout_lines": ["clusterrolebinding.rbac.authorization.k8s.io \"tiller\" created"]}

TASK [k8s-openebs-operator-helm : 6) Getting the home directory of kubernetes master.] *********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:80
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.048877", "end": "2018-06-12 15:57:55.381352", "rc": 0, "start": "2018-06-12 15:57:55.332475", "stderr": "", "stderr_lines": [], "stdout": "/home/ubuntu", "stdout_lines": ["/home/ubuntu"]}

TASK [k8s-openebs-operator-helm : 6a) Copying the patch yaml file to kubernetes master.] *******************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:86
changed: [kubemaster01] => {"changed": true, "checksum": "6e4809589a615f2dff209cc087f25ad683e55025", "dest": "/home/ubuntu/update.json", "gid": 1000, "group": "ubuntu", "md5sum": "8b81d678fd996264f460546ad89d5b1a", "mode": "0664", "owner": "ubuntu", "size": 111, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1528819075.6-207987422537019/source", "state": "file", "uid": 1000}

TASK [k8s-openebs-operator-helm : 6b) Updating the tiller-deploy deployment with the service account.] *****************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:91
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl -n kube-system patch deploy/tiller-deploy -p \"$(cat /home/ubuntu/update.json)\"", "delta": "0:00:00.751246", "end": "2018-06-12 15:57:59.514933", "rc": 0, "start": "2018-06-12 15:57:58.763687", "stderr": "", "stderr_lines": [], "stdout": "deployment.extensions \"tiller-deploy\" patched", "stdout_lines": ["deployment.extensions \"tiller-deploy\" patched"]}

TASK [k8s-openebs-operator-helm : 7) Installing openebs using stable charts.] ******************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:100
FAILED - RETRYING: 7) Installing openebs using stable charts. (5 retries left).
changed: [kubemaster01] => {"attempts": 2, "changed": true, "cmd": "helm install stable/openebs --name \"storage-mule\" --namespace \"openebs\"", "delta": "0:00:09.464449", "end": "2018-06-12 16:00:12.939426", "rc": 0, "start": "2018-06-12 16:00:03.474977", "stderr": "", "stderr_lines": [], "stdout": "NAME:   storage-mule\nLAST DEPLOYED: Tue Jun 12 16:00:06 2018\nNAMESPACE: openebs\nSTATUS: DEPLOYED\n\nRESOURCES:\n==> v1beta1/ClusterRole\nNAME                  AGE\nstorage-mule-openebs  0s\n\n==> v1beta1/ClusterRoleBinding\nNAME                  AGE\nstorage-mule-openebs  0s\n\n==> v1/Service\nNAME                             CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE\nstorage-mule-openebs-apiservice  10.102.144.200  <none>       5656/TCP  0s\n\n==> v1beta1/Deployment\nNAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE\nstorage-mule-openebs-apiserver    1        1        1           0          0s\nstorage-mule-openebs-provisioner  1        1        1           0          0s\n\n==> v1beta1/CustomResourceDefinition\nNAME                          KIND\nstoragepools.openebs.io       CustomResourceDefinition.v1beta1.apiextensions.k8s.io\nstoragepoolclaims.openebs.io  CustomResourceDefinition.v1beta1.apiextensions.k8s.io\n\n==> v1/ServiceAccount\nNAME                  SECRETS  AGE\nstorage-mule-openebs  1        0s\n\n\nNOTES:\nThe OpenEBS has been installed. Check its status by running:\n  kubectl get pods -n openebs\n\nFor dynamically creating OpenEBS Volumes, you will need to create StorageClass. \n\nOpenEBS Storage class can be created using the following spec:\n---\napiVersion: storage.k8s.io/v1\nkind: StorageClass\nmetadata:\n   name: openebs-standard\nprovisioner: openebs.io/provisioner-iscsi\nparameters:\n  openebs.io/storage-pool: \"default\"\n  openebs.io/jiva-replica-count: \"3\"\n  openebs.io/volume-monitor: \"true\"\n  openebs.io/capacity: 5G\n---\n\nAnd use this storage class \"openebs-standard\" in your PVC as shown below:\n---\nkind: PersistentVolumeClaim\napiVersion: v1\nmetadata:\n  name: demo-vol-claim\nspec:\n  storageClassName: openebs-standard\n  accessModes:\n    - ReadWriteOnce\n  resources:\n    requests:\n      storage: 4G\n---\n\nFor more information, please visit http://docs.openebs.io/.\n\nPlease note that, OpenEBS uses iSCSI for connecting applications with the \nOpenEBS Volumes and your nodes should have the iSCSI initiator installed. ", "stdout_lines": ["NAME:   storage-mule", "LAST DEPLOYED: Tue Jun 12 16:00:06 2018", "NAMESPACE: openebs", "STATUS: DEPLOYED", "", "RESOURCES:", "==> v1beta1/ClusterRole", "NAME                  AGE", "storage-mule-openebs  0s", "", "==> v1beta1/ClusterRoleBinding", "NAME                  AGE", "storage-mule-openebs  0s", "", "==> v1/Service", "NAME                             CLUSTER-IP      EXTERNAL-IP  PORT(S)   AGE", "storage-mule-openebs-apiservice  10.102.144.200  <none>       5656/TCP  0s", "", "==> v1beta1/Deployment", "NAME                              DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE", "storage-mule-openebs-apiserver    1        1        1           0          0s", "storage-mule-openebs-provisioner  1        1        1           0          0s", "", "==> v1beta1/CustomResourceDefinition", "NAME                          KIND", "storagepools.openebs.io       CustomResourceDefinition.v1beta1.apiextensions.k8s.io", "storagepoolclaims.openebs.io  CustomResourceDefinition.v1beta1.apiextensions.k8s.io", "", "==> v1/ServiceAccount", "NAME                  SECRETS  AGE", "storage-mule-openebs  1        0s", "", "", "NOTES:", "The OpenEBS has been installed. Check its status by running:", "  kubectl get pods -n openebs", "", "For dynamically creating OpenEBS Volumes, you will need to create StorageClass. ", "", "OpenEBS Storage class can be created using the following spec:", "---", "apiVersion: storage.k8s.io/v1", "kind: StorageClass", "metadata:", "   name: openebs-standard", "provisioner: openebs.io/provisioner-iscsi", "parameters:", "  openebs.io/storage-pool: \"default\"", "  openebs.io/jiva-replica-count: \"3\"", "  openebs.io/volume-monitor: \"true\"", "  openebs.io/capacity: 5G", "---", "", "And use this storage class \"openebs-standard\" in your PVC as shown below:", "---", "kind: PersistentVolumeClaim", "apiVersion: v1", "metadata:", "  name: demo-vol-claim", "spec:", "  storageClassName: openebs-standard", "  accessModes:", "    - ReadWriteOnce", "  resources:", "    requests:", "      storage: 4G", "---", "", "For more information, please visit http://docs.openebs.io/.", "", "Please note that, OpenEBS uses iSCSI for connecting applications with the ", "OpenEBS Volumes and your nodes should have the iSCSI initiator installed. "]}

TASK [k8s-openebs-operator-helm : 8) Checking if the provisioner is up.] ***********************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:109
FAILED - RETRYING: 8) Checking if the provisioner is up. (15 retries left).
changed: [kubemaster01] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n \"openebs\" | grep \"provisioner\"", "delta": "0:00:01.117939", "end": "2018-06-12 16:01:17.885569", "rc": 0, "start": "2018-06-12 16:01:16.767630", "stderr": "", "stderr_lines": [], "stdout": "storage-mule-openebs-provisioner-6f58fb8bd6-9f4nd   1/1       Running   0          1m", "stdout_lines": ["storage-mule-openebs-provisioner-6f58fb8bd6-9f4nd   1/1       Running   0          1m"]}

TASK [k8s-openebs-operator-helm : 8a) Checking if the openebs-apiserver is up.] ****************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:118
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n \"openebs\" | grep \"apiserver\"", "delta": "0:00:00.558520", "end": "2018-06-12 16:01:19.238932", "rc": 0, "start": "2018-06-12 16:01:18.680412", "stderr": "", "stderr_lines": [], "stdout": "storage-mule-openebs-apiserver-555c87859d-jq9w9     1/1       Running   0          1m", "stdout_lines": ["storage-mule-openebs-apiserver-555c87859d-jq9w9     1/1       Running   0          1m"]}

TASK [k8s-openebs-operator-helm : 9) Creating the default storage classes] *********************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:127
changed: [kubemaster01] => {"changed": true, "cmd": "kubectl apply -f \"https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml\"", "delta": "0:00:03.506281", "end": "2018-06-12 16:01:23.258656", "rc": 0, "start": "2018-06-12 16:01:19.752375", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-standalone\" created\nstorageclass.storage.k8s.io \"openebs-percona\" created\nstorageclass.storage.k8s.io \"openebs-jupyter\" created\nstorageclass.storage.k8s.io \"openebs-mongodb\" created\nstorageclass.storage.k8s.io \"openebs-cassandra\" created\nstorageclass.storage.k8s.io \"openebs-redis\" created\nstorageclass.storage.k8s.io \"openebs-kafka\" created\nstorageclass.storage.k8s.io \"openebs-zk\" created\nstorageclass.storage.k8s.io \"openebs-es-data-sc\" created", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-standalone\" created", "storageclass.storage.k8s.io \"openebs-percona\" created", "storageclass.storage.k8s.io \"openebs-jupyter\" created", "storageclass.storage.k8s.io \"openebs-mongodb\" created", "storageclass.storage.k8s.io \"openebs-cassandra\" created", "storageclass.storage.k8s.io \"openebs-redis\" created", "storageclass.storage.k8s.io \"openebs-kafka\" created", "storageclass.storage.k8s.io \"openebs-zk\" created", "storageclass.storage.k8s.io \"openebs-es-data-sc\" created"]}
META: ran handlers
META: ran handlers

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-operator : Download YAML for openebs operator] *******************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:2
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Change m-apiserver image to desired tag in operator YAML] *********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:12
skipping: [kubemaster01] => (item=m-apiserver) => {"changed": false, "item": "m-apiserver", "skip_reason": "Conditional result was False"}
skipping: [kubemaster01] => (item=jiva) => {"changed": false, "item": "jiva", "skip_reason": "Conditional result was False"}
skipping: [kubemaster01] => (item=openebs-k8s-provisioner) => {"changed": false, "item": "openebs-k8s-provisioner", "skip_reason": "Conditional result was False"}
skipping: [kubemaster01] => {"changed": false, "msg": "All items completed", "results": [{"_ansible_ignore_errors": null, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "m-apiserver", "skip_reason": "Conditional result was False", "skipped": true}, {"_ansible_ignore_errors": null, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "jiva", "skip_reason": "Conditional result was False", "skipped": true}, {"_ansible_ignore_errors": null, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "openebs-k8s-provisioner", "skip_reason": "Conditional result was False", "skipped": true}]}

TASK [k8s-openebs-operator : Get kubernetes master name] ***************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:22
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Get kubernetes master status] *************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:28
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : debug] ************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:38
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}
META:

TASK [k8s-openebs-operator : Start the log aggregator to capture operator logs] ****************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:47
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Deploy the openebs operator yml] **********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:52
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Confirm provisioner & apiserver are running] **********************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:62
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Get maya-apiserver pod name] **************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:72
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Create fact for pod name] *****************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:78
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Confirm that maya-cli is available in the maya-apiserver pod] *****************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:82
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Download YAML for openebs storage classes] ************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:89
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Deploy the openebs storageclasses yml] ****************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:99
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Confirm that openebs storage classes are created] *****************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:104
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator : Terminate the log aggregator] *************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:113
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************
kubemaster01               : ok=14   changed=12   unreachable=0    failed=2

```