### PR TITLE
gh-1614: Fix mix-indent in openebs\k8s\lib\vagrant\test\Vagrantfile

### DIFF
--- a/k8s/lib/vagrant/test/Vagrantfile
+++ b/k8s/lib/vagrant/test/Vagrantfile
@@ -16,27 +16,27 @@ Vagrant.configure("2") do |config|
   # For a complete reference, please see the online documentation at
   # https://docs.vagrantup.com.
 
-  if ((box_Mode.to_i < BOX_MODE_OPENEBS.to_i) || \
-      (box_Mode.to_i > BOX_MODE_KUBERNETES.to_i))
-        puts "Invalid value set for OPENEBS_BUILD_BOX."
-        puts "Usage: OPENEBS_BUILD_BOX=1 for OpenEBS."
-        puts "Usage: OPENEBS_BUILD_BOX=2 for Kubernetes."
-        puts "Defaulting to OpenEBS..." 
-        puts "Do you want to continue?(y/n):"
+  if ((box_Mode.to_i < BOX_MODE_OPENEBS.to_i) || (box_Mode.to_i > BOX_MODE_KUBERNETES.to_i))
+    puts "Invalid value set for OPENEBS_BUILD_BOX."
+    puts "Usage: OPENEBS_BUILD_BOX=1 for OpenEBS."
+    puts "Usage: OPENEBS_BUILD_BOX=2 for Kubernetes."
+    puts "Defaulting to OpenEBS..."
+    puts "Do you want to continue?(y/n):"
 
+    input = STDIN.gets.chomp
+    while 1 do
+      if(input == "n")
+        Kernel.exit!(0)
+      elsif(input == "y")
+        break
+      else
+        puts "Invalid input: type 'y' or 'n'"
         input = STDIN.gets.chomp
-        while 1 do
-           if(input == "n")
-             Kernel.exit!(0)
-           elsif(input == "y")
-             break
-           else
-             puts "Invalid input: type 'y' or 'n'"
-             input = STDIN.gets.chomp
-           end
-        end
-        box_Mode = 1
+      end
     end
+
+    box_Mode = 1
+  end
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -47,21 +47,18 @@ Vagrant.configure("2") do |config|
   # The default user is ubuntu for those boxes
   config.ssh.username = "ubuntu"
   config.vm.provision "shell", inline: <<-SHELL
-      echo "ubuntu:ubuntu" | sudo chpasswd
+    echo "ubuntu:ubuntu" | sudo chpasswd
   SHELL
-
 
   if box_Mode.to_i == BOX_MODE_KUBERNETES.to_i
     config.vm.provider "virtualbox" do |vb|
       vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "k8s-console.log")]
     end
     config.vm.box = "openebs/k8s-1.7"
-
   elsif box_Mode.to_i == BOX_MODE_OPENEBS.to_i
     config.vm.provider "virtualbox" do |vb|
       vb.customize ["modifyvm", :id, "--uartmode1", "file", File.join(Dir.pwd, "openebs-console.log")]
     end
     config.vm.box = "ubuntu/xenial64"
-
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:

Updated openebs\k8s\lib\vagrant\test\Vagrantfile following Ruby Style Guide indentation best practice:

- Use two spaces per indentation level (aka soft tabs). No hard tabs.
- Align the parameters of a method call if they span more than one line. When aligning parameters is not appropriate due to line-length constraints, single indent for the lines after the first is also acceptable.
- If multiple lines are required to describe the problem, subsequent lines should be indented three spaces after the # (one general plus two for indentation purpose).


**Which issue this PR fixes** 
This fixes #1614 