### PR TITLE
Ansible role to uninstall OpenEBS using helm

### DIFF
--- a/e2e/ansible/cleanup-openebs.yml
+++ b/e2e/ansible/cleanup-openebs.yml
@@ -1,0 +1,5 @@
+
+- hosts: kubernetes-kubemasters
+  roles:
+    - {role: k8s-openebs-uninstall-helm, when: deployment_mode == "hyperconverged" and openebs_deploy == "helm"}
+

--- a/e2e/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-uninstall-helm/defaults/main.yaml
@@ -1,2 +1,9 @@
 
-soft_uninstall: yes
+
+patch_file: update.json
+
+k8s_namespace: kube-system
+
+storage_classes: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml
+
+namespace: openebs 

--- a/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
+++ b/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml
@@ -1,5 +1,15 @@
 ---
-# From the charts list, finding out the OpenEBS chart name.
+
+# Steps 
+
+#1) Find out the openebs chart name.
+#2) Uninstall openebs.
+#3) Verify if openebs is uninstalled succeffully.
+#4) Delete the namespace.
+#5) Uninstall helm.
+#6) Delete the resources.
+#7) Delete the test artifacts.
+
 - name: Getting OpenEBS chart name
   shell: helm ls --all | grep openebs | grep DEPLOYED | awk '{print $1}'
   args:
@@ -12,29 +22,79 @@
     executable: /bin/bash
   register: purge_out
   until: "'deleted' in purge_out.stdout"
-  delay: 20
+  delay: 60
   retries: 10
-  when: "{{soft_uninstall}}" == "no"
 
-- name: Uninstall OpenEBS
-  shell: helm del "{{charts.stdout}}"
+- name: Checking if provisioner and api server are deleted.
+  shell: kubectl get po -n "{{ namespace }}" 
+  args: 
+    executable: /bin/bash
+  register: pod
+  until: "'apiserver' and 'provisioner' not in pod.stdout"
+  delay: 60
+  retries: 15
+
+- name: Uninstalling helm
+  shell: helm reset
   args:
     executable: /bin/bash
-  register: purge_out
-  until: "'deleted' in purge_out.stdout"
-  delay: 20
+  register: helm_out
+  until: "'Tiller' and 'uninstalled' in helm_out.stdout"
+  delay: 60
   retries: 10
-  when: "{{soft_uninstall}}" == "yes"
 
+- name: Checking if tiller has been uninstalled successfully
+  shell: kubectl get po -n "{{ k8s_namespace }}"
+  args:
+    executable: /bin/bash
+  register: pods
+  until: "'tiller-deploy' not in pods.stdout"
+  delay: 60
+  retries: 10
 
-- name: Check if OpenEBS namespace is deleted.
-  shell: kubectl get ns 
+- name: Deleting service account
+  shell: kubectl delete sa tiller -n "{{ k8s_namespace }}"
+  args:
+    executable: /bin/bash
+  register: sa
+  until: "'deleted' in sa.stdout"
+  delay: 60
+  retries: 5
+
+- name: Deleting clusterolebinding
+  shell: kubectl delete clusterrolebinding tiller
+  args:
+    executable: /bin/bash
+  register: crd
+  until: "'deleted' in crd.stdout"
+  delay: 30
+  retries: 5
+
+- name: Deleting the namespace
+  shell: kubectl delete ns "{{ namespace }}"
   args:
     executable: /bin/bash
   register: ns_out
-  until: "'openebs' not in ns_out.stdout"
+  until: "'deleted' in ns_out.stdout"
   delay: 20
-  retries: 10 
- 
+  retries: 10
+
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- name: Deleting the patch yaml file copied to k8s master.
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
+    state: absent
+
+- name: Deleting the storage classes
+  shell: kubectl delete -f "{{ storage_classes }}"
+  args:
+    executable: /bin/bash
   
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:

Implemented ansible role to uninstall openebs using helm chart and including this role in the cleanup-openebs playbook.

Steps followed:

- Find out the openebs chart name.
- Uninstall openebs.
- Verify if openebs is uninstalled successfully.
- Delete the namespace.
- Uninstall helm.
- Delete the resources service account and clusterrolebinding.
- Delete the test artifacts.

** Sample test run output**

```
giri@vagrant-host:~/openebs/e2e/ansible$ ansible-playbook cleanup-openebs.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/openebs/e2e/ansible/ansible.cfg as config file

PLAYBOOK: cleanup-openebs.yml ******************************************************************************************************************************************
1 plays in cleanup-openebs.yml

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-uninstall-helm : Getting OpenEBS chart name] *********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:13
changed: [kubemaster01] => {"changed": true, "cmd": "helm ls --all | grep openebs | grep DEPLOYED | awk '{print $1}'", "delta": "0:00:01.052527", "end": "2018-06-12 16:10:41.134192", "rc": 0, "start": "2018-06-12 16:10:40.081665", "stderr": "", "stderr_lines": [], "stdout": "storage-mule", "stdout_lines": ["storage-mule"]}

TASK [k8s-openebs-uninstall-helm : Uninstall OpenEBS] ******************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:19
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "helm del --purge \"storage-mule\"", "delta": "0:00:10.869496", "end": "2018-06-12 16:10:53.147440", "rc": 0, "start": "2018-06-12 16:10:42.277944", "stderr": "", "stderr_lines": [], "stdout": "release \"storage-mule\" deleted", "stdout_lines": ["release \"storage-mule\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Checking if provisioner and api server are deleted.] ********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:28
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl get po -n \"openebs\"", "delta": "0:00:00.819314", "end": "2018-06-12 16:10:54.849611", "rc": 0, "start": "2018-06-12 16:10:54.030297", "stderr": "", "stderr_lines": [], "stdout": "NAME                                              READY     STATUS        RESTARTS   AGE\nstorage-mule-openebs-apiserver-555c87859d-jq9w9   1/1       Terminating   1          10m", "stdout_lines": ["NAME                                              READY     STATUS        RESTARTS   AGE", "storage-mule-openebs-apiserver-555c87859d-jq9w9   1/1       Terminating   1          10m"]}

TASK [k8s-openebs-uninstall-helm : Uninstalling helm] ******************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:37
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "helm reset", "delta": "0:00:04.508754", "end": "2018-06-12 16:10:59.998609", "rc": 0, "start": "2018-06-12 16:10:55.489855", "stderr": "", "stderr_lines": [], "stdout": "Tiller (the Helm server-side component) has been uninstalled from your Kubernetes Cluster.", "stdout_lines": ["Tiller (the Helm server-side component) has been uninstalled from your Kubernetes Cluster."]}

TASK [k8s-openebs-uninstall-helm : Checking if tiller has been uninstalled successfully] *******************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:46
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl get po -n \"kube-system\"", "delta": "0:00:00.944360", "end": "2018-06-12 16:11:02.191055", "rc": 0, "start": "2018-06-12 16:11:01.246695", "stderr": "", "stderr_lines": [], "stdout": "NAME                                    READY     STATUS     RESTARTS   AGE\netcd-kubemaster-01                      1/1       Running    8          9h\nkube-apiserver-kubemaster-01            1/1       Running    6          9h\nkube-controller-manager-kubemaster-01   1/1       Running    6          9h\nkube-dns-86f4d74b45-h9lkn               3/3       Running    8          9h\nkube-proxy-cwrkr                        1/1       Running    5          9h\nkube-proxy-s52z2                        1/1       Running    2          9h\nkube-proxy-spgtn                        1/1       NodeLost   5          9h\nkube-proxy-tj2hj                        1/1       Running    3          9h\nkube-router-4jjs5                       1/1       Running    18         9h\nkube-router-7nh4c                       1/1       Running    12         9h\nkube-router-95zhd                       1/1       Running    10         9h\nkube-router-qbzlx                       1/1       NodeLost   13         9h\nkube-scheduler-kubemaster-01            1/1       Running    3          9h\nkubernetes-dashboard-75d647ffd9-g6vpm   1/1       Running    2          9h", "stdout_lines": ["NAME                                    READY     STATUS     RESTARTS   AGE", "etcd-kubemaster-01                      1/1       Running    8          9h", "kube-apiserver-kubemaster-01            1/1       Running    6          9h", "kube-controller-manager-kubemaster-01   1/1       Running    6          9h", "kube-dns-86f4d74b45-h9lkn               3/3       Running    8          9h", "kube-proxy-cwrkr                        1/1       Running    5          9h", "kube-proxy-s52z2                        1/1       Running    2          9h", "kube-proxy-spgtn                        1/1       NodeLost   5          9h", "kube-proxy-tj2hj                        1/1       Running    3          9h", "kube-router-4jjs5                       1/1       Running    18         9h", "kube-router-7nh4c                       1/1       Running    12         9h", "kube-router-95zhd                       1/1       Running    10         9h", "kube-router-qbzlx                       1/1       NodeLost   13         9h", "kube-scheduler-kubemaster-01            1/1       Running    3          9h", "kubernetes-dashboard-75d647ffd9-g6vpm   1/1       Running    2          9h"]}

TASK [k8s-openebs-uninstall-helm : Deleting service account] ***********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:55
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete sa tiller -n \"kube-system\"", "delta": "0:00:00.565807", "end": "2018-06-12 16:11:03.412438", "rc": 0, "start": "2018-06-12 16:11:02.846631", "stderr": "", "stderr_lines": [], "stdout": "serviceaccount \"tiller\" deleted", "stdout_lines": ["serviceaccount \"tiller\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Deleting clusterolebinding] *********************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:64
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete clusterrolebinding tiller", "delta": "0:00:00.687952", "end": "2018-06-12 16:11:04.836220", "rc": 0, "start": "2018-06-12 16:11:04.148268", "stderr": "", "stderr_lines": [], "stdout": "clusterrolebinding.rbac.authorization.k8s.io \"tiller\" deleted", "stdout_lines": ["clusterrolebinding.rbac.authorization.k8s.io \"tiller\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Deleting the namespace] *************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:73
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "kubectl delete ns \"openebs\"", "delta": "0:00:00.495852", "end": "2018-06-12 16:11:06.660801", "rc": 0, "start": "2018-06-12 16:11:06.164949", "stderr": "", "stderr_lines": [], "stdout": "namespace \"openebs\" deleted", "stdout_lines": ["namespace \"openebs\" deleted"]}

TASK [k8s-openebs-uninstall-helm : Get $HOME of K8s master for kubernetes user] ****************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:82
changed: [kubemaster01 -> None] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.005621", "end": "2018-06-12 16:11:07.290243", "rc": 0, "start": "2018-06-12 16:11:07.284622", "stderr": "", "stderr_lines": [], "stdout": "/home/ubuntu", "stdout_lines": ["/home/ubuntu"]}

TASK [k8s-openebs-uninstall-helm : Deleting the patch yaml file copied to k8s master.] *********************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:90
changed: [kubemaster01] => {"changed": true, "path": "/home/ubuntu/update.json", "state": "absent"}

TASK [k8s-openebs-uninstall-helm : Deleting the storage classes] *******************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/roles/k8s-openebs-uninstall-helm/tasks/main.yaml:95
changed: [kubemaster01] => {"changed": true, "cmd": "kubectl delete -f \"https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml\"", "delta": "0:00:03.650474", "end": "2018-06-12 16:11:12.731532", "rc": 0, "start": "2018-06-12 16:11:09.081058", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-standalone\" deleted\nstorageclass.storage.k8s.io \"openebs-percona\" deleted\nstorageclass.storage.k8s.io \"openebs-jupyter\" deleted\nstorageclass.storage.k8s.io \"openebs-mongodb\" deleted\nstorageclass.storage.k8s.io \"openebs-cassandra\" deleted\nstorageclass.storage.k8s.io \"openebs-redis\" deleted\nstorageclass.storage.k8s.io \"openebs-kafka\" deleted\nstorageclass.storage.k8s.io \"openebs-zk\" deleted\nstorageclass.storage.k8s.io \"openebs-es-data-sc\" deleted", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-standalone\" deleted", "storageclass.storage.k8s.io \"openebs-percona\" deleted", "storageclass.storage.k8s.io \"openebs-jupyter\" deleted", "storageclass.storage.k8s.io \"openebs-mongodb\" deleted", "storageclass.storage.k8s.io \"openebs-cassandra\" deleted", "storageclass.storage.k8s.io \"openebs-redis\" deleted", "storageclass.storage.k8s.io \"openebs-kafka\" deleted", "storageclass.storage.k8s.io \"openebs-zk\" deleted", "storageclass.storage.k8s.io \"openebs-es-data-sc\" deleted"]}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************
kubemaster01               : ok=12   changed=11   unreachable=0    failed=0```
