### PR TITLE
Update openebs-operator with 0.6.0-RC2

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -79,7 +79,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.6.0-RC1
+        image: openebs/m-apiserver:0.6.0-RC2
         ports:
         - containerPort: 5656
         env:
@@ -94,13 +94,31 @@ spec:
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.6.0-RC1"
+          value: "openebs/jiva:0.6.0-RC2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.6.0-RC1"
+          value: "openebs/jiva:0.6.0-RC2"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.6.0-RC1"
+          value: "openebs/m-exporter:0.6.0-RC2"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
+        # DEFAULT_CONTROLLER_NODE_SELECTOR allows your to specify the nodes
+        # on which openebs controller have to be scheduled. To use this feature, 
+        # the nodes should already be labeled with the key=value. For example:
+        # `kubectl label nodes <node-name> nodetype=storage
+        # Note: It is recommended that node selector for controller be 
+        # same as that of the stateful apps.
+        # This is supported for maya api server version 0.6.0-RC2 onwards
+        #- name: DEFAULT_CONTROLLER_NODE_SELECTOR
+        #  value: "nodetype=storage"
+        # DEFAULT_REPLICA_NODE_SELECTOR allows your to specify the nodes
+        # on which openebs replicas have to be scheduled. To use this feature, 
+        # the nodes should already be labeled with the key=value. For example:
+        # `kubectl label nodes <node-name> nodetype=storage
+        # Note: It is recommended that node selector for replica will specify
+        # nodes that have disks/ssds attached to them. 
+        # This is supported for maya api server version 0.6.0-RC2 onwards
+        #- name: DEFAULT_REPLICA_NODE_SELECTOR
+        #  value: "nodetype=storage"
 ---
 apiVersion: v1
 kind: Service
@@ -132,7 +150,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: Always
-        image: openebs/openebs-k8s-provisioner:0.6.0-RC1
+        image: openebs/openebs-k8s-provisioner:0.6.0-RC2
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -179,10 +197,10 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:0.6.0-RC1
+          image: openebs/snapshot-controller:0.6.0-RC2
           imagePullPolicy: Always
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:0.6.0-RC1
+          image: openebs/snapshot-provisioner:0.6.0-RC2
           imagePullPolicy: Always
 ---
 apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Updates the images to 0.6.0-RC2
- Includes fixes for:
  * mayactl fixes for volume stats and volume info to display replica details
  * apiserver is enhanced to support specification of nodeselectors for storage pods (https://github.com/openebs/maya/pull/372)
  * enhancements to snapshot functionality to manage snapshots on volumes in different namespaces

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
