### PR TITLE
Ansible playbook for testing jiva volume resizing

### DIFF
--- a/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-vars.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-vars.yml
@@ -3,8 +3,6 @@ test_name: kubectl_snapshot_restore
 
 namespace: k8s-snapshot
 
-utils_path: openebs/e2e/ansible/playbooks/utils
-
 test_log_path: setup/logs/snap_create_revert.log
 
 test_pod_regex: maya*|openebs*|pvc*|snapshot*

--- a/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
@@ -31,14 +31,12 @@
 
         - include: prerequisites.yml
 
-        - name: 1) Check if openebs-provisioner and maya-apiserver are running
+        - name: 1) Check if maya-apiserver is running.
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
           vars:
             ns: openebs
-            app:
-              - apiserver
-              - provisioner
-
+            app: apiserver
+        
         - name: 2) Copy the snapshot specific files to K8s master
           copy:
             src: "{{ item }}"
@@ -59,10 +57,10 @@
           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
         - name: 4) Deploy percona mysql pod
-          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
-          vars:
-           app_yml: "{{ percona_link }}"
-           ns: "{{ namespace }}"
+          shell: kubectl apply -f "{{ percona_link }}" -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
         - name: 5) Confirm pod status is running
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
@@ -193,7 +191,7 @@
         - name: 10a) Deploying the application with the snapped pvc
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
           vars:
-           app_yml: "{{ result_kube_home.stdout }}/{{ percona }}"
+           app_yml: "{{ percona }}"
            ns: "{{ namespace }}"
 
         - name: Wait few seconds

--- a/e2e/ansible/playbooks/feature/snapshots/simple-volume/snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/simple-volume/snapshot.yml
@@ -293,6 +293,6 @@
         - name: Send slack notification
           slack:
             token: "{{ lookup('env','SLACK_TOKEN') }}"
-            msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}'
+            msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}, {{ cflag }}'
           when: slack_notify | bool and lookup('env','SLACK_TOKEN')
 

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/percona-openebs-deployment.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/percona-openebs-deployment.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+      nodeSelector:
+        app: percona
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: percona-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: percona-claim
+spec:
+  storageClassName: openebs-percona
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/pre-requisites.yml
@@ -1,0 +1,13 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+  vars:
+    status: start
+

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml
@@ -1,0 +1,56 @@
+---
+- name: Getting PV name from the pvc
+  shell: kubectl get pvc {{ claim_name }} -n "{{ namespace }}" -o custom-columns=:spec.volumeName --no-headers
+  args:
+    executable: /bin/bash
+  register: pv
+  delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+- name: Deleting percona deployment
+  shell: kubectl delete -f "{{ percona_def }}" -n "{{ namespace }}"
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Checking if the application pod is deleted.
+  shell: kubectl get pods --all-namespaces --show-labels | grep {{ app_label }} | awk {'print $2'} | wc -l
+  args:
+    executable: /bin/bash
+  register: app_count
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: app_count.stdout |int == 0
+  delay: 20
+  retries: 15
+
+- name: Checking if the replica pods are deleted
+  shell: kubectl get pods --all-namespaces --show-labels |  grep openebs/replica=jiva-replica | awk {'print$2'} | wc -l
+  args:
+    executable: /bin/bash
+  register: rep_count
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  until: rep_count.stdout |int == 0
+  delay: 20
+  retries: 15
+
+- name: Checking if the corresponding svc is deleted
+  shell: kubectl get svc -n "{{ namespace }}" | grep {{ pv.stdout }} | wc -l
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: svc_count
+  until: svc_count.stdout |int == 0
+  delay: 20
+  retries: 15
+
+- name: Delete the percona definition yaml file copied
+  file:
+    path: "{{ percona_def }}"
+    state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Delete the test specific namespace
+  shell: source ~/.profile; kubectl delete ns "{{ namespace }}"
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume-vars.yml
@@ -1,0 +1,16 @@
+---
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: setup/logs/resize_volume.log
+
+test_name: test-resize-jiva-volume
+
+percona_def: percona-openebs-deployment.yaml
+
+claim_name: percona-claim
+
+app_label: "name=percona"
+
+replica_label: "openebs/replica=jiva-replica"
+
+namespace: resize-volume

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml
@@ -1,0 +1,333 @@
+# Test name: Resize Jiva volume
+
+#Description: Check if the OpenEBS Jiva volume's capacity can be expanded.
+
+# STEPS INVOLVED:
+#1) Deploy OpenEBS
+#2) Create label for a node.
+#3) Deploy percona with node selector applied.
+#4) Obtain iSCSI target details.
+#5) Unmount the file system
+#6) Logout the iscsi target
+#7) Get the id of the volume
+#8) Modfiy the volume size
+#9) Restart the replicas
+#10) Check the file system consistency
+#10) Expand the file system
+#)11) Mount the file system
+#12) Restart the application pod
+#13) Write data on the resized portion of the file system.
+
+- hosts: localhost
+
+  vars_files:
+    - resize-volume-vars.yml
+
+  tasks:
+
+    - block:
+
+        - include: pre-requisites.yml
+
+        - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+          vars:
+             ns: openebs
+             app: apiserver
+
+        - name: Copy the percona definition yaml to k8s master
+          copy:
+            src: "{{ percona_def }}"
+            dest: "{{ result_kube_home.stdout }}"
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+        - name: Getting the node name
+          shell: kubectl get nodes -o wide  | awk {'print $1'} | awk 'FNR == 4{print}'
+          args:
+            executable: /bin/bash
+          register: node_name
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+# Creating label "app=percona" for a node, so that node selector tag can be used in next task.
+
+        - name: Creating label for the node
+          shell: kubectl label nodes {{node_name.stdout}} app=percona
+          args:
+            executable: /bin/bash
+          register: label
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          until: '"labeled" in label.stdout'
+          delay: 10
+          retries: 3
+
+        - name: Creating test specific namespace
+          shell: kubectl create ns "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+        - name: Deploying application
+          shell: source ~/.profile; kubectl apply -f "{{ percona_def }}" -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          register: percona_status
+          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+          until: "'created' in percona_status.stdout"
+          delay: 30
+          retries: 5
+
+        - name: Checking if the application is deployed successfully
+          shell: kubectl get pods -n "{{ namespace }}" --show-labels | grep "{{ app_label }}"
+          args:
+            executable: /bin/bash
+          register: app_status
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+          until: "'Running' in app_status.stdout"
+          delay: 60
+          retries: 15
+
+        - name: Getting PV name from the pvc
+          shell: kubectl get pvc {{ claim_name }} -n "{{ namespace }}" -o custom-columns=:spec.volumeName --no-headers
+          args:
+            executable: /bin/bash
+          register: pv
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+        - name: Getting the controller service IP address
+          shell: kubectl get svc -n "{{ namespace }}" | grep "{{ pv.stdout }}" | grep ctrl | awk {'print $3'}
+          args:
+            executable: /bin/bash
+          register: target_IP
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+
+        - name: Getting the device name
+          shell: fdisk -l | grep "5 G" | awk {'print $2'} | sed 's/.$//'
+          args:
+            executable: /bin/bash
+          become: true
+          register: device_name
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Getting the mounted directory
+          shell: mount | grep "{{ device_name.stdout }}" | awk {'print $3'} | awk 'FNR == {{item}} {print}'
+          args:
+            executable: /bin/bash
+          register: mount_path
+          with_items:
+            - 1
+            - 2
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Unmount the file system
+          mount:
+            path: "{{ item }}"
+            state: unmounted
+          become: true
+          with_items:
+            - "{{ mount_path.results[0].stdout }}"
+            - "{{mount_path.results[1].stdout }}"
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Finding the iSCSI target name
+          shell: iscsiadm -m session | grep "{{ target_IP.stdout}}"| awk {'print $4'}
+          args:
+            executable: /bin/bash
+          become: true
+          register: iqn
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Logging out the iSCSI target
+          open_iscsi:
+            login: no
+            target: "{{ iqn.stdout }}"
+            show_nodes: yes
+          become: true
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Getting the response of volume api
+          shell: curl http://"{{target_IP.stdout}}":9501/v1/volumes
+          args:
+            executable: /bin/bash
+          register: resp
+          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+          changed_when: true
+
+        - set_fact:
+            vol_id: "{{ (resp.stdout | from_json).data[0].id  }}"
+
+        - name: Modify the capacity of volume
+          uri:
+            url: http://{{target_IP.stdout}}:9501/v1/volumes/{{vol_id}}?action=resize
+            method: POST
+            return_content: yes
+            body: {"name":"{{pv.stdout}}","size":"6 G"}
+            body_format: json
+            headers:
+              Content-Type: "application/json"
+          register: modify
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+
+        - name: Getting the replica pod names
+          shell:  kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print $2'} | awk 'FNR == {{ item }} {print}'
+          args:
+            executable: /bin/bash
+          register: pods
+          with_items:
+            - 1
+            - 2
+            - 3
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+
+        - name: Deleting all replica pods at once
+          shell: sleep 30; kubectl delete pod "{{ pods.results[0].stdout }}" "{{pods.results[1].stdout}}" "{{pods.results[2].stdout}}" -n "{{ namespace }}"
+          args:
+            executable: /bin/bash
+          register: delete_pod
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+          until: "'deleted' in delete_pod.stdout"
+          delay: 20
+          retries: 5
+
+        - name: Checking if the replica pods are created again.
+          shell: kubectl get pods -n "{{ namespace }}" --show-labels | grep "{{ pv.stdout }}" | grep "{{ replica_label }}" | grep Running | wc -l
+          args:
+            executable: /bin/bash
+          register: result
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+          until: result.stdout|int == 3
+          delay: 30
+          retries: 10
+
+        - name: Login to iSCSI target
+          open_iscsi:
+            show_nodes: yes
+            login: yes
+            target: "{{ iqn.stdout }}"
+          become: yes
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Finding the new device name
+          shell: iscsiadm -m session -P3 | egrep 'iqn|disk' | grep disk | awk {'print $4'}
+         #shell: fdisk -l | grep "6 G" | awk {'print $2'} | sed 's/.$//'
+          args:
+            executable: /bin/bash
+          become: true
+          register: new_device
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Running fsck on the new device
+          shell: e2fsck -f /dev/{{ new_device.stdout }} -y
+          args:
+            executable: /bin/bash
+          become: true
+          register: fs_check
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+          until: '"MODIFIED" or "clean" in fs_check.stdout'
+          delay: 20
+          retries: 5
+          ignore_errors: yes
+
+        - name: Resizing the file system
+          shell: resize2fs /dev/{{ new_device.stdout }}
+          args:
+            executable: /bin/bash
+          become: true
+          register: resize
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+          until: "'Resizing the filesystem on' in resize.stdout"
+          delay: 20
+          retries: 10
+
+        - name: Mount FS
+          shell: mount /dev/{{ new_device.stdout }} "{{ item }}"
+          args:
+            executable: /bin/bash
+          become: true
+          with_items:
+            - "{{ mount_path.results[0].stdout }}"
+            - "{{mount_path.results[1].stdout }}"
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Wait
+          wait_for: timeout=120
+
+        - name: Getting application pod
+          shell: kubectl get pods --all-namespaces --show-labels | grep {{ app_label }} | awk {'print $2'}
+          args:
+            executable: /bin/bash
+          register: app
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+
+        - name: Deleting the application pod
+          shell: kubectl delete pod {{ app.stdout }} -n "{{ namespace }}" --grace-period=0 --force
+          args:
+            executable: /bin/bash
+          register: delete_app
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+          until: "'deleted' in delete_app.stdout"
+          delay: 10
+          retries: 5
+
+        - name: Check if the application pod is running
+          shell: kubectl get pods -n "{{ namespace }}" --show-labels | grep "{{app_label}}"
+          args:
+            executable: /bin/bash
+          register: app_out
+          delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+          until: "'Running' in app_out.stdout"
+          delay: 20
+          retries: 10
+
+        - name: Writing data into the volume using dd
+          shell: dd if=/dev/urandom of="{{mount_path.results[1].stdout}}/f1" bs=4k seek=1250000 count=20000
+          args:
+            executable: /bin/bash
+          become: true
+          delegate_to: "{{groups['kubernetes-kubeminions'].1}}"
+
+        - name: Setting the Pass flag
+          set_fact:
+            flag: "TEST PASSED"
+
+        - name: Wait
+          wait_for: timeout=200
+
+      rescue:
+        - name: Setting the fail flag
+          set_fact:
+            flag: "TEST FAILED"
+
+      always:
+
+        - block:
+
+            - name: Remove the node label
+              shell: kubectl label node "{{node_name.stdout}}" app-
+              args:
+                executable: /bin/bash
+              delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
+
+            - include: resize-cleanup.yml
+              when: clean | bool
+
+            - name: Setting Cleanup flag to passed
+              set_fact:
+                cflag: "CLEANUP PASSED"
+
+          rescue:
+
+            - name: Setting cleanup flag to failed
+              set_fact:
+                cflag: "CLEANUP FAILED"
+
+          always:
+
+            - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+              vars:
+                status: stop
+
+            - name: Send slack notification
+              slack:
+                token: "{{ lookup('env','SLACK_TOKEN') }}"
+                msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }}, {{ cflag }}'
+              when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+

--- a/e2e/ansible/playbooks/utils/deploy_check.yml
+++ b/e2e/ansible/playbooks/utils/deploy_check.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check {{ app }} pod status
-  shell: source ~/.profile; kubectl get pods -n {{ ns }} | grep {{ item }}
+  shell: source ~/.profile; kubectl get pods -n {{ ns }} | grep {{ app }}
   args:
     executable: /bin/bash
   register: result


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
Tests whether jiva volume can be expanded.

Steps followed:

- Deploy OpenEBS
- Create a label for the node.
- Deploy percona with node selector applied, so that the pod will be scheduled on the same node.
- Obtain the iSCSI target details.
- Unmount the file system
 - Logout the iscsi target
- Get the id of the volume
- Modify the volume size
- Restart the replicas
- Check the file system consistency
- Expand the file system
- Mount the file system
- Restart the application pod
- Write data on the resized portion of the file system.
- Delete the test artifacts

**Special notes for your reviewer**:
- Modified the deploy_check utility by removing the item.

Sample test run output:
```
giri@vagrant-host:~/openebs/e2e/ansible$ ansible-playbook playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/openebs/e2e/ansible/ansible.cfg as config file
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in 
a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
statically imported: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml
statically imported: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/pre-requisites.yml

PLAYBOOK: resize-volume.yml ********************************************************************************************************************************************************************************
1 plays in playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml

PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Get $HOME of K8s master for kubernetes user] *********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/pre-requisites.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.024796", "end": "2018-06-19 07:45:26.352881", "rc": 0, "start": "2018-06-19 07:45:26.328085", "stderr": "", "stderr_lines": [], "stdout": "/home/ubuntu", "stdout_lines": ["/home/ubuntu"]}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/pre-requisites.yml:10
included: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; nohup stern --all-namespaces \"maya*|openebs*|pvc*|percona*\" --kubeconfig /home/ubuntu/.kube/config --since 1m > /home/ubuntu/setup/logs/resize_volume.log &", "delta": "0:00:00.013548", "end": "2018-06-19 07:45:27.465117", "rc": 0, "start": "2018-06-19 07:45:27.451569", "stderr": "mesg: ttyname failed: Inappropriate ioctl for device\n/bin/bash: /home/ubuntu/setup/logs/resize_volume.log: No such file or directory", "stderr_lines": ["mesg: ttyname failed: Inappropriate ioctl for device", "/bin/bash: /home/ubuntu/setup/logs/resize_volume.log: No such file or directory"], "stdout": "", "stdout_lines": []}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:32
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml for localhost

TASK [Check apiserver pod status] **************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml:2
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n openebs | grep apiserver", "delta": "0:00:01.366962", "end": "2018-06-19 07:45:29.567248", "rc": 0, "start": "2018-06-19 07:45:28.200286", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-6cfd67f8-kqgzd                  1/1       Running   8          3d", "stdout_lines": ["maya-apiserver-6cfd67f8-kqgzd                  1/1       Running   8          3d"]}

TASK [Copy the percona definition yaml to k8s master] ******************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:37
changed: [localhost -> None] => {"changed": true, "checksum": "696952daf2cc95ebf42694fce53ff4204971e99a", "dest": "/home/ubuntu/percona-openebs-deployment.yaml", "gid": 1000, "group": "ubuntu", "md5sum": "61036016785f1ec2eea95e32651ff02d", "mode": "0664", "owner": "ubuntu", "size": 1248, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1529394331.0-14766364284326/source", "state": "file", "uid": 1000}

TASK [Getting the node name] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:43
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get nodes -o wide | awk {'print $1'} | awk 'FNR == 4{print}'", "delta": "0:00:00.342914", "end": "2018-06-19 07:45:34.329909", "rc": 0, "start": "2018-06-19 07:45:33.986995", "stderr": "", "stderr_lines": [], "stdout": "kubeminion-02", "stdout_lines": ["kubeminion-02"]}

TASK [Creating label for the node] *************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:52
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "kubectl label nodes kubeminion-02 app=percona", "delta": "0:00:00.761138", "end": "2018-06-19 07:45:35.679300", "rc": 0, "start": "2018-06-19 07:45:34.918162", "stderr": "", "stderr_lines": [], "stdout": "node \"kubeminion-02\" labeled", "stdout_lines": ["node \"kubeminion-02\" labeled"]}

TASK [Creating test specific namespace] ********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:62
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl create ns \"resize-volume\"", "delta": "0:00:00.632294", "end": "2018-06-19 07:45:37.247234", "rc": 0, "start": "2018-06-19 07:45:36.614940", "stderr": "", "stderr_lines": [], "stdout": "namespace \"resize-volume\" created", "stdout_lines": ["namespace \"resize-volume\" created"]}

TASK [Deploying application] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:68
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl apply -f \"percona-openebs-deployment.yaml\" -n \"resize-volume\"", "delta": "0:00:02.284765", "end": "2018-06-19 07:45:40.228955", "rc": 0, "start": "2018-06-19 07:45:37.944190", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"percona\" created\npersistentvolumeclaim \"percona-claim\" created\nservice \"percona-mysql\" created", "stdout_lines": ["deployment.apps \"percona\" created", "persistentvolumeclaim \"percona-claim\" created", "service \"percona-mysql\" created"]}

TASK [Checking if the application is deployed successfully] ************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:78
FAILED - RETRYING: Checking if the application is deployed successfully (15 retries left).
FAILED - RETRYING: Checking if the application is deployed successfully (14 retries left).
changed: [localhost -> None] => {"attempts": 3, "changed": true, "cmd": "kubectl get pods -n \"resize-volume\" --show-labels | grep \"name=percona\"", "delta": "0:00:00.706398", "end": "2018-06-19 07:47:49.794542", "rc": 0, "start": "2018-06-19 07:47:49.088144", "stderr": "", "stderr_lines": [], "stdout": "percona-67bb497d48-8rtgj                                        1/1       Running   0          2m        name=percona,pod-template-hash=2366053804", "stdout_lines": ["percona-67bb497d48-8rtgj                                        1/1       Running   0          2m        name=percona,pod-template-hash=2366053804"]}

TASK [Getting PV name from the pvc] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:88
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get pvc percona-claim -n \"resize-volume\" -o custom-columns=:spec.volumeName --no-headers", "delta": "0:00:00.810971", "end": "2018-06-19 07:47:51.352827", "rc": 0, "start": "2018-06-19 07:47:50.541856", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "stdout_lines": ["pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db"]}

TASK [Getting the controller service IP address] ***********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:95
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get svc -n \"resize-volume\" | grep \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\" | grep ctrl | awk {'print $3'}", "delta": "0:00:00.894008", "end": "2018-06-19 07:47:53.166946", "rc": 0, "start": "2018-06-19 07:47:52.272938", "stderr": "", "stderr_lines": [], "stdout": "10.104.212.71", "stdout_lines": ["10.104.212.71"]}

TASK [Getting the device name] *****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:102
changed: [localhost -> None] => {"changed": true, "cmd": "fdisk -l | grep \"5 G\" | awk {'print $2'} | sed 's/.$//'", "delta": "0:00:00.084089", "end": "2018-06-19 07:47:56.998444", "rc": 0, "start": "2018-06-19 07:47:56.914355", "stderr": "", "stderr_lines": [], "stdout": "/dev/sdc", "stdout_lines": ["/dev/sdc"]}

TASK [Getting the mounted directory] ***********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:110
changed: [localhost -> None] => (item=1) => {"changed": true, "cmd": "mount | grep \"/dev/sdc\" | awk {'print $3'} | awk 'FNR == 1 {print}'", "delta": "0:00:00.080210", "end": "2018-06-19 07:47:58.315065", "item": 1, "rc": 0, "start": "2018-06-19 07:47:58.234855", "stderr": "", "stderr_lines": [], "stdout": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0", "stdout_lines": ["/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0"], "warnings": ["Consider using mount module rather than running mount"]}
changed: [localhost -> None] => (item=2) => {"changed": true, "cmd": "mount | grep \"/dev/sdc\" | awk {'print $3'} | awk 'FNR == 2 {print}'", "delta": "0:00:00.029358", "end": "2018-06-19 07:47:59.366504", "item": 2, "rc": 0, "start": "2018-06-19 07:47:59.337146", "stderr": "", "stderr_lines": [], "stdout": "/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "stdout_lines": ["/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db"], "warnings": ["Consider using mount module rather than running mount"]}
 [WARNING]: Consider using mount module rather than running mount


TASK [Unmount the file system] *****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:120
changed: [localhost -> None] => (item=/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0) => {"changed": true, "dump": "0", "fstab": "/etc/fstab", "item": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0", "name": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0", "opts": "defaults", "passno": "0"}
changed: [localhost -> None] => (item=/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db) => {"changed": true, "dump": "0", "fstab": "/etc/fstab", "item": "/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "name": "/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "opts": "defaults", "passno": "0"}

TASK [Finding the iSCSI target name] ***********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:130
changed: [localhost -> None] => {"changed": true, "cmd": "iscsiadm -m session | grep \"10.104.212.71\"| awk {'print $4'}", "delta": "0:00:00.048184", "end": "2018-06-19 07:48:03.441582", "rc": 0, "start": "2018-06-19 07:48:03.393398", "stderr": "", "stderr_lines": [], "stdout": "iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "stdout_lines": ["iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db"]}

TASK [Logging out the iSCSI target] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:138
changed: [localhost -> None] => {"changed": true, "connection_changed": true, "nodes": ["iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "iqn.2016-09.com.openebs.jiva:pvc-ec201994-6fd5-11e8-a2d3-02b983f0a4db"]}

TASK [Getting the response of volume api] ******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:146
 [WARNING]: Consider using get_url or uri module rather than running curl

changed: [localhost -> None] => {"changed": true, "cmd": "curl http://\"10.104.212.71\":9501/v1/volumes", "delta": "0:00:00.146280", "end": "2018-06-19 07:48:06.772336", "rc": 0, "start": "2018-06-19 07:48:06.626056", "stderr": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100   769  100   769    0     0  50545      0 --:--:-- --:--:-- --:--:-- 54928", "stderr_lines": ["  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current", "                                 Dload  Upload   Total   Spent    Left  Speed", "", "  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0", "100   769  100   769    0     0  50545      0 --:--:-- --:--:-- --:--:-- 54928"], "stdout": "{\"data\":[{\"actions\":{\"revert\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=revert\",\"shutdown\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=shutdown\",\"snapshot\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=snapshot\"},\"id\":\"cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\",\"links\":{\"self\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\"},\"name\":\"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://10.104.212.71:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}", "stdout_lines": ["{\"data\":[{\"actions\":{\"revert\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=revert\",\"shutdown\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=shutdown\",\"snapshot\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=snapshot\"},\"id\":\"cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\",\"links\":{\"self\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\"},\"name\":\"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}],\"links\":{\"self\":\"http://10.104.212.71:9501/v1/volumes\"},\"resourceType\":\"volume\",\"type\":\"collection\"}"]}

TASK [set_fact] ********************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:154
ok: [localhost] => {"ansible_facts": {"vol_id": "cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg=="}, "changed": false}

TASK [Modify the capacity of volume] ***********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:157
ok: [localhost -> None] => {"changed": false, "connection": "close", "content": "{\"actions\":{\"revert\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=revert\",\"shutdown\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=shutdown\",\"snapshot\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=snapshot\"},\"id\":\"cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\",\"links\":{\"self\":\"http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==\"},\"name\":\"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\",\"readOnly\":\"false\",\"replicaCount\":3,\"type\":\"volume\"}\n", "content_length": "658", "content_type": "application/json", "cookies": {}, "date": "Tue, 19 Jun 2018 07:48:08 GMT", "json": {"actions": {"revert": "http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=revert", "shutdown": "http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=shutdown", "snapshot": "http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=snapshot"}, "id": "cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==", "links": {"self": "http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg=="}, "name": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "readOnly": "false", "replicaCount": 3, "type": "volume"}, "msg": "OK (658 bytes)", "redirected": false, "status": 200, "url": "http://10.104.212.71:9501/v1/volumes/cHZjLWMyZjViODU3LTczOTQtMTFlOC04MWE0LTAyYjk4M2YwYTRkYg==?action=resize", "x_api_schemas": "http://10.104.212.71:9501/v1/schemas"}

TASK [Getting the replica pod names] ***********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:169
changed: [localhost -> None] => (item=1) => {"changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print $2'} | awk 'FNR == 1 {print}'", "delta": "0:00:01.124261", "end": "2018-06-19 07:48:10.524351", "item": 1, "rc": 0, "start": "2018-06-19 07:48:09.400090", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-95868", "stdout_lines": ["pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-95868"]}
changed: [localhost -> None] => (item=2) => {"changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print $2'} | awk 'FNR == 2 {print}'", "delta": "0:00:01.166048", "end": "2018-06-19 07:48:12.954022", "item": 2, "rc": 0, "start": "2018-06-19 07:48:11.787974", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-nzvgw", "stdout_lines": ["pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-nzvgw"]}
changed: [localhost -> None] => (item=3) => {"changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print $2'} | awk 'FNR == 3 {print}'", "delta": "0:00:01.498780", "end": "2018-06-19 07:48:15.515523", "item": 3, "rc": 0, "start": "2018-06-19 07:48:14.016743", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-zm8pj", "stdout_lines": ["pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-zm8pj"]}

TASK [Deleting all replica pods at once] *******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:180
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "sleep 30; kubectl delete pod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-95868\" \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-nzvgw\" \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-zm8pj\" -n \"resize-volume\"", "delta": "0:00:31.782105", "end": "2018-06-19 07:48:48.395609", "rc": 0, "start": "2018-06-19 07:48:16.613504", "stderr": "", "stderr_lines": [], "stdout": "pod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-95868\" deleted\npod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-nzvgw\" deleted\npod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-zm8pj\" deleted", "stdout_lines": ["pod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-95868\" deleted", "pod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-nzvgw\" deleted", "pod \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-rep-5d8445f566-zm8pj\" deleted"]}

TASK [Checking if the replica pods are created again.] *****************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:190
FAILED - RETRYING: Checking if the replica pods are created again. (10 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n \"resize-volume\" --show-labels | grep \"pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\" | grep \"openebs/replica=jiva-replica\" | grep Running | wc -l", "delta": "0:00:00.600685", "end": "2018-06-19 07:49:21.747008", "rc": 0, "start": "2018-06-19 07:49:21.146323", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [Login to iSCSI target] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:200
changed: [localhost -> None] => {"changed": true, "connection_changed": true, "devicenodes": [], "nodes": ["iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "iqn.2016-09.com.openebs.jiva:pvc-ec201994-6fd5-11e8-a2d3-02b983f0a4db"]}

TASK [Finding the new device name] *************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:208
changed: [localhost -> None] => {"changed": true, "cmd": "iscsiadm -m session -P3 | egrep 'iqn|disk' | grep disk | awk {'print $4'}", "delta": "0:00:00.056035", "end": "2018-06-19 07:49:29.004884", "rc": 0, "start": "2018-06-19 07:49:28.948849", "stderr": "", "stderr_lines": [], "stdout": "sdc", "stdout_lines": ["sdc"]}

TASK [Running fsck on the new device] **********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:217
fatal: [localhost -> None]: FAILED! => {"attempts": 1, "changed": true, "cmd": "e2fsck -f /dev/sdc -y", "delta": "0:00:06.772260", "end": "2018-06-19 07:49:37.146592", "msg": "non-zero return code", "rc": 1, "start": "2018-06-19 07:49:30.374332", "stderr": "e2fsck 1.42.13 (17-May-2015)", "stderr_lines": ["e2fsck 1.42.13 (17-May-2015)"], "stdout": "/dev/sdc: recovering journal\nPass 1: Checking inodes, blocks, and sizes\nPass 2: Checking directory structure\nPass 3: Checking directory connectivity\nPass 4: Checking reference counts\nPass 5: Checking group summary information\nFree blocks count wrong (1254818, counted=1219919).\nFix? yes\n\nFree inodes count wrong (327669, counted=327462).\nFix? yes\n\n\n/dev/sdc: ***** FILE SYSTEM WAS MODIFIED *****\n/dev/sdc: 218/327680 files (9.2% non-contiguous), 90801/1310720 blocks", "stdout_lines": ["/dev/sdc: recovering journal", "Pass 1: Checking inodes, blocks, and sizes", "Pass 2: Checking directory structure", "Pass 3: Checking directory connectivity", "Pass 4: Checking reference counts", "Pass 5: Checking group summary information", "Free blocks count wrong (1254818, counted=1219919).", "Fix? yes", "", "Free inodes count wrong (327669, counted=327462).", "Fix? yes", "", "", "/dev/sdc: ***** FILE SYSTEM WAS MODIFIED *****", "/dev/sdc: 218/327680 files (9.2% non-contiguous), 90801/1310720 blocks"]}
...ignoring

TASK [Resizing the file system] ****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:229
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "resize2fs /dev/sdc", "delta": "0:00:02.061414", "end": "2018-06-19 07:49:40.626794", "rc": 0, "start": "2018-06-19 07:49:38.565380", "stderr": "resize2fs 1.42.13 (17-May-2015)", "stderr_lines": ["resize2fs 1.42.13 (17-May-2015)"], "stdout": "Resizing the filesystem on /dev/sdc to 1572864 (4k) blocks.\nThe filesystem on /dev/sdc is now 1572864 (4k) blocks long.", "stdout_lines": ["Resizing the filesystem on /dev/sdc to 1572864 (4k) blocks.", "The filesystem on /dev/sdc is now 1572864 (4k) blocks long."]}

TASK [Mount FS] ********************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:240
changed: [localhost -> None] => (item=/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0) => {"changed": true, "cmd": "mount /dev/sdc \"/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0\"", "delta": "0:00:00.762805", "end": "2018-06-19 07:49:42.986449", "item": "/var/lib/kubelet/plugins/kubernetes.io/iscsi/iface-default/10.104.212.71:3260-iqn.2016-09.com.openebs.jiva:pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db-lun-0", "rc": 0, "start": "2018-06-19 07:49:42.223644", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": [], "warnings": ["Consider using mount module rather than running mount"]}
changed: [localhost -> None] => (item=/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db) => {"changed": true, "cmd": "mount /dev/sdc \"/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db\"", "delta": "0:00:00.506599", "end": "2018-06-19 07:49:44.671014", "item": "/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "rc": 0, "start": "2018-06-19 07:49:44.164415", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": [], "warnings": ["Consider using mount module rather than running mount"]}

TASK [Wait] ************************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:250
ok: [localhost] => {"changed": false, "elapsed": 120, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Getting application pod] *****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:253
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep name=percona | awk {'print $2'}", "delta": "0:00:00.974084", "end": "2018-06-19 07:51:49.111202", "rc": 0, "start": "2018-06-19 07:51:48.137118", "stderr": "", "stderr_lines": [], "stdout": "percona-67bb497d48-8rtgj", "stdout_lines": ["percona-67bb497d48-8rtgj"]}

TASK [Deleting the application pod] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:260
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "kubectl delete pod percona-67bb497d48-8rtgj -n \"resize-volume\" --grace-period=0 --force", "delta": "0:00:00.915376", "end": "2018-06-19 07:51:51.190385", "rc": 0, "start": "2018-06-19 07:51:50.275009", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"percona-67bb497d48-8rtgj\" deleted", "stdout_lines": ["pod \"percona-67bb497d48-8rtgj\" deleted"]}

TASK [Check if the application pod is running] *************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:270
FAILED - RETRYING: Check if the application pod is running (10 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "kubectl get pods -n \"resize-volume\" --show-labels | grep \"name=percona\"", "delta": "0:00:00.965412", "end": "2018-06-19 07:52:14.228849", "rc": 0, "start": "2018-06-19 07:52:13.263437", "stderr": "", "stderr_lines": [], "stdout": "percona-67bb497d48-nml2k                                        1/1       Running   0          23s       name=percona,pod-template-hash=2366053804", "stdout_lines": ["percona-67bb497d48-nml2k                                        1/1       Running   0          23s       name=percona,pod-template-hash=2366053804"]}

TASK [Writing data into the volume using dd] ***************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:280
changed: [localhost -> None] => {"changed": true, "cmd": "dd if=/dev/urandom of=\"/var/lib/kubelet/pods/c3058943-7394-11e8-81a4-02b983f0a4db/volumes/kubernetes.io~iscsi/pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db/f1\" bs=4k seek=1250000 count=20000", "delta": "0:00:10.371417", "end": "2018-06-19 07:52:28.911212", "rc": 0, "start": "2018-06-19 07:52:18.539795", "stderr": "20000+0 records in\n20000+0 records out\n81920000 bytes (82 MB, 78 MiB) copied, 10.3501 s, 7.9 MB/s", "stderr_lines": ["20000+0 records in", "20000+0 records out", "81920000 bytes (82 MB, 78 MiB) copied, 10.3501 s, 7.9 MB/s"], "stdout": "", "stdout_lines": []}

TASK [Setting the Pass flag] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:287
ok: [localhost] => {"ansible_facts": {"flag": "TEST PASSED"}, "changed": false}

TASK [Wait] ************************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:291
ok: [localhost] => {"changed": false, "elapsed": 200, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Remove the node label] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:303
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl label node \"kubeminion-02\" app-", "delta": "0:00:00.845884", "end": "2018-06-19 07:55:52.829243", "rc": 0, "start": "2018-06-19 07:55:51.983359", "stderr": "", "stderr_lines": [], "stdout": "node \"kubeminion-02\" labeled", "stdout_lines": ["node \"kubeminion-02\" labeled"]}

TASK [Getting PV name from the pvc] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get pvc percona-claim -n \"resize-volume\" -o custom-columns=:spec.volumeName --no-headers", "delta": "0:00:00.723397", "end": "2018-06-19 07:55:54.722556", "rc": 0, "start": "2018-06-19 07:55:53.999159", "stderr": "", "stderr_lines": [], "stdout": "pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db", "stdout_lines": ["pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db"]}

TASK [Deleting percona deployment] *************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:9
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl delete -f \"percona-openebs-deployment.yaml\" -n \"resize-volume\"", "delta": "0:00:03.064079", "end": "2018-06-19 07:55:58.862237", "rc": 0, "start": "2018-06-19 07:55:55.798158", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps \"percona\" deleted\npersistentvolumeclaim \"percona-claim\" deleted\nservice \"percona-mysql\" deleted", "stdout_lines": ["deployment.apps \"percona\" deleted", "persistentvolumeclaim \"percona-claim\" deleted", "service \"percona-mysql\" deleted"]}

TASK [Checking if the application pod is deleted.] *********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:15
FAILED - RETRYING: Checking if the application pod is deleted. (15 retries left).
FAILED - RETRYING: Checking if the application pod is deleted. (14 retries left).
FAILED - RETRYING: Checking if the application pod is deleted. (13 retries left).
FAILED - RETRYING: Checking if the application pod is deleted. (12 retries left).
FAILED - RETRYING: Checking if the application pod is deleted. (11 retries left).
changed: [localhost -> None] => {"attempts": 6, "changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep name=percona | awk {'print $2'} | wc -l", "delta": "0:00:00.841099", "end": "2018-06-19 07:57:51.101891", "rc": 0, "start": "2018-06-19 07:57:50.260792", "stderr": "The connection to the server 172.28.128.3:6443 was refused - did you specify the right host or port?", "stderr_lines": ["The connection to the server 172.28.128.3:6443 was refused - did you specify the right host or port?"], "stdout": "0", "stdout_lines": ["0"]}

TASK [Checking if the replica pods are deleted] ************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:25
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print$2'} | wc -l", "delta": "0:00:10.391214", "end": "2018-06-19 07:58:02.566908", "rc": 0, "start": "2018-06-19 07:57:52.175694", "stderr": "Unable to connect to the server: net/http: TLS handshake timeout", "stderr_lines": ["Unable to connect to the server: net/http: TLS handshake timeout"], "stdout": "0", "stdout_lines": ["0"]}

TASK [Checking if the corresponding svc is deleted] ********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:35
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "kubectl get svc -n \"resize-volume\" | grep pvc-c2f5b857-7394-11e8-81a4-02b983f0a4db | wc -l", "delta": "0:00:16.272519", "end": "2018-06-19 07:58:19.988677", "rc": 0, "start": "2018-06-19 07:58:03.716158", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "0", "stdout_lines": ["0"]}

TASK [Delete the percona definition yaml file copied] ******************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:45
changed: [localhost -> None] => {"changed": true, "path": "percona-openebs-deployment.yaml", "state": "absent"}

TASK [Delete the test specific namespace] ******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-cleanup.yml:51
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl delete ns \"resize-volume\"", "delta": "0:00:00.301737", "end": "2018-06-19 07:58:22.146656", "rc": 0, "start": "2018-06-19 07:58:21.844919", "stderr": "", "stderr_lines": [], "stdout": "namespace \"resize-volume\" deleted", "stdout_lines": ["namespace \"resize-volume\" deleted"]}

TASK [Setting Cleanup flag to passed] **********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:312
ok: [localhost] => {"ansible_facts": {"cflag": "CLEANUP PASSED"}, "changed": false}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:324
included: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
fatal: [localhost -> None]: FAILED! => {"changed": true, "cmd": "source ~/.profile; killall stern", "delta": "0:00:00.026604", "end": "2018-06-19 07:58:23.815879", "msg": "non-zero return code", "rc": 1, "start": "2018-06-19 07:58:23.789275", "stderr": "mesg: ttyname failed: Inappropriate ioctl for device\nstern: no process found", "stderr_lines": ["mesg: ttyname failed: Inappropriate ioctl for device", "stern: no process found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Send slack notification] *****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml:328
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=48   changed=38   unreachable=0    failed=0   

```