### PR TITLE
Removing ignore_errors in snapshot creation task.

### DIFF
--- a/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
@@ -120,7 +120,6 @@
           until: "'Snapshot created successfully' in sp_out.stdout"
           delay: 60
           retries: 5
-          ignore_errors: true
 
         - name: 8) Creating PVC from the snapshot
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

Removing ignore_errors tag when we check if the snapshot is created successfully.
