### PR TITLE
Developed test for jenkins-upgrade

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/config_change.sh
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/config_change.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-sed -i -e 10d -e 11d -e 13d -e 14d -e 15d /var/jenkins_home/config.xml
+sed -i '\|<denyAnonymousReadAccess>true</denyAnonymousReadAccess>|d' /var/jenkins_home/config.xml
+sed -i '\|</authorizationStrategy>|d' /var/jenkins_home/config.xml 
+sed -i '\|<disableSignup>true</disableSignup>|d' /var/jenkins_home/config.xml
+sed -i '\|<enableCaptcha>false</enableCaptcha>|d' /var/jenkins_home/config.xml
+sed -i '\|</securityRealm>|d' /var/jenkins_home/config.xml
 sed -i 's#FullControlOnceLoggedInAuthorizationStrategy"#AuthorizationStrategy$Unsecured"/#g' /var/jenkins_home/config.xml
 sed -i 's#HudsonPrivateSecurityRealm"#SecurityRealm$None"/#g' /var/jenkins_home/config.xml
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/config_change.sh
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/config_change.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+sed -i -e 10d -e 11d -e 13d -e 14d -e 15d /var/jenkins_home/config.xml
+sed -i 's#FullControlOnceLoggedInAuthorizationStrategy"#AuthorizationStrategy$Unsecured"/#g' /var/jenkins_home/config.xml
+sed -i 's#HudsonPrivateSecurityRealm"#SecurityRealm$None"/#g' /var/jenkins_home/config.xml
+
+
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-prereq.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-prereq.yml
@@ -1,0 +1,13 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+  vars:
+    status: start
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
@@ -41,7 +41,7 @@
 - name: Remove test artifacts
   file:
     path: "{{ result_kube_home.stdout }}/{{ item }}"
-  state: absent
+    state: absent
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
          - "{{job_config_files}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Get pvc name to verify successful pvc deletion
+- name: Get the pvc name.
   shell: source ~/.profile; kubectl get pvc -n {{ namespace }}
   args:
     executable: /bin/bash

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-upgrade-cleanup.yml
@@ -1,0 +1,47 @@
+---
+
+- name: Get pvc name to verify successful pvc deletion
+  shell: source ~/.profile; kubectl get pvc -n {{ namespace }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: pvc
+  changed_when: true
+
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app_yml: "{{ pod_yaml_alias }}"
+
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  vars:
+    ns: "{{ namespace }}"
+    app: jenkins
+
+- name: Confirm pvc pod has been deleted
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  failed_when: "'pvc' and 'Running' in result.stdout"
+  delay: 30
+  retries: 10
+  changed_when: true
+
+
+- name: Delete namespace
+  shell: source ~/.profile; kubectl delete ns {{ namespace }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+
+- name: Remove test artifacts
+  file:
+    path: "{{ result_kube_home.stdout }}/{{ item }}"
+  state: absent
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items:
+         - "{{job_config_files}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
@@ -5,10 +5,21 @@ jenkins_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/
 
 pod_yaml_alias: jenkins.yml
 
- 
-jenkinsold: 2.124 
+operator_ns: openebs
 
-jenkinsnew: 2.125 
+
+replace_item: 
+
+  - lts
+
+  - 2.124 
+
+replace_with: 
+  
+  - 2.124
+
+  - 2.125
+
 
 namespace: jenkins-upgrade
 
@@ -16,8 +27,6 @@ job_config_files:
   - template.xml
   - config_change.sh
 
-
-utils_path: openebs/e2e/ansible/playbooks/utils
 
 test_pod_regex: maya*|openebs*|pvc*|jenkins*
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
@@ -5,8 +5,7 @@ jenkins_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/
 
 pod_yaml_alias: jenkins.yml
 
-#volume_claim: 
-
+ 
 jenkinsold: 2.124 
 
 jenkinsnew: 2.125 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
@@ -1,0 +1,25 @@
+---
+test_name: hyperconverged_jenkins_upgrade_on_k8s
+
+jenkins_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/jenkins/jenkins.yml
+
+pod_yaml_alias: jenkins.yml
+
+#volume_claim: 
+
+jenkinsold: 2.124 
+
+jenkinsnew: 2.125 
+
+namespace: jenkins-upgrade
+
+job_config_files: 
+  - template.xml
+  - config_change.sh
+
+
+utils_path: openebs/e2e/ansible/playbooks/utils
+
+test_pod_regex: maya*|openebs*|pvc*|jenkins*
+
+test_log_path: setup/logs/jenkins_test.log

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-pod-vars.yml
@@ -12,11 +12,14 @@ replace_item:
 
   - lts
 
+replace_item1:
+
   - 2.124 
 
 replace_with: 
   
   - 2.124
+replace_with1:
 
   - 2.125
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -106,8 +106,9 @@
          files_to_copy: "{{ job_config_files }}"
 
      - name: 4b) Copy job configuration files to jenkins-pod from master.
-       shell: |
-         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}}  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
+       shell: >
+         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}} 
+         {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
@@ -115,7 +116,8 @@
    
      - name: 5) Run the config_change.sh file for required changes inside pod.
        shell: > 
-          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} -- bash -c "sh /var/jenkins_home/config_change.sh"
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} 
+          -- bash -c "sh /var/jenkins_home/config_change.sh"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -148,7 +150,8 @@
      - name: 6)  Create and Build one sample job inside pod.
        shell: >
          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
-         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 create-job sample < /var/jenkins_home/template.xml";
+         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080
+            create-job sample < /var/jenkins_home/template.xml";
          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace  }} 
          -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 build sample" 
        args:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -87,7 +87,7 @@
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-       untill: "'saved' in  result.stdout"
+       until: "'saved' in  result.stdout"
        delay: 80
        retries: 8
 
@@ -146,7 +146,7 @@
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }}
           -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 console sample"
-       arge:
+       args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
        register: First_Build

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -1,0 +1,232 @@
+#k8s-jenkins-upgrade.yml
+# Description: Deploy Jenkins application using OpenEBS volume.
+# Created jobs and builds inside mounted path and role upgrade pods.
+# Check for jobs and build after Upgrade.
+
+###############################################################################################
+#Test Steps:
+#1. Check whether the OpenEBS components are deployed.
+#2. Download the test artifacts to k8s master.
+#3. Deploy Jenkins application.
+#4. Check if the application pod is up and running
+#5. Check if the Jenkins service us up.
+#6. Perform Job creation and building activity inside pod.
+#7. Check for data persitency.
+###############################################################################################
+
+- hosts: localhost
+
+  vars_files:
+    - k8s-jenkins-pod-vars.yml
+ 
+  tasks:
+
+   - block:
+
+     - include: k8s-jenkins-pod-prereq.yml
+      
+     - name: Download YAML for jenkins 
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
+       vars:
+         url: "{{ jenkins_link }}"
+         dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+
+     - name: Check whether maya-apiserver is deployed
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       vars:
+          ns: "{{ operator_ns }}"
+          app: maya-api
+
+     - name: Replace jenkins pod version
+       lineinfile:
+         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+         regexp: "image: jenkins/jenkins:"
+         line: "     image: jenkins/jenkins:{{jenkinsold}}"
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+    
+     - name: Create namespace for deployement.
+       shell: source ~/.profile; kubectl create ns {{namespace}}
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+      
+     - name:  Deploy jenkins pod 
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       vars:
+          app_yml: "{{ pod_yaml_alias }}"
+          ns: "{{ namespace }}"
+    
+     - name:  Confirm pod status is running
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       vars:
+          ns: "{{ namespace }}"
+          app: jenkins
+
+     - name: Verify that the jenkins is a cluster service
+       shell: source ~/.profile; kubectl get svc -n {{namespace}}
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: result_service
+       failed_when: "'jenkins-svc' not in result_service.stdout"
+
+     - name: Get the name of the pod.
+       shell: source ~/.profile; kubectl get pods -n {{namespace}} | grep jenkins | awk {'print $1'}
+       args: 
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: jenkins_pod_name
+
+         
+     - name: Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
+       shell: >
+          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
+          -- wget -P /var/jenkins_home http://localhost:8080/jnlpJars/jenkins-cli.jar
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       untill: "'saved' in  result.stdout"
+       delay: 80
+       retries: 8
+
+     - name: Copy job configuration files to master.
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
+       vars:
+         destination_node: "{{groups['kubernetes-kubemasters'].0}}"
+         files_to_copy: "{{ job_config_files }}"
+
+     - name: Copy job configuration files to jenkins-pod from master.
+       shell: |
+         source ~/.profile; kubectl cp template.xml  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/
+         source ~/.profile; kubectl cp config_change.sh {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+   
+     - name: Run the config_change.sh file for required changes inside pod.
+       shell: > 
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{ namespace }} -- bash -c "sh /var/jenkins_home/config_change.sh"
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+     - name: Retrieve Password of jenkins running pods.
+       shell: >
+          source ~/.profile; kubectl exec  {{ jenkins_pod_name.stdout }} -n {{ namespace }}
+          -- bash -c "cat /var/jenkins_home/secrets/initialAdminPassword"
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: jenkins_password
+  
+     - name: Restart the jenkins pod for running jenkins actions.
+       shell: >
+          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
+          -- java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 restart
+          --username admin --password {{ jenkins_password.stdout }}
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+     - name: wait for 20 seconds.
+       wait_for:
+          timeout: 20
+ 
+     - name: Create and Build one sample job inside pod.
+       shell: |
+         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 create-job sample < /var/jenkins_home/template.xml"
+         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace  }} -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 build sample" 
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+    
+     - name: Running a build job
+       shell: >
+          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }}
+          -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 console sample"
+       arge:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+       register: First_Build
+  
+     - name: (2) Replace jenkins pod version 
+       lineinfile:
+         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+         regexp: "image: jenkins/jenkins:"
+         line: "     image: jenkins/jenkins:{{jenkinsnew}}"
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+     - name: (2) Deploy jenkins pod Again
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       vars:
+          app_yml: "{{ pod_yaml_alias }}"
+          ns: "{{ namespace }}"
+
+     - name: (2) Confirm pod status is running
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       vars:
+          ns: "{{namespace}}"
+          app: jenkins
+
+     - name: (2) Verify that the jenkins is a cluster service
+       shell: source ~/.profile; kubectl get svc
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: result_service_2
+       failed_when: "'jenkins-svc' not in result_service.stdout"
+
+     - name: (2) Get the name of the pod.
+       shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep jenkins | awk {'print $1'}
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: jenkins_pod_name_2
+
+     - name: Create a new build from existing  job inside pod.
+       shell: > 
+          source ~/.profie; kubectl exec  {{ jenkins_pod_name_2.stdout }} -n {{ namespace }} 
+          -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 console sample"
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: Second_Build
+ 
+     - name: Compare
+       set_fact:
+         flag: "Test Passed"
+       when: "First_Build.stdout == Second_Build.stdout"
+    
+     rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Test Failed"
+
+     always:
+       - block:
+
+           - include: k8s-jenkins-pod-upgrade-cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+         always:
+
+           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+             vars:
+               status: stop
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+ 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -86,7 +86,9 @@
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: jenkins_pod_name
 
-         
+
+     
+
      - name: 4) Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{namespace}} 
@@ -95,9 +97,9 @@
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        until: "'saved' in result.stdout"
-       delay: 30
+       delay: 60
        retries: 2
-       ignore_errors: true
+       failed_when: false       
 
      - name: 4a)  Copy job configuration files to master.
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
@@ -106,9 +108,8 @@
          files_to_copy: "{{ job_config_files }}"
 
      - name: 4b) Copy job configuration files to jenkins-pod from master.
-       shell: >
-         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}} 
-         {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
+       shell: |
+         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}}  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
@@ -116,8 +117,7 @@
    
      - name: 5) Run the config_change.sh file for required changes inside pod.
        shell: > 
-          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} 
-          -- bash -c "sh /var/jenkins_home/config_change.sh"
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} -- bash -c "sh /var/jenkins_home/config_change.sh"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -140,6 +140,11 @@
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+     - name: wait for some time to jenkins save changes.
+       wait_for:
+           timeout: 120
+
+
      - name:  Confirm pod status is running
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
        vars:
@@ -150,8 +155,7 @@
      - name: 6)  Create and Build one sample job inside pod.
        shell: >
          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
-         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080
-            create-job sample < /var/jenkins_home/template.xml";
+         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 create-job sample < /var/jenkins_home/template.xml";
          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace  }} 
          -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 build sample" 
        args:
@@ -204,7 +208,7 @@
        register: jenkins_pod_name_2
 
      - name: Verify jenkins-version post upgrade.
-       shell: source ~/.profile;  kubectl describe pod {{jenkins_pod_name_2.stdout }}| grep Image: | awk {'print $2'} 
+       shell: source ~/.profile;  kubectl describe pod {{jenkins_pod_name_2.stdout }}| grep Image | awk {'print $2'} 
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -5,13 +5,18 @@
 
 ###############################################################################################
 #Test Steps:
-#1. Check whether the OpenEBS components are deployed.
-#2. Download the test artifacts to k8s master.
-#3. Deploy Jenkins application.
-#4. Check if the application pod is up and running
-#5. Check if the Jenkins service us up.
-#6. Perform Job creation and building activity inside pod.
-#7. Check for data persitency.
+
+#1.Check whether the OpenEBS components are deployed.
+#2.Deployed jenkins application pod with any version (Here version=2.124).
+#3.Download the test artifacts to k8s master.(jenkins-cli.war , change_onfig.sh, config.xml file for job creation).
+#4.Run the Script file in order to get required changes inside application pod and restart the pod for save change.
+#5.Created sample job and build it.
+#6.Upgraded application pod with newer version(here version=2.125).
+#7.Downloading jenkins-cli.jar file inside var/jenkins_home mounted path of jenkins application creation and building of jobs.
+#8.Perform build operation with the existing created job.
+#9.Compare both the jobs buil.
+#(Way to Check for data persitency inside application pod.)
+
 ###############################################################################################
 
 - hosts: localhost
@@ -24,47 +29,49 @@
    - block:
 
      - include: k8s-jenkins-pod-prereq.yml
+
+     - name: 1)  Check whether maya-apiserver is deployed
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       vars:
+          ns: "{{ operator_ns }}"
+          app: apiserver
+
       
-     - name: Download YAML for jenkins 
+     - name: 2)  Download YAML for jenkins 
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/get_url.yml"
        vars:
          url: "{{ jenkins_link }}"
          dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
 
-     - name: Check whether maya-apiserver is deployed
-       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+
+     - name: 2a) Replace jenkins pod version
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
        vars:
-          ns: "{{ operator_ns }}"
-          app: maya-api
-
-     - name: Replace jenkins pod version
-       lineinfile:
-         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-         regexp: "image: jenkins/jenkins:"
-         line: "     image: jenkins/jenkins:{{jenkinsold}}"
-       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
+         path: "{{ result_kube_home.stdout }}/jenkins.yml"
+         regex1: "{{replace_item}}"
+         regex2: "{{replace_with}}"
+       delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
     
-     - name: Create namespace for deployement.
+     - name: Create namespace for deployment.
        shell: source ~/.profile; kubectl create ns {{namespace}}
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
       
-     - name:  Deploy jenkins pod 
+     - name: 3) Deploy jenkins pod 
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
        vars:
           app_yml: "{{ pod_yaml_alias }}"
           ns: "{{ namespace }}"
     
-     - name:  Confirm pod status is running
+     - name: 3a) Confirm pod status is running
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
        vars:
           ns: "{{ namespace }}"
           app: jenkins
 
-     - name: Verify that the jenkins is a cluster service
+     - name: 3b) Verify that the jenkins is a cluster service
        shell: source ~/.profile; kubectl get svc -n {{namespace}}
        args:
          executable: /bin/bash
@@ -72,7 +79,7 @@
        register: result_service
        failed_when: "'jenkins-svc' not in result_service.stdout"
 
-     - name: Get the name of the pod.
+     - name: 3c) Get the name of the pod.
        shell: source ~/.profile; kubectl get pods -n {{namespace}} | grep jenkins | awk {'print $1'}
        args: 
          executable: /bin/bash
@@ -80,48 +87,49 @@
        register: jenkins_pod_name
 
          
-     - name: Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
+     - name: 4) Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
        shell: >
-          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
+          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{namespace}} 
           -- wget -P /var/jenkins_home http://localhost:8080/jnlpJars/jenkins-cli.jar
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-       until: "'saved' in  result.stdout"
-       delay: 80
-       retries: 8
+       until: "'saved' in result.stdout"
+       delay: 30
+       retries: 2
+       ignore_errors: true
 
-     - name: Copy job configuration files to master.
+     - name: 4a)  Copy job configuration files to master.
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
        vars:
          destination_node: "{{groups['kubernetes-kubemasters'].0}}"
          files_to_copy: "{{ job_config_files }}"
 
-     - name: Copy job configuration files to jenkins-pod from master.
+     - name: 4b) Copy job configuration files to jenkins-pod from master.
        shell: |
-         source ~/.profile; kubectl cp template.xml  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/
-         source ~/.profile; kubectl cp config_change.sh {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/
+         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}}  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+       with_items: "{{ job_config_files }}"
    
-     - name: Run the config_change.sh file for required changes inside pod.
+     - name: 5) Run the config_change.sh file for required changes inside pod.
        shell: > 
-          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{ namespace }} -- bash -c "sh /var/jenkins_home/config_change.sh"
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} -- bash -c "sh /var/jenkins_home/config_change.sh"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-     - name: Retrieve Password of jenkins running pods.
+     - name: 5a)  Retrieve Password of jenkins running pods.
        shell: >
-          source ~/.profile; kubectl exec  {{ jenkins_pod_name.stdout }} -n {{ namespace }}
+          source ~/.profile; kubectl exec  {{ jenkins_pod_name.stdout }} -n {{namespace}}
           -- bash -c "cat /var/jenkins_home/secrets/initialAdminPassword"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: jenkins_password
   
-     - name: Restart the jenkins pod for running jenkins actions.
+     - name: 5b) Restart the jenkins pod for running jenkins actions.
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
           -- java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 restart
@@ -130,19 +138,24 @@
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-     - name: wait for 20 seconds.
-       wait_for:
-          timeout: 20
+     - name:  Confirm pod status is running
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+       vars:
+          ns: "{{ namespace }}"
+          app: jenkins     
+
  
-     - name: Create and Build one sample job inside pod.
-       shell: |
-         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 create-job sample < /var/jenkins_home/template.xml"
-         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace  }} -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 build sample" 
+     - name: 6)  Create and Build one sample job inside pod.
+       shell: >
+         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
+         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 create-job sample < /var/jenkins_home/template.xml";
+         source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace  }} 
+         -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 build sample" 
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
     
-     - name: Running a build job
+     - name: 6a)  Running a build job
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }}
           -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 console sample"
@@ -151,41 +164,52 @@
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
        register: First_Build
   
-     - name: (2) Replace jenkins pod version 
-       lineinfile:
-         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
-         regexp: "image: jenkins/jenkins:"
-         line: "     image: jenkins/jenkins:{{jenkinsnew}}"
-       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+     - name: 7)  Replace jenkins pod version 
+       include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+       vars:
+         path: "{{ result_kube_home.stdout }}/jenkins.yml"
+         regex1: "{{replace_item}}"
+         regex2: "{{replace_with}}"
+       delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-     - name: (2) Deploy jenkins pod Again
+
+     - name: 7a)  Deploy jenkins pod Again
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
        vars:
           app_yml: "{{ pod_yaml_alias }}"
           ns: "{{ namespace }}"
 
-     - name: (2) Confirm pod status is running
+     - name: 7b)  Confirm pod status is running
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
        vars:
           ns: "{{namespace}}"
-          app: jenkins
-
-     - name: (2) Verify that the jenkins is a cluster service
-       shell: source ~/.profile; kubectl get svc
+          app: jenkins     
+       
+     - name: 7c)  Verify that the jenkins is a cluster service
+       shell: source ~/.profile; kubectl get svc -n {{ namespace }}
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: result_service_2
        failed_when: "'jenkins-svc' not in result_service.stdout"
 
-     - name: (2) Get the name of the pod.
+     - name: 8) Get the name of the pod.
        shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep jenkins | awk {'print $1'}
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: jenkins_pod_name_2
 
-     - name: Create a new build from existing  job inside pod.
+     - name: Verify jenkins-version post upgrade.
+       shell: source ~/.profile;  kubectl describe pod {{jenkins_pod_name_2.stdout }}| grep Image: | awk {'print $2'} 
+       args:
+         executable: /bin/bash
+       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       register: version
+       failed_when: "'jenkins/jenkins:2.125' not in version.stdout"
+       
+         
+     - name: 8b) Create a new build from existing  job inside pod.
        shell: > 
           source ~/.profie; kubectl exec  {{ jenkins_pod_name_2.stdout }} -n {{ namespace }} 
           -- bash -c "java -jar /var/jenkins_home/jenkins-cli.jar -s http://localhost:8080 console sample"
@@ -194,10 +218,10 @@
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: Second_Build
  
-     - name: Compare
+     - name: Compare between two builds
        set_fact:
          flag: "Test Passed"
-       when: "First_Build.stdout == Second_Build.stdout"
+       when: "'Hello World!' in Second_Build.stdout"
     
      rescue:
        - name: Test Failed

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -87,6 +87,8 @@
        register: jenkins_pod_name
 
 
+     
+
      - name: 4) Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{namespace}} 
@@ -106,9 +108,8 @@
          files_to_copy: "{{ job_config_files }}"
 
      - name: 4b) Copy job configuration files to jenkins-pod from master.
-       shell: >
-         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}} 
-         {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
+       shell: |
+         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}}  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
@@ -116,8 +117,7 @@
    
      - name: 5) Run the config_change.sh file for required changes inside pod.
        shell: > 
-          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} 
-          -- bash -c "sh /var/jenkins_home/config_change.sh"
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} -- bash -c "sh /var/jenkins_home/config_change.sh"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -140,16 +140,15 @@
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-     - name: wait for some time to jenkins save changes.
-       wait_for:
-           timeout: 120
-
-
      - name:  Confirm pod status is running
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
        vars:
           ns: "{{ namespace }}"
-          app: jenkins     
+          app: jenkins    
+
+     - name: wait for some time to jenkins save changes.
+       wait_for:
+           timeout: 60
 
  
      - name: 6)  Create and Build one sample job inside pod.
@@ -208,7 +207,7 @@
        register: jenkins_pod_name_2
 
      - name: Verify jenkins-version post upgrade.
-       shell: source ~/.profile;  kubectl describe pod {{jenkins_pod_name_2.stdout }}| grep Image | awk {'print $2'} 
+       shell: source ~/.profile; kubectl describe pod {{jenkins_pod_name_2.stdout }} -n {{ namespace }}  | grep Image | awk {'print $2'} 
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -171,8 +171,8 @@
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
        vars:
          path: "{{ result_kube_home.stdout }}/jenkins.yml"
-         regex1: "{{replace_item}}"
-         regex2: "{{replace_with}}"
+         regex1: "{{replace_item1}}"
+         regex2: "{{replace_with1}}"
        delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -87,8 +87,6 @@
        register: jenkins_pod_name
 
 
-     
-
      - name: 4) Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{namespace}} 
@@ -108,8 +106,9 @@
          files_to_copy: "{{ job_config_files }}"
 
      - name: 4b) Copy job configuration files to jenkins-pod from master.
-       shell: |
-         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}}  {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
+       shell: >
+         source ~/.profile; kubectl cp {{result_kube_home.stdout}}/{{item}} 
+         {{namespace}}/{{ jenkins_pod_name.stdout }}:/var/jenkins_home/   
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
@@ -117,7 +116,8 @@
    
      - name: 5) Run the config_change.sh file for required changes inside pod.
        shell: > 
-          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} -- bash -c "sh /var/jenkins_home/config_change.sh"
+          source ~/.profile; kubectl exec {{  jenkins_pod_name.stdout }} -n {{namespace}} 
+          -- bash -c "sh /var/jenkins_home/config_change.sh"
        args:
          executable: /bin/bash
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/template.xml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/template.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders>
+        <hudson.tasks.Shell>
+            <command>echo 'Hello World!'</command>
+        </hudson.tasks.Shell>
+    </builders>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
Signed-off-by: vibhor995 <vvibhr995@gmail.com>


**Data persistent check inside application pod before and after rolling upgrade**:

1.  Deploying Jenkins application pod with any version (my case: 2.124).
2.  Downloading Jenkins-cli.war file and Copying configuration change script and job configuration XML 
     the file inside the pod.
3. Running the Copied artefacts (i.e script file) for required changes.
4. Created a job name "sample" and Build it in order to get output. 
5. Upgraded Jenkins pod with the new version and tried to build new job with the existing "sample" job.
6. Comparing the sample jobs created before and after changing Jenkins pod version.


    

2.  **Conclusion**

   Data and jobs are persisting inside the pods and Jobs can be created after rolling upgrade of the pod which is running in OpenEBS PVC's




**Special notes for your reviewer**:
Please review @dargasudarshan  @ksatchit 