### PR TITLE
Modified the playbook to check the data existence in cloned volume.

### DIFF
--- a/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml
@@ -68,20 +68,9 @@
             ns: "{{ namespace }}"
             app: percona
 
-        - name: 5a) Get IP address of percona mysql pod
-          shell: source ~/.profile; kubectl describe pod percona -n "{{ namespace }}"
-          args:
-            executable: /bin/bash
-          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-          register: result_IP
-
-        - name: 5b) Set IP of Pod to variable
-          set_fact:
-            pod_ip: "{{ result_IP.stdout_lines[7].split()[1] }}"
-
         - name: 6) Write a test database into percona mysql
           shell: |
-            sleep 120 #db init time
+            sleep 180 #db init time
             kubectl exec -it percona -n {{ namespace }} -- mysql -uroot -pk8sDem0 -e "create database tdb;"
             kubectl exec -it percona -n {{ namespace }} -- mysql -uroot -pk8sDem0 -e "create table ttbl (Data VARCHAR(20));" tdb
             kubectl exec -it percona -n {{ namespace }} -- mysql -uroot -pk8sDem0 -e "insert into ttbl (Data) VALUES ('tdata');" tdb
@@ -209,23 +198,10 @@
           retries: 5
           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-        - name: 10c) Get new percona pod details
-          shell: >
-            source ~/.profile;
-            kubectl get pods -n "{{ namespace }}" -o wide | grep percona-new
-          args:
-            executable: /bin/bash
-          register: new_pod
-          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
-        - name: 10d) Store new percona pod IP in variable
-          set_fact:
-            new_pod_ip: "{{ new_pod.stdout.split()[5] }}"
-
         - name: 11) Verify successful snapshot restore by db query
           shell: |
             sleep 120 # DB init
-            kubectl exec -it percona -n {{ namespace }} -- mysql -uroot -pk8sDem0 -e "select * from ttbl;" tdb
+            kubectl exec -it percona-new -n {{ namespace }} -- mysql -uroot -pk8sDem0 -e "select * from ttbl;" tdb
           args:
             executable: /bin/bash
           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- After creating clone, checking if the data written is existing.
- Removing the unused code.

**Special notes for your reviewer**:
```
giri@vagrant-host:~/openebs/e2e/ansible$ ansible-playbook playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/openebs/e2e/ansible/ansible.cfg as config file
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions. This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: include is kept for backwards compatibility but usage is discouraged. The module documentation details page may explain more about this rationale.. This feature will be removed in 
a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
statically imported: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml
statically imported: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/prerequisites.yml

PLAYBOOK: test-kubectl-snapshot.yml ************************************************************************************************************************************************************************
1 plays in playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml

PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [1a) Get $HOME of K8s master for kubernetes user] *****************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/prerequisites.yml:1
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.007493", "end": "2018-06-29 10:41:14.383169", "rc": 0, "start": "2018-06-29 10:41:14.375676", "stderr": "", "stderr_lines": [], "stdout": "/home/ubuntu", "stdout_lines": ["/home/ubuntu"]}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/prerequisites.yml:17
included: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; nohup stern --all-namespaces \"maya*|openebs*|pvc*|snapshot*\" --kubeconfig /home/ubuntu/.kube/config --since 1m > /home/ubuntu/setup/logs/snap_create_revert.log &", "delta": "0:00:00.041191", "end": "2018-06-29 10:41:15.972434", "rc": 0, "start": "2018-06-29 10:41:15.931243", "stderr": "mesg: ttyname failed: Inappropriate ioctl for device\n/bin/bash: /home/ubuntu/setup/logs/snap_create_revert.log: No such file or directory", "stderr_lines": ["mesg: ttyname failed: Inappropriate ioctl for device", "/bin/bash: /home/ubuntu/setup/logs/snap_create_revert.log: No such file or directory"], "stdout": "", "stdout_lines": []}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [1) Check if maya-apiserver is running.] **************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:34
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml for localhost

TASK [Check apiserver pod status] **************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml:2
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n openebs | grep apiserver", "delta": "0:00:02.114524", "end": "2018-06-29 10:41:19.618925", "rc": 0, "start": "2018-06-29 10:41:17.504401", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver-66f97d5dfd-57qnh                1/1       Running   0          5m", "stdout_lines": ["maya-apiserver-66f97d5dfd-57qnh                1/1       Running   0          5m"]}

TASK [2) Copy the snapshot specific files to K8s master] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:40
changed: [localhost -> None] => (item=snapshot.yml) => {"changed": true, "checksum": "e091f39b3432f00054bf4be0885322dce08ca7e3", "dest": "/home/ubuntu/snapshot.yml", "gid": 1000, "group": "ubuntu", "item": "snapshot.yml", "md5sum": "e6b3eaed93f5ff68850db5347b2a784d", "mode": "0664", "owner": "ubuntu", "size": 185, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1530268879.92-14813729322533/source", "state": "file", "uid": 1000}
changed: [localhost -> None] => (item=snapshot-claim.yml) => {"changed": true, "checksum": "a4e86015d800ba934e1af0bc4ca0316ad37575b7", "dest": "/home/ubuntu/snapshot-claim.yml", "gid": 1000, "group": "ubuntu", "item": "snapshot-claim.yml", "md5sum": "2fba63a0e25057ef45e12802077a934e", "mode": "0664", "owner": "ubuntu", "size": 305, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1530268883.32-40179300062502/source", "state": "file", "uid": 1000}

TASK [3) Check if snapshot-controller is running.] *********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:47
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml for localhost

TASK [Check openebs-snapshot-controller pod status] ********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml:2
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n openebs | grep openebs-snapshot-controller", "delta": "0:00:01.944168", "end": "2018-06-29 10:41:28.251363", "rc": 0, "start": "2018-06-29 10:41:26.307195", "stderr": "", "stderr_lines": [], "stdout": "openebs-snapshot-controller-78dbf7bb8d-t7cfz   2/2       Running   0          5m", "stdout_lines": ["openebs-snapshot-controller-78dbf7bb8d-t7cfz   2/2       Running   0          5m"]}

TASK [4) Create test specific namespace] *******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:53
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl create ns k8s-snapshot", "delta": "0:00:00.643225", "end": "2018-06-29 10:41:29.707391", "rc": 0, "start": "2018-06-29 10:41:29.064166", "stderr": "", "stderr_lines": [], "stdout": "namespace \"k8s-snapshot\" created", "stdout_lines": ["namespace \"k8s-snapshot\" created"]}

TASK [4) Deploy percona mysql pod] *************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:59
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl apply -f \"https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml\" -n \"k8s-snapshot\"", "delta": "0:00:03.080649", "end": "2018-06-29 10:41:33.697665", "rc": 0, "start": "2018-06-29 10:41:30.617016", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona\" created\npersistentvolumeclaim \"demo-vol1-claim\" created", "stdout_lines": ["pod \"percona\" created", "persistentvolumeclaim \"demo-vol1-claim\" created"]}

TASK [5) Confirm pod status is running] ********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:65
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml for localhost

TASK [Check percona pod status] ****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_check.yml:2
FAILED - RETRYING: Check percona pod status (15 retries left).
FAILED - RETRYING: Check percona pod status (14 retries left).
FAILED - RETRYING: Check percona pod status (13 retries left).
FAILED - RETRYING: Check percona pod status (12 retries left).
FAILED - RETRYING: Check percona pod status (11 retries left).
FAILED - RETRYING: Check percona pod status (10 retries left).
FAILED - RETRYING: Check percona pod status (9 retries left).
FAILED - RETRYING: Check percona pod status (8 retries left).
FAILED - RETRYING: Check percona pod status (7 retries left).
FAILED - RETRYING: Check percona pod status (6 retries left).
FAILED - RETRYING: Check percona pod status (5 retries left).
FAILED - RETRYING: Check percona pod status (4 retries left).
FAILED - RETRYING: Check percona pod status (3 retries left).
changed: [localhost -> None] => {"attempts": 14, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n k8s-snapshot | grep percona", "delta": "0:00:01.016312", "end": "2018-06-29 10:48:31.118756", "rc": 0, "start": "2018-06-29 10:48:30.102444", "stderr": "", "stderr_lines": [], "stdout": "percona                                                         1/1       Running   0          6m", "stdout_lines": ["percona                                                         1/1       Running   0          6m"]}

TASK [6) Write a test database into percona mysql] *********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:82
changed: [localhost -> None] => {"changed": true, "cmd": "sleep 180 #db init time\n kubectl exec -it percona -n k8s-snapshot -- mysql -uroot -pk8sDem0 -e \"create database tdb;\"\n kubectl exec -it percona -n k8s-snapshot -- mysql -uroot -pk8sDem0 -e \"create table ttbl (Data VARCHAR(20));\" tdb\n kubectl exec -it percona -n k8s-snapshot -- mysql -uroot -pk8sDem0 -e \"insert into ttbl (Data) VALUES ('tdata');\" tdb\n kubectl exec -it percona -n k8s-snapshot -- mysql -uroot -pk8sDem0 -e \"flush tables with read lock;\"", "delta": "0:03:07.786380", "end": "2018-06-29 10:51:39.998080", "failed_when_result": false, "rc": 0, "start": "2018-06-29 10:48:32.211700", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.\nUnable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure.", "Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [6a) Perform fs sync on percona pod before taking snap] ***********************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:95
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl exec \"percona\" -n k8s-snapshot -- bash -c \"sync;sync;sync\"", "delta": "0:00:02.065251", "end": "2018-06-29 10:51:43.271508", "rc": 0, "start": "2018-06-29 10:51:41.206257", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [7) Creating the volume snapshot] *********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:104
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl apply -f \"snapshot.yml\"", "delta": "0:00:01.397978", "end": "2018-06-29 10:51:45.698452", "rc": 0, "start": "2018-06-29 10:51:44.300474", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io \"snapshot-demo\" created", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io \"snapshot-demo\" created"]}

TASK [7a) Check if the snapshot is created successfully] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:114
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "sleep 20 ; source ~/.profile; kubectl describe volumesnapshot snapshot-demo -n \"k8s-snapshot\" | grep Message", "delta": "0:00:21.006987", "end": "2018-06-29 10:52:08.135230", "rc": 0, "start": "2018-06-29 10:51:47.128243", "stderr": "", "stderr_lines": [], "stdout": "    Message:               Snapshot created successfully", "stdout_lines": ["    Message:               Snapshot created successfully"]}

TASK [8) Creating PVC from the snapshot] *******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:124
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_task.yml for localhost

TASK [Deploy application files] ****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_task.yml:2
changed: [localhost -> None] => (item=snapshot-claim.yml) => {"changed": true, "cmd": "source ~/.profile; kubectl apply -f \"/home/ubuntu/snapshot-claim.yml\" -n k8s-snapshot", "delta": "0:00:01.232037", "end": "2018-06-29 10:52:11.024662", "item": "snapshot-claim.yml", "rc": 0, "start": "2018-06-29 10:52:09.792625", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"demo-snap-vol-claim\" created", "stdout_lines": ["persistentvolumeclaim \"demo-snap-vol-claim\" created"]}

TASK [8a) Checking if the pvc is created successfully] *****************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:130
FAILED - RETRYING: 8a) Checking if the pvc is created successfully (10 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get pvc -n \"k8s-snapshot\" | grep demo-snap-vol-claim", "delta": "0:00:00.569981", "end": "2018-06-29 10:53:16.198610", "rc": 0, "start": "2018-06-29 10:53:15.628629", "stderr": "", "stderr_lines": [], "stdout": "demo-snap-vol-claim   Bound     pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db   5Gi        RWO            snapshot-promoter   1m", "stdout_lines": ["demo-snap-vol-claim   Bound     pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db   5Gi        RWO            snapshot-promoter   1m"]}

TASK [9) Obtaining new PV name] ****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:140
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get pv | grep demo-snap-vol-claim | awk {'print $1'}", "delta": "0:00:01.042904", "end": "2018-06-29 10:53:18.448234", "rc": 0, "start": "2018-06-29 10:53:17.405330", "stderr": "", "stderr_lines": [], "stdout": "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db", "stdout_lines": ["pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db"]}

TASK [9a) Obtaining the new controller pod name] ***********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:147
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get po -n \"k8s-snapshot\" | grep pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db | grep ctrl | awk {'print $1'}", "delta": "0:00:00.875596", "end": "2018-06-29 10:53:20.581719", "rc": 0, "start": "2018-06-29 10:53:19.706123", "stderr": "", "stderr_lines": [], "stdout": "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx", "stdout_lines": ["pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx"]}

TASK [9b) Obtaining the controller container name] *********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:154
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get pods pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx -n k8s-snapshot -o jsonpath='{.spec.containers[*].name}' | awk '{print $1}'", "delta": "0:00:00.640855", "end": "2018-06-29 10:53:22.324360", "rc": 0, "start": "2018-06-29 10:53:21.683505", "stderr": "", "stderr_lines": [], "stdout": "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-con", "stdout_lines": ["pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-con"]}

TASK [9c) Checking if the sync completed] ******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:161
FAILED - RETRYING: 9c) Checking if the sync completed (10 retries left).
FAILED - RETRYING: 9c) Checking if the sync completed (9 retries left).
changed: [localhost -> None] => {"attempts": 3, "changed": true, "cmd": "source ~/.profile; kubectl logs pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx -c pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-con -n k8s-snapshot", "delta": "0:00:00.873109", "end": "2018-06-29 10:56:51.875638", "rc": 0, "start": "2018-06-29 10:56:51.002529", "stderr": "", "stderr_lines": [], "stdout": "mount: special device /host/dev does not exist\ntime=\"2018-06-29T10:52:16Z\" level=info msg=\"Listening on :9501\" \ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Register Replica, Address: 10.1.2.19 Uptime: 2m1.307878s State: closed Type: Backend RevisionCount: 0 PeerCount: 0\" \n10.1.2.19 - - [29/Jun/2018:10:54:18 +0000] \"POST /v1/register HTTP/1.1\" 200 0\ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Connecting to remote: 10.1.2.19:9502\" \ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Opening: 10.1.2.19:9502\" \ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Adding backend: tcp://10.1.2.19:9502\" \ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Start monitoring tcp://10.1.2.19:9502\" \ntime=\"2018-06-29T10:54:18Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:18Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:20Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:20Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:22Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:22Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:25Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:25Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:27Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:27Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:29Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:29Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:31Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:31Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:33Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:33Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:35Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:35Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:37Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:37Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:39Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:39Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:41Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:43Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:43Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:45Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:45Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:47Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:47Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:49Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:49Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:51Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:51Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:53Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:53Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:55Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:55Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:57Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:57Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:54:59Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:54:59Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:01Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:01Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:03Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:03Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:05Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:05Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:07Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:07Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:09Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:09Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:11Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:11Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:13Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:13Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:15Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:15Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:17Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:17Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:19Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:19Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:21Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:21Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:24Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:24Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:26Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:26Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:28Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:28Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:30Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:30Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:32Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:32Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:34Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:34Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:36Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:36Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:38Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:38Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:40Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:40Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:42Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:42Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:44Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:44Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:46Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:46Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:48Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:48Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:50Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:50Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:52Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:52Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:54Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:54Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:56Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:56Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:55:58Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:55:58Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:00Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:00Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:02Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:02Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:04Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:04Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:06Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:06Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:08Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:08Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:10Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:10Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:12Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:12Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:14Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:14Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:16Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:16Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:18Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:18Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:20Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:20Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:22Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:22Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:24Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:24Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:26Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:26Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:28Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:28Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:30Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:30Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:32Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:32Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:34Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:34Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:36Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:36Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:39Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:39Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Set replica tcp://10.1.2.19:9502 to mode RW\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 revision counter 0\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"SCSI device created\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Listening ...\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Connecting to remote: 10.1.3.18:9502\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Connecting to remote: 10.1.1.26:9502\" \n10.1.2.19 - - [29/Jun/2018:10:54:18 +0000] \"POST /v1/volumes/cHZjLTc5OGQ0N2M0LTdiOGEtMTFlOC05YjZlLTAyYjk4M2YwYTRkYg==?action=start HTTP/1.1\" 200 658\ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Opening: 10.1.3.18:9502\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Opening: 10.1.1.26:9502\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Snapshot: 10.1.2.19:9502 67b5776e-cb11-41d5-a177-ed43dcfe2376 UserCreated false Created at 2018-06-29T10:56:41Z\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Snapshot: 10.1.1.26:9502 67b5776e-cb11-41d5-a177-ed43dcfe2376 UserCreated false Created at 2018-06-29T10:56:41Z\" \n10.1.1.26 - - [29/Jun/2018:10:54:29 +0000] \"POST /v1/replicas HTTP/1.1\" 200 412\ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Adding backend: tcp://10.1.1.26:9502\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Start monitoring tcp://10.1.1.26:9502\" \ntime=\"2018-06-29T10:56:41Z\" level=error msg=\"Error in request: Can only have one WO replica at a time\" \n10.1.3.18 - - [29/Jun/2018:10:54:24 +0000] \"POST /v1/replicas HTTP/1.1\" 500 185\n10.1.1.26 - - [29/Jun/2018:10:56:41 +0000] \"GET /v1/replicas/dGNwOi8vMTAuMS4xLjI2Ojk1MDI= HTTP/1.1\" 200 412\ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Set revision counter of 10.1.1.26:9502 to : 0\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Set backend tcp://10.1.1.26:9502 revision counter to 0\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Synchronizing volume-head-001.img.meta to volume-head-001.img.meta@10.1.1.26:9700\" \ntime=\"2018-06-29T10:56:41Z\" level=info msg=\"Done synchronizing volume-head-001.img.meta to volume-head-001.img.meta@10.1.1.26:9700\" \n10.1.1.26 - - [29/Jun/2018:10:56:41 +0000] \"POST /v1/replicas/dGNwOi8vMTAuMS4xLjI2Ojk1MDI=?action=preparerebuild HTTP/1.1\" 200 432\ntime=\"2018-06-29T10:56:43Z\" level=error msg=\"Error reading from wire: read tcp 10.1.1.27:41526->10.1.1.26:9503: read: connection reset by peer, RemoteAddr: 10.1.1.26:9503\" \ntime=\"2018-06-29T10:56:43Z\" level=info msg=\"Exiting rpc reader, RemoteAddr:10.1.1.26:9503\" \ntime=\"2018-06-29T10:56:43Z\" level=error msg=\"Backend tcp://10.1.1.26:9502 monitoring failed, mark as ERR: read tcp 10.1.1.27:41526->10.1.1.26:9503: read: connection reset by peer\" \ntime=\"2018-06-29T10:56:43Z\" level=info msg=\"Set replica tcp://10.1.1.26:9502 to mode ERR\" \ntime=\"2018-06-29T10:56:43Z\" level=info msg=\"Monitoring stopped tcp://10.1.1.26:9502\" \ntime=\"2018-06-29T10:56:43Z\" level=info msg=\"Removing backend: tcp://10.1.1.26:9502\" \ntime=\"2018-06-29T10:56:43Z\" level=info msg=\"Closing: 10.1.1.26:9502\" ", "stdout_lines": ["mount: special device /host/dev does not exist", "time=\"2018-06-29T10:52:16Z\" level=info msg=\"Listening on :9501\" ", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Register Replica, Address: 10.1.2.19 Uptime: 2m1.307878s State: closed Type: Backend RevisionCount: 0 PeerCount: 0\" ", "10.1.2.19 - - [29/Jun/2018:10:54:18 +0000] \"POST /v1/register HTTP/1.1\" 200 0", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Connecting to remote: 10.1.2.19:9502\" ", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Opening: 10.1.2.19:9502\" ", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Adding backend: tcp://10.1.2.19:9502\" ", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Start monitoring tcp://10.1.2.19:9502\" ", "time=\"2018-06-29T10:54:18Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:18Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:20Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:20Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:22Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:22Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:25Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:25Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:27Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:27Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:29Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:29Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:31Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:31Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:33Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:33Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:35Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:35Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:37Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:37Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:39Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:39Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:41Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:43Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:43Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:45Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:45Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:47Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:47Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:49Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:49Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:51Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:51Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:53Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:53Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:55Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:55Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:57Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:57Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:54:59Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:54:59Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:01Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:01Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:03Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:03Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:05Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:05Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:07Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:07Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:09Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:09Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:11Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:11Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:13Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:13Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:15Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:15Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:17Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:17Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:19Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:19Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:21Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:21Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:24Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:24Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:26Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:26Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:28Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:28Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:30Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:30Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:32Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:32Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:34Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:34Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:36Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:36Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:38Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:38Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:40Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:40Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:42Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:42Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:44Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:44Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:46Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:46Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:48Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:48Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:50Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:50Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:52Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:52Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:54Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:54Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:56Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:56Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:55:58Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:55:58Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:00Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:00Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:02Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:02Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:04Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:04Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:06Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:06Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:08Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:08Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:10Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:10Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:12Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:12Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:14Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:14Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:16Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:16Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:18Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:18Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:20Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:20Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:22Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:22Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:24Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:24Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:26Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:26Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:28Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:28Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:30Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:30Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:32Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:32Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:34Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:34Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:36Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:36Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:39Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:39Z\" level=error msg=\"Waiting for replica to update CloneStatus to Completed/NA, retry after 2s\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 clone status\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Set replica tcp://10.1.2.19:9502 to mode RW\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Get backend tcp://10.1.2.19:9502 revision counter 0\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"SCSI device created\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Listening ...\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Connecting to remote: 10.1.3.18:9502\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Connecting to remote: 10.1.1.26:9502\" ", "10.1.2.19 - - [29/Jun/2018:10:54:18 +0000] \"POST /v1/volumes/cHZjLTc5OGQ0N2M0LTdiOGEtMTFlOC05YjZlLTAyYjk4M2YwYTRkYg==?action=start HTTP/1.1\" 200 658", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Opening: 10.1.3.18:9502\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Opening: 10.1.1.26:9502\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Snapshot: 10.1.2.19:9502 67b5776e-cb11-41d5-a177-ed43dcfe2376 UserCreated false Created at 2018-06-29T10:56:41Z\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Snapshot: 10.1.1.26:9502 67b5776e-cb11-41d5-a177-ed43dcfe2376 UserCreated false Created at 2018-06-29T10:56:41Z\" ", "10.1.1.26 - - [29/Jun/2018:10:54:29 +0000] \"POST /v1/replicas HTTP/1.1\" 200 412", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Adding backend: tcp://10.1.1.26:9502\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Start monitoring tcp://10.1.1.26:9502\" ", "time=\"2018-06-29T10:56:41Z\" level=error msg=\"Error in request: Can only have one WO replica at a time\" ", "10.1.3.18 - - [29/Jun/2018:10:54:24 +0000] \"POST /v1/replicas HTTP/1.1\" 500 185", "10.1.1.26 - - [29/Jun/2018:10:56:41 +0000] \"GET /v1/replicas/dGNwOi8vMTAuMS4xLjI2Ojk1MDI= HTTP/1.1\" 200 412", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Set revision counter of 10.1.1.26:9502 to : 0\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Set backend tcp://10.1.1.26:9502 revision counter to 0\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Synchronizing volume-head-001.img.meta to volume-head-001.img.meta@10.1.1.26:9700\" ", "time=\"2018-06-29T10:56:41Z\" level=info msg=\"Done synchronizing volume-head-001.img.meta to volume-head-001.img.meta@10.1.1.26:9700\" ", "10.1.1.26 - - [29/Jun/2018:10:56:41 +0000] \"POST /v1/replicas/dGNwOi8vMTAuMS4xLjI2Ojk1MDI=?action=preparerebuild HTTP/1.1\" 200 432", "time=\"2018-06-29T10:56:43Z\" level=error msg=\"Error reading from wire: read tcp 10.1.1.27:41526->10.1.1.26:9503: read: connection reset by peer, RemoteAddr: 10.1.1.26:9503\" ", "time=\"2018-06-29T10:56:43Z\" level=info msg=\"Exiting rpc reader, RemoteAddr:10.1.1.26:9503\" ", "time=\"2018-06-29T10:56:43Z\" level=error msg=\"Backend tcp://10.1.1.26:9502 monitoring failed, mark as ERR: read tcp 10.1.1.27:41526->10.1.1.26:9503: read: connection reset by peer\" ", "time=\"2018-06-29T10:56:43Z\" level=info msg=\"Set replica tcp://10.1.1.26:9502 to mode ERR\" ", "time=\"2018-06-29T10:56:43Z\" level=info msg=\"Monitoring stopped tcp://10.1.1.26:9502\" ", "time=\"2018-06-29T10:56:43Z\" level=info msg=\"Removing backend: tcp://10.1.1.26:9502\" ", "time=\"2018-06-29T10:56:43Z\" level=info msg=\"Closing: 10.1.1.26:9502\" "]}

TASK [9d) Check if the ctrl and replica pods are running] **************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:171
changed: [localhost -> None] => (item=ctrl) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n \"k8s-snapshot\" | grep pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db | grep \"ctrl\"", "delta": "0:00:00.634385", "end": "2018-06-29 10:56:53.645005", "item": "ctrl", "rc": 0, "start": "2018-06-29 10:56:53.010620", "stderr": "", "stderr_lines": [], "stdout": "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   2/2       Running   0          4m", "stdout_lines": ["pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   2/2       Running   0          4m"]}
changed: [localhost -> None] => (item=rep) => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n \"k8s-snapshot\" | grep pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db | grep \"rep\"", "delta": "0:00:00.868586", "end": "2018-06-29 10:56:55.032225", "item": "rep", "rc": 0, "start": "2018-06-29 10:56:54.163639", "stderr": "", "stderr_lines": [], "stdout": "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-9w7br    1/1       Running   0          4m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-lttkc    1/1       Running   1          4m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-mm5f4    1/1       Running   0          4m", "stdout_lines": ["pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-9w7br    1/1       Running   0          4m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-lttkc    1/1       Running   1          4m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-mm5f4    1/1       Running   0          4m"]}

TASK [10) Copy the percona yaml to K8s master] *************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:184
changed: [localhost -> None] => {"changed": true, "checksum": "3209229bac7cd39aa28ac3e143d50399e81d83c9", "dest": "/home/ubuntu/demo-percona-mysql-pvc.yaml", "gid": 1000, "group": "ubuntu", "md5sum": "fc12eda04867439a9c9c7bda6d765523", "mode": "0664", "owner": "ubuntu", "size": 568, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1530269815.29-229227219161631/source", "state": "file", "uid": 1000}

TASK [10a) Deploying the application with the snapped pvc] *************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:190
included: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_task.yml for localhost

TASK [Deploy application files] ****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/deploy_task.yml:2
changed: [localhost -> None] => (item=demo-percona-mysql-pvc.yaml) => {"changed": true, "cmd": "source ~/.profile; kubectl apply -f \"/home/ubuntu/demo-percona-mysql-pvc.yaml\" -n k8s-snapshot", "delta": "0:00:00.676538", "end": "2018-06-29 10:56:58.920906", "item": "demo-percona-mysql-pvc.yaml", "rc": 0, "start": "2018-06-29 10:56:58.244368", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-new\" created", "stdout_lines": ["pod \"percona-new\" created"]}

TASK [Wait few seconds] ************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:196
ok: [localhost -> None] => {"changed": false, "elapsed": 120, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [10b) Check if new percona pod has been running successfully] *****************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:200
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n \"k8s-snapshot\" -l name=percona-new --no-headers", "delta": "0:00:00.709957", "end": "2018-06-29 10:59:01.876505", "rc": 0, "start": "2018-06-29 10:59:01.166548", "stderr": "", "stderr_lines": [], "stdout": "percona-new   1/1       Running   0         2m", "stdout_lines": ["percona-new   1/1       Running   0         2m"]}

TASK [11) Verify successful snapshot restore by db query] **************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:225
changed: [localhost -> None] => {"changed": true, "cmd": "sleep 120 # DB init\n kubectl exec -it percona-new -n k8s-snapshot -- mysql -uroot -pk8sDem0 -e \"select * from ttbl;\" tdb", "delta": "0:02:01.723611", "end": "2018-06-29 11:01:04.777705", "failed_when_result": false, "rc": 0, "start": "2018-06-29 10:59:03.054094", "stderr": "Unable to use a TTY - input is not a terminal or the right kind of file\nmysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["Unable to use a TTY - input is not a terminal or the right kind of file", "mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [12) Set the pass flag] *******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:235
ok: [localhost] => {"ansible_facts": {"flag": "Test Passed"}, "changed": false}

TASK [Wait few seconds before initiating cleanup] **********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:247
ok: [localhost -> None] => {"changed": false, "elapsed": 60, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [Delete percona application deployed with snapped pvc] ************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:2
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl delete -f \"demo-percona-mysql-pvc.yaml\" -n \"k8s-snapshot\"", "delta": "0:00:01.290093", "end": "2018-06-29 11:02:08.745968", "rc": 0, "start": "2018-06-29 11:02:07.455875", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona-new\" deleted", "stdout_lines": ["pod \"percona-new\" deleted"]}

TASK [Check if the percona pod has been deleted] ***********************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:13
FAILED - RETRYING: Check if the percona pod has been deleted (15 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n \"k8s-snapshot\"", "delta": "0:00:01.282135", "end": "2018-06-29 11:02:43.782466", "rc": 0, "start": "2018-06-29 11:02:42.500331", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY     STATUS    RESTARTS   AGE\npercona                                                          1/1       Running   0          21m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   2/2       Running   0          10m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-9w7br    1/1       Running   0          10m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-lttkc    1/1       Running   1          10m\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-mm5f4    1/1       Running   2          10m\npvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-ctrl-b9567c644-f6x5k    2/2       Running   0          21m\npvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-klvnr    1/1       Running   0          21m\npvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-lcdxd    1/1       Running   0          21m\npvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-rgrhp    1/1       Running   0          21m", "stdout_lines": ["NAME                                                             READY     STATUS    RESTARTS   AGE", "percona                                                          1/1       Running   0          21m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   2/2       Running   0          10m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-9w7br    1/1       Running   0          10m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-lttkc    1/1       Running   1          10m", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-rep-86466c95f6-mm5f4    1/1       Running   2          10m", "pvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-ctrl-b9567c644-f6x5k    2/2       Running   0          21m", "pvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-klvnr    1/1       Running   0          21m", "pvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-lcdxd    1/1       Running   0          21m", "pvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-rep-8594bf684f-rgrhp    1/1       Running   0          21m"]}

TASK [Delete the snapshot claim] ***************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:24
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl delete -f \"snapshot-claim.yml\" -n \"k8s-snapshot\"", "delta": "0:00:00.464275", "end": "2018-06-29 11:02:45.328908", "rc": 0, "start": "2018-06-29 11:02:44.864633", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"demo-snap-vol-claim\" deleted", "stdout_lines": ["persistentvolumeclaim \"demo-snap-vol-claim\" deleted"]}

TASK [Delete volume snapshot] ******************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:35
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl delete -f \"snapshot.yml\" -n \"k8s-snapshot\"", "delta": "0:00:00.505277", "end": "2018-06-29 11:02:46.550544", "rc": 0, "start": "2018-06-29 11:02:46.045267", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshot.volumesnapshot.external-storage.k8s.io \"snapshot-demo\" deleted", "stdout_lines": ["volumesnapshot.volumesnapshot.external-storage.k8s.io \"snapshot-demo\" deleted"]}

TASK [Delete the percona pod which was created before capturing snaphshot] *********************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:46
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl delete -f \"https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml\" -n \"k8s-snapshot\"", "delta": "0:00:01.958672", "end": "2018-06-29 11:02:49.475266", "rc": 0, "start": "2018-06-29 11:02:47.516594", "stderr": "", "stderr_lines": [], "stdout": "pod \"percona\" deleted\npersistentvolumeclaim \"demo-vol1-claim\" deleted", "stdout_lines": ["pod \"percona\" deleted", "persistentvolumeclaim \"demo-vol1-claim\" deleted"]}

TASK [Check if the pod has been deleted] *******************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:57
FAILED - RETRYING: Check if the pod has been deleted (15 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n \"k8s-snapshot\"", "delta": "0:00:00.883036", "end": "2018-06-29 11:03:23.222039", "rc": 0, "start": "2018-06-29 11:03:22.339003", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                             READY     STATUS        RESTARTS   AGE\npvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   0/2       Terminating   0          11m\npvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-ctrl-b9567c644-f6x5k    2/2       Terminating   0          21m", "stdout_lines": ["NAME                                                             READY     STATUS        RESTARTS   AGE", "pvc-798d47c4-7b8a-11e8-9b6e-02b983f0a4db-ctrl-7fc76bbc7b-j9rpx   0/2       Terminating   0          11m", "pvc-fdb05f96-7b88-11e8-9b6e-02b983f0a4db-ctrl-b9567c644-f6x5k    2/2       Terminating   0          21m"]}

TASK [Remove snapshot specific files] **********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:68
changed: [localhost -> None] => (item=snapshot.yml) => {"changed": true, "item": "snapshot.yml", "path": "snapshot.yml", "state": "absent"}
changed: [localhost -> None] => (item=snapshot-claim.yml) => {"changed": true, "item": "snapshot-claim.yml", "path": "snapshot-claim.yml", "state": "absent"}
changed: [localhost -> None] => (item=demo-percona-mysql-pvc.yaml) => {"changed": true, "item": "demo-percona-mysql-pvc.yaml", "path": "demo-percona-mysql-pvc.yaml", "state": "absent"}

TASK [Delete the namespace] ********************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/kubectl-snapshot-cleanup.yml:77
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl delete ns \"k8s-snapshot\"", "delta": "0:00:00.757542", "end": "2018-06-29 11:03:28.381571", "rc": 0, "start": "2018-06-29 11:03:27.624029", "stderr": "", "stderr_lines": [], "stdout": "namespace \"k8s-snapshot\" deleted", "stdout_lines": ["namespace \"k8s-snapshot\" deleted"]}

TASK [Setting cleanup flag to passed] **********************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:254
ok: [localhost] => {"ansible_facts": {"cflag": "Cleanup passed"}, "changed": false}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:265
included: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
fatal: [localhost -> None]: FAILED! => {"changed": true, "cmd": "source ~/.profile; killall stern", "delta": "0:00:00.025600", "end": "2018-06-29 11:03:31.056397", "msg": "non-zero return code", "rc": 1, "start": "2018-06-29 11:03:31.030797", "stderr": "mesg: ttyname failed: Inappropriate ioctl for device\nstern: no process found", "stderr_lines": ["mesg: ttyname failed: Inappropriate ioctl for device", "stern: no process found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [Send slack notification] *****************************************************************************************************************************************************************************
task path: /home/giri/openebs/e2e/ansible/playbooks/feature/snapshots/kubectl_snapshot/test-kubectl-snapshot.yml:269
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=44   changed=32   unreachable=0    failed=0 
```