### PR TITLE
Implemented scaleup storage replicas dynamically test playbook

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-pvc-deletion/k8s_delete_pvc.yml
@@ -72,7 +72,7 @@
         - name: 6) Create the storage class in K8s master
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
           vars:
-           app_yml: "{{ result_kube_home.stdout }}/{{ sc_def }}"
+           app_yml: "{{ sc_def }}"
            ns: default
 
 #Copying the create_pvc.yaml to k8s master
@@ -85,11 +85,11 @@
         - name: 6b) Create PVC in k8s cluster
           include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
           vars:
-           app_yml: "{{result_kube_home.stdout }}/{{ pvc_def }}"
+           app_yml: "{{ pvc_def }}"
            ns: "{{ namespace }}"
 
         - name: Wait for few seconds
-          wait_for: timeout=30
+          wait_for: timeout=90
           delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
 #Find the PV name by referring the storage class 'openebs-test'
@@ -187,12 +187,12 @@
             
         - name: Setting pass flag
           set_fact:
-            flag: "TEST PASSED"
+            flag: "Test Passed"
          
       rescue:
         - name: Setting failed flag
           set_fact:
-            flag: "TEST FAILED"
+            flag: "Test Failed"
 
       always:
        
@@ -203,13 +203,13 @@
  
             - name: Setting cleanup flag to passed
               set_fact: 
-                cflag: "CLEANUP PASSED"
+                cflag: "Cleanup Passed"
        
           rescue:
         
             - name: Setting cleanup to failed
               set_fact:
-                cflag: "CLEANUP FAILED"
+                cflag: "Cleanup Failed"
        
           always:
         

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Wait some time
   wait_for:
     timeout: 50
@@ -12,15 +13,6 @@
   until: "'percona' and 'deleted' in del_out.stdout"
   delay: 90
   retries: 5
-
-- name: Remove copied files
-  file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "{{ patch_file }}"
-    - "{{ create_sc }}"
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name: Delete the namespace
   shell: kubectl delete ns "{{ namespace }}"
@@ -41,4 +33,42 @@
   until: '"{{ namespace }}" not in ns_out.stdout'
   delay: 60
   retries: 15
+
+- name: Delete storage class
+  shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+  args:
+    executable: /bin/bash
+  register: sc_out
+  until: "'deleted' in sc_out.stdout"
+  delay: 10
+  retries: 5
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: True
+
+- name: Replace the replica count in openebs-storageclasses yaml
+  replace:
+    path: "{{ create_sc }}"
+    regexp: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
+    replace: 'openebs.io/jiva-replica-count: "{{ (node_count |int) }}"'
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Apply storage class yaml
+  shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+  args:
+    executable: /bin/bash
+  register: sc_out
+  until: "'created' in sc_out.stdout"
+  delay: 10
+  retries: 5
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: True
+
+- name: Remove copied files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ patch_file }}"
+    - "{{ create_sc }}"
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -38,7 +38,7 @@
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             ns: openebs
-            app: openebs-apiserver
+            app: apiserver
 
        - name: 2) Obtaining storage classes yaml
          shell: kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
@@ -214,7 +214,7 @@
      rescue:
        - name: Setting fail flag
          set_fact:
-           flag: "Test failed"
+           flag: "Test Failed"
 
      always:
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -1,0 +1,87 @@
+---
+
+       - name: Get pvc name to verify successful pvc deletion
+         shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: pvc
+         changed_when: true
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+         vars:
+           ns: "{{ namespace }}"
+           app_yml: "{{ percona_files.0 }}"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+         vars:
+           ns: "{{ namespace }}"
+           app: percona
+
+       - name: Confirm pvc pod has been deleted
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'pvc' and 'Running' in result.stdout"
+         delay: 30
+         retries: 10
+         changed_when: true
+
+       - name: Remove the percona liveness check config map
+         shell: source ~/.profile; kubectl delete cm sqltest -n {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'configmap' and 'deleted' not in result.stdout"
+         changed_when: true
+
+       - name: Delete namespace
+         shell: source ~/.profile; kubectl delete ns {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+
+       - name: Delete storage class
+         shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         register: sc_out
+         until: "'deleted' in sc_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+       - name: Replace the replica count in openebs-storageclasses yaml
+         replace:
+           path: "{{ create_sc }}"
+           regexp: 'openebs.io/jiva-replica-count: "2"'
+           replace: 'openebs.io/jiva-replica-count: "{{ (node_count |int) }}"'
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Apply storage class yaml
+         shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         register: sc_out
+         until: "'created' in sc_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+       - name: Remove test artifacts
+         file:
+           path: "{{ result_kube_home.stdout }}/{{ item }}"
+           state: absent
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         with_items:
+           - "{{percona_files}}"
+
+       - name: sleep for 50 seconds and continue with play
+         wait_for:
+           timeout: "50"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -82,6 +82,3 @@
          with_items:
            - "{{percona_files}}"
 
-       - name: sleep for 50 seconds and continue with play
-         wait_for:
-           timeout: "50"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -59,7 +59,7 @@
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
            path: "{{ create_sc }}"
-           regexp: 'openebs.io/jiva-replica-count: "2"'
+           regexp: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
            replace: 'openebs.io/jiva-replica-count: "{{ (node_count |int) }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/pre-requisites.yml
@@ -1,0 +1,12 @@
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: True
+
+- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+  vars:
+    status: start
+

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -1,0 +1,236 @@
+# Description: Scaleup the storage replicas and test is there any impact on pods.
+# Author: Swarna
+
+########################################################################################
+# Test Steps:
+#1.Check the maya-apiserver is running.
+#2.Download and Copy Test artifacts to kubemaster.
+#3.Replace PVC name with test case name in percona yaml
+#4.Get the Nodes count and modify the replica count in storage class.
+#5.Delete the existing storage class and create new one.
+#6.Deploy Percona application with liveness probe running db queries continuously
+#7.Check percona and replica pods are running and store the replica pod names in a list
+#8.Scaleup the storage replica count using kubectl command.
+#9.Check the scaled up replica is running and store the replicas name in list.
+#10.Check access mode of replica using mayactl command.
+#11.Get the replica name which is scheduled before scaleup and kill that replica
+#12.Check the application pod status and check replica is re-schduled again after deleting replica.
+#14.Perform cleanup.
+##########################################################################################
+
+- hosts: localhost
+
+  vars_files:
+    - vars.yml
+
+  tasks:
+
+   - block:
+
+       - include: pre-requisites.yml
+
+
+       - name: Check status of maya-apiserver
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: openebs
+           app: apiserver
+
+       - name: Get percona spec and liveness scripts
+         get_url:
+           url: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items: "{{ percona_links }}"
+
+       - name: Replace volume-claim name with test parameters
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         vars:
+           path: "{{ result_kube_home.stdout }}/percona.yaml"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Get the number of nodes in the cluster
+         shell: source ~/.profile; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_out
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Fetch the node count from stdout
+         set_fact:
+            node_count: " {{ node_out.stdout}}"
+
+       - name: Obtaining storage classes yaml
+         shell: source ~/.profile; kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Replace the replica count in openebs-storageclasses yaml
+         replace:
+           path: "{{ create_sc }}"
+           regexp: 'openebs.io/jiva-replica-count: "3"'
+           replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Delete the existing storage class and create new one
+         shell: ~/.profile; kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
+         args:
+           executable: /bin/bash
+         register: sc_out
+         until: "'created' in sc_out.stdout"
+         delay: 10
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+
+       - name: Create namespace to deploy application
+         shell: source ~/.profile; kubectl create ns {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Create a configmap with the liveness sql script
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{ percona_files.1 }} -n {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'configmap' and 'created' not in result.stdout"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
+           ns: "{{ namespace }}"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
+
+       - name: Wait for 120s to ensure liveness check starts
+         wait_for:
+           timeout: 120
+
+       - name: Get any one of the replica name
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | awk {'print $1'} |  awk 'FNR == 1 {print}'
+         args:
+           executable: /bin/bash
+         register: old_replica_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+
+       - name: Get the replica deployment name
+         shell: source ~/.profile; kubectl get deployment -n {{ namespace }} | grep rep | awk {'print $1'}
+         args:
+           executable: /bin/bash
+         register: rep_deployment_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       #### scale up the stoarge replica using kubectl command ####
+
+       - name: Scaleup the srorage replicas using kubectl command
+         shell: source ~/.profile; kubectl scale deployment {{ rep_deployment_name.stdout }} --replicas={{(node_count |int)}} -n {{ namespace }}
+         args:
+           executable: /bin/bash
+         result: result
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Confirm scaled up replica  pod status is running
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | grep Running | wc -l
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: (node_count)| int == result.stdout|int
+         delay: 120
+         retries: 30
+
+
+       - name: Wait for 180s to ensure Replicas access mode
+         wait_for:
+           timeout: 180
+
+        #### Check the replica access mode after scaling up using mayactl commands ####
+       - name: Check the replicas access mode
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/access-mode-check.yml"
+         vars:
+           ns: "{{ namespace }}"
+
+        #### Delete the replica which is scheduled before scale up to check newly crated replica is in sync"
+
+       - name: Delete the replica which is scheduled before scale up
+         shell: kubectl delete pod {{ old_replica_name.stdout }} -n "{{ namespace }}"
+         args:
+           executable: /bin/bash
+         register: pod_delete
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         until: "'deleted' in pod_delete.stdout"
+         delay: 60
+         retries: 3
+         changed_when: True
+         tags:
+          - skip_ansible_lint
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
+
+       - name: Confirm the replica is scheduled again
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | grep Running | wc -l
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         until: (node_count)| int == (result.stdout)|int
+         delay: 120
+         retries: 30
+
+
+       - name: Test Passed
+         set_fact:
+           flag: "Test Passed"
+
+     rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Test Failed"
+
+     always:
+       - block:
+
+           - include: cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+         always:
+
+           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+             vars:
+               status: stop
+
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+
+
+
+
+
+
+
+

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -30,7 +30,7 @@
        - include: pre-requisites.yml
 
 
-       - name: Check status of maya-apiserver
+       - name: Check status of apiserver
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
            ns: openebs

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -52,7 +52,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
        - name: Get the number of nodes in the cluster
-         shell: source ~/.profile; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
+         shell: source ~/.profile; kubectl get nodes | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: node_out
@@ -76,7 +76,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: ~/.profile; kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/vars.yml
@@ -1,0 +1,26 @@
+---
+test_name: test_scaleup_storage_replicas
+
+percona_links:
+  - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/percona.yaml
+  - https://raw.githubusercontent.com/openebs/elves/master/e2e/percona-liveness/sql-test.sh
+
+percona_files:
+  - percona.yaml
+  - sql-test.sh
+
+replace_item:
+  - demo-vol1-claim
+  - demo-vol1
+
+replace_with:
+  - test-scaleup-storage
+  - test-scaleup
+
+create_sc: storage-class.yml
+
+namespace: scaleup-storage
+
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: setup/logs/scaleup_storage_replicas_test.log

--- a/e2e/ansible/playbooks/utils/access-mode-check.yml
+++ b/e2e/ansible/playbooks/utils/access-mode-check.yml
@@ -1,5 +1,19 @@
+
+       - name: Get the pv name
+         shell: source ~/.profile; kubectl get pvc -n {{ ns }}
+         args:
+           executable: /bin/bash
+         register: pv_name
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         changed_when: True
+
+       - name: Set PV name to a variable
+         set_fact:
+           pvname: "{{pv_name.stdout.split()[10] }}"
+
+
        - name: Get the maya-apiser pod name
-         shell: source ~/.profile; kubectl get pods -n openebs | grep maya-apiserver | awk '{print $1}'
+         shell: source ~/.profile; kubectl get pods -n openebs | grep apiserver | awk '{print $1}'
          args:
            executable: /bin/bash
          register: mayapod
@@ -13,8 +27,10 @@
          register: volname
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          changed_when: True
+         failed_when: "pvname not in volname.stdout"
 
-       - name: Get the volumes access mode
+
+       - name: Get the replicas access mode
          shell: source ~/.profile; kubectl exec -it {{ mayapod.stdout }} -n openebs -- mayactl volume info --volname {{ volname.stdout.split()[2] }} -n {{ ns }}
          args:
            executable: /bin/bash
@@ -26,11 +42,11 @@
          set_fact:
            vol_accessmode_count: "{{ result.stdout.count('RW') }}"
 
-       - name: Verfy the replicas access mode
+       - name: Verify the replicas access mode
          command: echo "Verfiy the replicas access mode"
          when: vol_accessmode_count|int == (node_count)| int
          register: result
        - debug:
-           msg: "All the PVCs are in sync"
+           msg: "All the replicas are in sync"
          when: "result.rc == 0"
 

--- a/e2e/ansible/playbooks/utils/access-mode-check.yml
+++ b/e2e/ansible/playbooks/utils/access-mode-check.yml
@@ -28,7 +28,7 @@
 
        - name: Verfy the replicas access mode
          command: echo "Verfiy the replicas access mode"
-         when: vol_accessmode_count == "3"
+         when: vol_accessmode_count|int == (node_count)| int
          register: result
        - debug:
            msg: "All the PVCs are in sync"

--- a/e2e/ansible/playbooks/utils/access-mode-check.yml
+++ b/e2e/ansible/playbooks/utils/access-mode-check.yml
@@ -1,0 +1,36 @@
+       - name: Get the maya-apiser pod name
+         shell: source ~/.profile; kubectl get pods -n openebs | grep maya-apiserver | awk '{print $1}'
+         args:
+           executable: /bin/bash
+         register: mayapod
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         changed_when: True
+
+       - name: Get the volume list
+         shell: source ~/.profile; kubectl exec -it {{ mayapod.stdout }} -n openebs -- mayactl volume list
+         args:
+           executable: /bin/bash
+         register: volname
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         changed_when: True
+
+       - name: Get the volumes access mode
+         shell: source ~/.profile; kubectl exec -it {{ mayapod.stdout }} -n openebs -- mayactl volume info --volname {{ volname.stdout.split()[2] }} -n {{ ns }}
+         args:
+           executable: /bin/bash
+         register: result
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         changed_when: True
+
+       - name: Set RW count to a variable
+         set_fact:
+           vol_accessmode_count: "{{ result.stdout.count('RW') }}"
+
+       - name: Verfy the replicas access mode
+         command: echo "Verfiy the replicas access mode"
+         when: vol_accessmode_count == "3"
+         register: result
+       - debug:
+           msg: "All the PVCs are in sync"
+         when: "result.rc == 0"
+


### PR DESCRIPTION
Signed-off-by: swarna <swarnalatha@cloudbyte.com>

**What this PR does / why we need it**:
***Scaleup storage replicas dynamically without impacting application services and implement utility to check volume access mode using mayactl command***
- Get the node count and change the replica count in stoarge class to nodecount-1
- Delete the existing storage class and create new one
- Deploy percona application with liveness probe check app ctrl and replicas pods are running.
- Scale up the storage replicas using kubectl scale command.
- After scale up check the newly created replica pod is running and access mode using mayactl command.
- Delete the replica which is scheduled before scale up and check percona app should not crash.(quorum met check).
- Check deleted replica pod re-scheduled again.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@ksatchit @gprasath @dargasudarshan Please review this PR.
