### PR TITLE
Check OpenEBS volume behaviour after kubelet service restart test playbook

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
@@ -5,7 +5,7 @@
          args:
            executable: /bin/bash
          register: result1
-         until: "'1' in result.stdout"
+         until: "'0' in result.stdout"
          delay: 60
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -38,7 +38,7 @@
              wait_for:
                timeout: "120"
 
-         when: "'1' not in result1.stdout"
+         when: "'0' not in result1.stdout"
 
        - name: Get pvc name to verify successful pvc deletion
          shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
@@ -1,11 +1,11 @@
 ---
 
-       - name: check the node is in Ready state after kubelet service restart
-         shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+       - name: check the node is in Ready state after kubelet service start
+         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: result1
-         until: "'0' in result.stdout"
+         until: "'0' in result1.stdout"
          delay: 60
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -14,7 +14,7 @@
 
        - block:
 
-           - name: restart kubelet service if the node still in Notready state
+           - name: Start kubelet service if the node is in NotReady state
              shell: source ~/.profile; systemctl start kubelet.service
              args:
                executable: /bin/bash
@@ -23,8 +23,8 @@
              delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
              changed_when: True
 
-           - name: check the node is in Ready state after kubelet service restart
-             shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+           - name: Check the node is in Ready state after kubelet service start
+             shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
              args:
                executable: /bin/bash
              register: result
@@ -95,6 +95,3 @@
          with_items:
            - "{{percona_files}}"
 
-       - name: sleep for 50 seconds and continue with play
-         wait_for:
-           timeout: "50"

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
@@ -1,5 +1,44 @@
 ---
 
+       - name: check the node is in Ready state after kubelet service restart
+         shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: result1
+         until: "'1' in result.stdout"
+         delay: 60
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+         ignore_errors: True
+
+       - block:
+
+           - name: restart kubelet service if the node still in Notready state
+             shell: source ~/.profile; systemctl start kubelet.service
+             args:
+               executable: /bin/bash
+             register: result
+             become: True
+             delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+             changed_when: True
+
+           - name: check the node is in Ready state after kubelet service restart
+             shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+             args:
+               executable: /bin/bash
+             register: result
+             until: "'0' in result.stdout"
+             delay: 60
+             retries: 5
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+             changed_when: True
+
+           - name: sleep for 120s
+             wait_for:
+               timeout: "120"
+
+         when: "'1' not in result1.stdout"
 
        - name: Get pvc name to verify successful pvc deletion
          shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
@@ -1,0 +1,61 @@
+---
+
+
+       - name: Get pvc name to verify successful pvc deletion
+         shell: source ~/.profile; kubectl get pvc -n {{ namespace }} | grep {{ replace_with.0 }} | awk {'print $3'}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: pvc
+         changed_when: true
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+         vars:
+           ns: "{{ namespace }}"
+           app_yml: "{{ percona_files.0 }}"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+         vars:
+           ns: "{{ namespace }}"
+           app: percona
+
+       - name: Confirm pvc pod has been deleted
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{ pvc.stdout }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'pvc' and 'Running' in result.stdout"
+         delay: 30
+         retries: 10
+         changed_when: true
+
+       - name: sleep for 10 seconds
+         wait_for:
+           timeout: "10"
+
+       - name: Remove the percona liveness check config map
+         shell: source ~/.profile; kubectl delete cm sqltest -n {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'configmap' and 'deleted' not in result.stdout"
+         changed_when: true
+
+       - name: Delete namespace
+         command: kubectl delete ns {{ namespace }}
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+
+       - name: Remove test artifacts
+         file:
+           path: "{{ result_kube_home.stdout }}/{{ item }}"
+           state: absent
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         with_items:
+           - "{{percona_files}}"
+
+       - name: sleep for 50 seconds and continue with play
+         wait_for:
+           timeout: "50"

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/percona.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/percona.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+            - mountPath: /sql-test.sh
+              subPath: sql-test.sh
+              name: sqltest-configmap
+          livenessProbe: 
+            exec: 
+              command: ["bash", "sql-test.sh"]
+            initialDelaySeconds: 30
+            periodSeconds: 1
+            timeoutSeconds: 10
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+        - name: sqltest-configmap
+          configMap: 
+            name: sqltest
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-percona
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/pre-requisites.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/pre-requisites.yml
@@ -1,0 +1,14 @@
+       - name: Get $HOME of K8s master for kubernetes user
+         shell: source ~/.profile; echo $HOME
+         args:
+           executable: /bin/bash
+         register: result_kube_home
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+         vars:
+           status: start
+
+
+

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/sql-test.sh
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/sql-test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mysql -uroot -pk8sDem0 -e "CREATE DATABASE Inventory;"
+mysql -uroot -pk8sDem0 -e "CREATE TABLE Hardware (id INTEGER, name VARCHAR(20), owner VARCHAR(20),description VARCHAR(20));" Inventory
+mysql -uroot -pk8sDem0 -e "INSERT INTO Hardware (id, name, owner, description) values (1, "dellserver", "basavaraj", "controller");" Inventory
+mysql -uroot -pk8sDem0 -e "DROP DATABASE Inventory;"

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
@@ -19,4 +19,4 @@ test_pod_regex: maya*|openebs*|pvc*|percona*
 
 test_log_path: setup/logs/kubelet_service_restart_test.log
 
-
+node_name: kubeminion-01

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
@@ -1,0 +1,22 @@
+
+test_name: test_kubelet_service_restart
+
+percona_files:
+  - percona.yaml
+  - sql-test.sh
+
+replace_item:
+  - demo-vol1-claim
+  - demo-vol1
+
+replace_with:
+  - test-kubelet-service
+  - test-kubelet
+
+namespace: kubelet-service
+
+test_pod_regex: maya*|openebs*|pvc*|percona*
+
+test_log_path: setup/logs/kubelet_service_restart_test.log
+
+

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
@@ -1,0 +1,227 @@
+# Description: Verify the behaviour of OpenEBS volumes when kubelet service is stopped on one of the nodes.
+# Author: Swarna
+
+########################################################################################
+# Test Steps:
+#1.Check the maya-apiserver is running.
+#2.Download and Copy Test artifacts to kubemaster.
+#3.Replace PVC name with test case name in percona yaml
+#3.Deploy Percona application with liveness probe running db queries continuously
+#4.Get the Replica name and node name where the replica is scheduled
+#5.Stop the kubelet service on the node where replica is running
+#6.Check the node state after stopping kubectl service
+#7.Check the percona pod status.
+#8.Start the kubelet service on node and check percona pod and replicas are up and running.
+#8.perform Cleanup.
+##########################################################################################
+
+- hosts: localhost
+
+  vars_files:
+    - test-kubelet-service-stop-vars.yml
+
+  tasks:
+
+   - block:
+
+       - include: pre-requisites.yml
+
+
+       - name: Check status of maya-apiserver
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+           ns: openebs
+           app: apiserver
+
+
+       - name: Copy the percona files to kube-master
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items: "{{ percona_files }}"
+
+       - name: Replace volume-claim name with test parameters
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         vars:
+           path: "{{ result_kube_home.stdout }}/percona.yaml"
+           regex1: "{{replace_item}}"
+           regex2: "{{replace_with}}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+
+       - name: Create namespace to deploy application
+         shell: source ~/.profile; kubectl create ns {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+       - name: Create a configmap with the liveness sql script
+         shell: source ~/.profile; kubectl create configmap sqltest --from-file={{result_kube_home.stdout}}/{{ percona_files.1 }} -n {{ namespace }}
+         args:
+           executable: /bin/bash
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         register: result
+         failed_when: "'configmap' and 'created' not in result.stdout"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         vars:
+           app_yml: "{{ percona_files.0 }}"
+           ns: "{{ namespace }}"
+
+       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
+
+       - name: Wait for 120s to ensure liveness check starts
+         wait_for:
+           timeout: 120
+
+       - name: Get the number of nodes in the cluster
+         shell: kubectl get nodes | grep '<none>' | wc -l
+         args:
+           executable: /bin/bash
+         register: node_out
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Fetch the node count from stdout
+         set_fact:
+            node_count: " {{ node_out.stdout}}"
+
+       - name: Get the number of nodes that are in ready state
+         shell: source ~/.profile; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: ready_node_cout
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - debug:
+           msg: "All the nodes are in ready state"
+         when: (node_count)| int == (ready_node_cout.stdout)| int
+
+       - name: Stop kubelet service in one of the node
+         shell: source ~/.profile; systemctl stop kubelet.service
+         args:
+           executable: /bin/bash
+         register: result
+         become: True
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+         changed_when: True
+
+
+       - name: check the node is in NotReady state after kubelet service is stopped
+         shell: source ~/.profile; kubectl get nodes | grep NotReady | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'1' in result.stdout"
+         delay: 60
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+       - name: Wait for 300s to check the pods are still running after kubelet service stop
+         wait_for:
+           timeout: 300
+
+       - name: Start kubelet service
+         shell: source ~/.profile; systemctl start kubelet.service
+         args:
+           executable: /bin/bash
+         register: result
+         become: True
+         delegate_to: "{{groups['kubernetes-kubeminions'].0}}"
+         changed_when: True
+
+
+       - name: check the node is in Ready state after kubelet service restart
+         shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+         args:
+           executable: /bin/bash
+         register: result
+         until: "'0' in result.stdout"
+         delay: 60
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+
+
+       - name: Confirm liveness checks on percona are successful &  pod is still in running state
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
+
+       - name: Check if the replica pods are scheduled again and running
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | grep -i running |wc -l
+         args:
+           executable: /bin/bash
+         register: rep_count
+         until: "'3' in rep_count.stdout"
+         delay: 60
+         retries: 5
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: True
+
+       - name: Get Controller SVC IP
+         shell: source ~/.profile; kubectl get svc -n {{ namespace }} | grep ctrl | awk {'print $3'}
+         args:
+           executable: /bin/bash
+         register: SVC
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         changed_when: true
+
+       - name: Wait for 180s to ensure volume access mode
+         wait_for:
+           timeout: 180
+
+
+       - name: Check if the replica is rebuilded using mayactl commands
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/access-mode-check.yml"
+         vars:
+           ns: "{{ namespace }}"
+
+
+       - name: Test Passed
+         set_fact:
+           flag: "Test Passed"
+
+     rescue:
+       - name: Test Failed
+         set_fact:
+           flag: "Test Failed"
+
+     always:
+       - block:
+
+           - include: cleanup.yml
+
+           - name: Test Cleanup Passed
+             set_fact:
+               cflag: "Cleanup Passed"
+
+         rescue:
+           - name: Test Cleanup Failed
+             set_fact:
+               cflag: "Cleanup Failed"
+
+         always:
+
+           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+             vars:
+               status: stop
+
+
+           - name: Send slack notification
+             slack:
+               token: "{{ lookup('env','SLACK_TOKEN') }}"
+               msg: '{{ ansible_date_time.time }} TEST: {{test_name}}, RESULT: {{ flag }},{{ cflag }}'
+             when: slack_notify | bool and lookup('env','SLACK_TOKEN')
+
+
+
+
+
+
+

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
@@ -110,7 +110,7 @@
 
 
        - name: check the node is in NotReady state after kubelet service is stopped
-         shell: source ~/.profile; kubectl get nodes | grep NotReady | wc -l
+         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep NotReady | wc -l
          args:
            executable: /bin/bash
          register: result
@@ -140,8 +140,8 @@
          changed_when: True
 
 
-       - name: check the node is in Ready state after kubelet service restart
-         shell: source ~/.profile; kubectl get nodes | grep 'NotReady' | grep 'none' | wc -l
+       - name: check the node is in Ready state after kubelet service start
+         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: result
@@ -153,7 +153,7 @@
 
 
 
-       - name: Confirm liveness checks on percona are successful &  pod is still in running state
+       - name: Confirm liveness checks on percona are successful & pod is still in running state
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ namespace }}"

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
@@ -124,6 +124,12 @@
          wait_for:
            timeout: 300
 
+       - name: Confirm liveness checks on percona are successful &  pod is still in running state
+         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         vars:
+            ns: "{{ namespace }}"
+            app: percona
+
        - name: Start kubelet service
          shell: source ~/.profile; systemctl start kubelet.service
          args:


### PR DESCRIPTION
Signed-off-by: swarna <swarnalatha@cloudbyte.com>

**What this PR does / why we need it**:
***Implemented test playbook to check openebs volume behaviour after kubelet service restart in one of the nodes***
- copy the percona files to kubemaster and deploy.
- Check the application,ctrl and replica pods are running.
- Get the number of nodes count that are in ready state.
- stop the kubelet service in any one of the node and check service is stopped on the node.
- wait for some time and start the kubelet service on the node and check kubelet service is running.
-After restarting the service check the application pod and replica pods scheduled again and running.
- Check the replicas are rebuilded using mayactl command. 

 **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
