### PR TITLE
Modified operator role to skip the checks performed in master if the cluster is managed

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -26,7 +26,7 @@ weave_version_list:
 #Option to specify OpenEBS deployment type
 # It can be either kubectl or helm based installation
 
-openebs_deploy: helm
+openebs_deploy: kubectl
 #########################################
 # OpenEBS Deployment Specifications     #
 #########################################
@@ -88,3 +88,6 @@ vagrant_path: openebs/k8s/vagrant/1.8.8/ubuntu/
 utils_path: openebs/e2e/ansible/playbooks/utils
 kubeconfig: .kube/config
 build_type: normal
+
+# In case , if you want to deploy openebs in the cluster in managed kubernetes services, specify "cluster_type= managed". By default specifying the cluster_type to local.
+cluster_type: hosted

--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-operator-ns-openebs.yaml
+openebs_operator_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
 
 openebs_operator_alias: openebs-operator.yaml 
 

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -18,6 +18,8 @@
     - m-apiserver
     - jiva
     - openebs-k8s-provisioner
+    - snapshot-controller
+    - snapshot-provisioner
 
 - block:
 

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -19,30 +19,34 @@
     - jiva
     - openebs-k8s-provisioner
 
-- name: Get kubernetes master name
-  shell: hostname
-  args:
-    executable: /bin/bash
-  register: result
+- block:
 
-- name: Get kubernetes master status
-  shell: source ~/.profile; kubectl get nodes | grep {{ result.stdout.lower()}} | awk '{print $2}'
-  args:
-    executable: /bin/bash
-  register: result
-  until:  result.stdout == 'Ready'
-  delay: 60
-  retries: 10 
-  ignore_errors: true  
+    - name: Get kubernetes master name
+      shell: hostname
+      args:
+        executable: /bin/bash
+      register: result
 
-- name: 
-  debug: 
-    msg: "Ending play, K8S Master NOT READY"
-  when: result.stdout != "Ready"
+    - name: Get kubernetes master status
+      shell: source ~/.profile; kubectl get nodes | grep {{ result.stdout.lower()}} | awk '{print $2}'
+      args:
+        executable: /bin/bash
+      register: result
+      until:  result.stdout == 'Ready'
+      delay: 60
+      retries: 10 
+      ignore_errors: true  
 
-- name: Ending Playbook Run - K8S master is NOT READY
-  meta: end_play
-  when: result.stdout != "Ready"
+    - name: 
+      debug: 
+        msg: "Ending play, K8S Master NOT READY"
+      when: result.stdout != "Ready"
+
+    - name: Ending Playbook Run - K8S master is NOT READY
+      meta: end_play
+      when: result.stdout != "Ready"
+
+  when: cluster_type == "hosted"
 
 - name: Start the log aggregator to capture operator logs
   shell: source ~/.profile; nohup stern "maya*|openebs*" --since 1m >"{{ ansible_env.HOME }}/setup/logs/operator.log" &


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- Changed the install_type to kubectl by default.
- Introduced new variable cluster_type. Skipping several tasks which are not applicable in cloud ci. 

**Special notes for your reviewer**:
- Implemented new variable cluster_type
- Changed the default value of openebs_deploy to 'kubectl' from 'helm'
- Skipping few tasks if the cluster_type is not 'hosted'