### PR TITLE
[TA1787, TA1789] Rewrite PromQl to get the cumulative stats and recreate Dashboard

### DIFF
--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -170,7 +170,7 @@ spec:
         app: openebs-grafana
     spec:
       containers:
-      - image: grafana/grafana:5.2.0
+      - image: grafana/grafana:5.1.3
         name: grafana
         ports:
         - containerPort: 3000

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -170,7 +170,7 @@ spec:
         app: openebs-grafana
     spec:
       containers:
-      - image: grafana/grafana:5.1.3
+      - image: grafana/grafana:5.2.0
         name: grafana
         ports:
         - containerPort: 3000

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openebs-prometheus-tunables
+  namespace: openebs
 data:
   storage-retention: 24h
 ---
@@ -14,6 +15,7 @@ data:
 kind: ConfigMap
 metadata:
   name: openebs-prometheus-config
+  namespace: openebs
 apiVersion: v1
 data:
   prometheus.yml: |-
@@ -28,7 +30,7 @@ data:
       # Added this to allow for federation collection
       # Replace localhost with the nodeIP
       #  - targets: ['localhost:32514']
-    - job_name: 'openebs-prometheus-server'
+    - job_name: 'prometheus'
       scheme: http
       kubernetes_sd_configs:
       - role: pod
@@ -65,6 +67,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: openebs-prometheus
+  namespace: openebs
 spec:
   replicas: 1
   template:
@@ -75,7 +78,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: prometheus
-          image: prom/prometheus:v2.1.0
+          image: prom/prometheus:v2.3.0
           args:
             - "--config.file=/etc/prometheus/conf/prometheus.yml"
             # Metrics are stored in an emptyDir volume which
@@ -128,6 +131,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-prometheus-service
+  namespace: openebs
 spec:
   selector: 
     name: openebs-prometheus-server
@@ -166,7 +170,7 @@ spec:
         app: openebs-grafana
     spec:
       containers:
-      - image: grafana/grafana:4.6.3
+      - image: grafana/grafana:5.2.0
         name: grafana
         ports:
         - containerPort: 3000

--- a/k8s/openebs-monitoring/alertmanager.yaml
+++ b/k8s/openebs-monitoring/alertmanager.yaml
@@ -2,34 +2,53 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: alertmanager
+  labels:
+    k8s-app: alertmanager
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: alertmanager
+      k8s-app: alertmanager
   template:
     metadata:
-      name: alertmanager
       labels:
-        app: alertmanager
+        k8s-app: alertmanager
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: prometheus
       containers:
-      - name: alertmanager
-        image: prom/alertmanager:v0.9.1
+      - name: prometheus-alertmanager
+        image: prom/alertmanager:v0.15.0
         args:
-          - '-config.file=/etc/alertmanager/config.yml'
-          - '-storage.path=/alertmanager'
+          - '--config.file=/etc/config/alertmanager.yml'
+          - '--storage.path=/data'
+          - '--web.external-url=/'
         ports:
-        - name: alertmanager
-          containerPort: 9093
+        - containerPort: 9093
+        readinessProbe:
+          httpGet:
+            path: /#/status
+            port: 9093
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
         volumeMounts:
         - name: config-volume
-          mountPath: /etc/alertmanager
+          mountPath: /etc/config
         - name: templates-volume
           mountPath: /alertmanager/template/
-        - name: alertmanager
-          mountPath: /alertmanager
+        - name: storage-volume
+          mountPath: "/data"
+          subPath: ""
+        resources:
+          limits:
+            cpu: 10m
+            memory: 50Mi
+          requests:
+            cpu: 10m
+            memory: 50Mi
       volumes:
       - name: config-volume
         configMap:
@@ -37,25 +56,22 @@ spec:
       - name: templates-volume
         configMap:
           name: alertmanager-templates
-      - name: alertmanager
+      - name: storage-volume
         emptyDir: {}
-
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/path: '/alertmanager/metrics'
-  labels:
-    name: alertmanager
   name: alertmanager
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "Alertmanager"
 spec:
   selector:
-    app: alertmanager
+    k8s-app: alertmanager
   type: NodePort
   ports:
-  - name: alertmanager
-    protocol: TCP
+  - protocol: TCP
     port: 9093
     targetPort: 9093

--- a/k8s/openebs-monitoring/configs/alertmanager-config.yaml
+++ b/k8s/openebs-monitoring/configs/alertmanager-config.yaml
@@ -2,45 +2,47 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: alertmanager-config
+  labels:
+    k8s-app: alertmanager
 data:
-  config.yml: |-
+  alertmanager.yml: |-
     global:
-      
+
       # ResolveTimeout is the time after which an alert is declared resolved
       # if it has not been updated.
       resolve_timeout: 5m
-      # Replace the given api url by your slack webhook url.        
+      # Replace the given api url by your slack webhook url.
       slack_api_url: 'https://hooks.slack.com/services/T3NU2A2UV/Your_Token'
 
     # The directory from which notification templates are read.
     templates:
     - '/alertmanager/templates/slack.tmpl'
-    
+
     # The root route on which each incoming alert enters.
     route:
       # The labels by which incoming alerts are grouped together. For example,
       # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
       # be batched into a single group.
       group_by: ['alertname', 'cluster', 'service']
-      
+
       # When a new group of alerts is created by an incoming alert, wait at
       # least 'group_wait' to send the initial notification.
       # This way ensures that you get multiple alerts for the same group that start
       # firing shortly after another are batched together on the first
       # notification.
       group_wait: 10s
-      
+
       # When the first notification was sent, wait 'group_interval' to send a batch
       # of new alerts that started firing for that group.
-      
+
       group_interval: 1m
-      
+
       # If an alert has successfully been sent, wait 'repeat_interval' to
       # resend them.
       repeat_interval: 1m
-      
+
       receiver: slack_general
-      
+
       routes:
       - match:
           severity: 'warning'
@@ -49,7 +51,7 @@ data:
     receivers:
     - name: slack_general
       slack_configs:
-      # channel name where webhook integrated       
+      # channel name where webhook integrated
       - channel: '#alert'
         text: "<!here>{{ range .Alerts }}\nInstance: {{ .Labels.instance }}\n {{ end }}"
-        
+

--- a/k8s/openebs-monitoring/configs/alertmanager-templates.yaml
+++ b/k8s/openebs-monitoring/configs/alertmanager-templates.yaml
@@ -1,7 +1,9 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: alertmanager-templates 
+  name: alertmanager-templates
+  labels:
+    k8s-app: alertmanager
 data:
   slack.tmpl: |-
     # TODO

--- a/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-alert-rules.yaml
@@ -1,7 +1,9 @@
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-alert-rules
-apiVersion: v1
+  labels:
+    k8s-app: prometheus
 data:
   alert.rules.yml: |-
     groups:

--- a/k8s/openebs-monitoring/configs/prometheus-config.yaml
+++ b/k8s/openebs-monitoring/configs/prometheus-config.yaml
@@ -16,11 +16,12 @@
 #
 # If you are using Kubernetes 1.7.2 or earlier, please take note of the comments
 # for the kubernetes-cadvisor job; you will need to edit or remove this job.
-
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-config
-apiVersion: v1
+  labels:
+    k8s-app: prometheus
 data:
   prometheus.yml: |-
     global:
@@ -30,7 +31,7 @@ data:
       evaluation_interval: 5s
     rule_files:
     # alert rules passed as argument in prometheus-deployment at given path
-    - '/etc/prometheus-rules/alert.rules.yaml'
+    - '/etc/prometheus-rules/alert.rules.yml'
     # scrape config for maya-apiserver pods
     #
     # The relabeling allows the actual pod scrape endpoint to be configured via
@@ -48,7 +49,7 @@ data:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         relabel_configs:
-        - source_labels: [__meta_kubernetes_pod_label_name]
+        - source_labels: [__meta_kubernetes_pod_label_k8s_app]
           regex: alertmanager
           action: keep
         - source_labels: [__meta_kubernetes_namespace]

--- a/k8s/openebs-monitoring/grafana-operator.yaml
+++ b/k8s/openebs-monitoring/grafana-operator.yaml
@@ -26,7 +26,7 @@ spec:
         app: grafana
     spec:
       containers:
-      - image: grafana/grafana:5.0.0-beta4
+      - image: grafana/grafana:5.2.0
         name: grafana
         imagePullPolicy: Always
         ports:

--- a/k8s/openebs-monitoring/openebs-dashboard.json
+++ b/k8s/openebs-monitoring/openebs-dashboard.json
@@ -1,12 +1,66 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMDASH",
+      "label": "Promdash",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": "5.0.0"
+    }
+  ],
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "${DS_PROMDASH}",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "hideControls": false,
-  "id": 4,
+  "id": null,
+  "iteration": 1532617626696,
   "links": [
     {
       "icon": "info",
@@ -18,592 +72,607 @@
       "url": "http://docs.openebs.io/"
     }
   ],
-  "refresh": false,
-  "rows": [
+  "panels": [
     {
-      "collapse": false,
-      "height": 328,
-      "panels": [
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "description": "Elapsed time since Volume was provisioned",
+      "format": "m",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "prometheus",
-          "description": "Elapsed time since Volume was provisioned",
-          "format": "m",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 10,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "OpenEBS_volume_uptime{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}/60",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "refId": "A",
-              "step": 600
-            }
-          ],
-          "thresholds": "",
-          "title": "Uptime",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
+          "name": "value to text",
+          "value": 1
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 81, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "datasource": "prometheus",
-          "description": "Capacity Used by the Volume",
-          "format": "decgbytes",
-          "gauge": {
-            "maxValue": 5,
-            "minValue": 0,
-            "show": true,
-            "thresholdLabels": false,
-            "thresholdMarkers": false
-          },
-          "id": 2,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "__name__",
-          "targets": [
-            {
-              "expr": "OpenEBS_actual_used{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "",
-              "refId": "A",
-              "step": 600
-            }
-          ],
-          "thresholds": "4,5",
-          "title": "Capacity",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "openebs_volume_uptime{job=\"maya-volume-exporter\", volName=~\"$OpenEBS\"}/60",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": "",
+      "title": "Uptime",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#3f6833",
+        "rgba(237, 81, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "description": "Capacity Used by the Volume",
+      "format": "decgbytes",
+      "gauge": {
+        "maxValue": 5,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "prometheus",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "openebs_size_of_volume{job=\"maya-volume-exporter\", instance=~\"$Instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": "",
+      "title": "Capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "format": "decgbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 12,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "openebs_actual_used{job=\"maya-volume-exporter\", instance=~\"$Instance\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 15
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": "2h",
+      "timeShift": null,
+      "title": "Storage Usage",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "content": "<img src=\"https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png\" alt=\"OpenEBS logo\" style=\"height: 40px;\">\n<span style=\"font-family: 'Open Sans', 'Helvetica Neue', Helvetica; font-size: 25px;vertical-align: text-top;color: #bbbfc2;margin-left: 10px;\">OpenEBS</span>\n\n<p style=\"margin-top: 10px;\">You're monitoring OpenEBS Volumes using Prometheus. For more information, check out the <a href=\"http://openebs.io/\">OpenEBS</a> and <a href=\"http://prometheus.io/\">Prometheus</a> projects. If you would like to retain this volume monitoring data and much more, sign-up for <a href=\"http://mayaonline.io/\">MayaOnline</a> </p>",
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 11,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "IOPS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(openebs_reads{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])/60",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Reads}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "increase(openebs_writes{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])/60",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{Writes}}",
+          "refId": "B",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
           "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "hideTimeOverride": true,
-          "id": 12,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "OpenEBS_actual_used{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "A",
-              "step": 60
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": "2h",
-          "timeShift": null,
-          "title": "Storage Usage",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
         },
         {
-          "content": "<img src=\"https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png\" alt=\"OpenEBS logo\" style=\"height: 40px;\">\n<span style=\"font-family: 'Open Sans', 'Helvetica Neue', Helvetica; font-size: 25px;vertical-align: text-top;color: #bbbfc2;margin-left: 10px;\">OpenEBS</span>\n\n<p style=\"margin-top: 10px;\">You're monitoring OpenEBS Volumes using Prometheus. For more information, check out the <a href=\"http://openebs.io/\">OpenEBS</a> and <a href=\"http://prometheus.io/\">Prometheus</a> projects. If you would like to retain this volume monitoring data and much more, sign-up for <a href=\"http://mayaonline.io/\">MayaOnline</a> </p>",
-          "id": 11,
-          "links": [],
-          "mode": "html",
-          "span": 3,
-          "title": "",
-          "transparent": true,
-          "type": "text"
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "Throughput",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "IOPS",
-          "fill": 1,
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_iops{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Reads}}",
-              "refId": "A",
-              "step": 30
-            },
-            {
-              "expr": "OpenEBS_write_iops{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Writes}}",
-              "refId": "B",
-              "step": 30
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "IOPS",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "expr": "increase(openebs_read_block_count{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])/(1024*1024*60)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Read Throughput}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "increase(openebs_write_block_count{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])/(1024*1024*60)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Write Throughput}}",
+          "refId": "B",
+          "step": 2
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "IOPS Graph",
-      "titleSize": "h6"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "Latency",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "Throughput",
-          "fill": 1,
-          "id": 9,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_block_count_per_second{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}/(1024*1024)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Read Throughput}}",
-              "refId": "A",
-              "step": 30
-            },
-            {
-              "expr": "OpenEBS_write_block_count_per_second{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}/(1024*1024)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Write Throughput}}",
-              "refId": "B",
-              "step": 30
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Throughput",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "MBs",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "expr": "((increase(openebs_read_time{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m]))/(increase(openebs_reads{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Read Latency}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "((increase(openebs_write_time{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m]))/(increase(openebs_writes{job=\"maya-volume-exporter\", instance=~\"$Instance\"}[1m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Write Latency}}",
+          "refId": "B",
+          "step": 2
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Throughput Graph",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "prometheus",
-          "description": "Latency",
-          "fill": 1,
-          "id": 5,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "max": true,
-            "min": true,
-            "rightSide": true,
-            "show": true,
-            "sideWidth": 350,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_latency{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Read Latency}}",
-              "refId": "A",
-              "step": 30
-            },
-            {
-              "expr": "OpenEBS_write_latency{job=\"maya-volume-exporter\", instance=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Write Latency}}",
-              "refId": "B",
-              "step": 30
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Latency Graph",
-      "titleSize": "h6"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "schemaVersion": 14,
+  "refresh": false,
+  "schemaVersion": 16,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": [
       {
         "allValue": null,
-        "current": {
-          "text": "10.44.0.5:9500",
-          "value": "10.44.0.5:9500"
-        },
-        "datasource": "prometheus",
+        "current": {},
+        "datasource": "${DS_PROMDASH}",
         "hide": 0,
         "includeAll": false,
         "label": "OpenEBS Volume",
         "multi": false,
         "name": "OpenEBS",
         "options": [],
-        "query": "label_values(OpenEBS_size_of_volume, instance)",
+        "query": "label_values(openebs_volume_uptime, volName)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMDASH}",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Instance",
+        "options": [],
+        "query": "label_values(openebs_volume_uptime, instance)",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -645,6 +714,7 @@
     ]
   },
   "timezone": "",
-  "title": "OpenEBS Volume",
-  "version": 2
+  "title": "OpenEBS Volume Stats",
+  "uid": "JOHe1vdiz",
+  "version": 4
 }

--- a/k8s/openebs-monitoring/prometheus-operator.yaml
+++ b/k8s/openebs-monitoring/prometheus-operator.yaml
@@ -12,6 +12,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
+  labels:
+    k8s-app: prometheus
   namespace: default
 ---
 # RBAC, Role-based access control, is an an authorization mechanism for managing
@@ -29,14 +31,16 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: prometheus
+  labels:
+    k8s-app: prometheus
 # These are the rules to determine whether a request is allowed or denied
 rules:
   # You can use the Kubernetes API to read and write Kubernetes resource objects
-  # via a Kubernetes API endpoint. The API group being accessed (for resource 
+  # via a Kubernetes API endpoint. The API group being accessed (for resource
   # requests only). An empty string designates the core API group.
 - apiGroups: [""]
   # The ID or name of the resource that is being accessed (for resource requests
-  # only) –* For resource requests using get, update, patch, and delete verbs, 
+  # only) –* For resource requests using get, update, patch, and delete verbs,
   # you must provide the resource name.
   resources:
     # A Node may be a VM or physical machine
@@ -44,26 +48,26 @@ rules:
     # nodes/proxy connect POST requests to proxy of a Node for the given HTTP req
     # POST /api/v1/nodes/{name}/proxy
   - nodes/proxy
-    # Services are to load balance traffic across all Pods.and it Exposes an 
+    # Services are to load balance traffic across all Pods.and it Exposes an
     # externally accessible endpoint. In simple words they are the medium through
     # which pods communicate.
   - services
     # An endpoint is a URL pattern used to communicate with an API. For exp:
     # <ip>:<port>/metrics
   - endpoints
-    # A pod is a group of one or more containers (Exp: Docker containers),with 
+    # A pod is a group of one or more containers (Exp: Docker containers),with
     # shared storage/network, and a specification for how to run the containers.
   - pods
   verbs: ["get", "list", "watch"]
-  # nonResourceURLs are endpoints that don’t map to a traditional resource. 
+  # nonResourceURLs are endpoints that don’t map to a traditional resource.
   # Things like /ui/ or /apis or /swagger.json that are used for redirects
   # Prometheus by default look for /metrics endpoint for the differnet IP's.
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-# A RoleBinding maps a Role to a user or set of users, granting that Role's 
+# A RoleBinding maps a Role to a user or set of users, granting that Role's
 # permissions to those users for resources in that namespace. A ClusterRole-
-# Binding allows users to be granted a ClusterRole for authorization across the 
+# Binding allows users to be granted a ClusterRole for authorization across the
 # entire cluster.
 #
 # TODO: Check if default account also needs to be there
@@ -85,6 +89,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: prometheus-deployment
+  labels:
+    k8s-app: prometheus
 spec:
   replicas: 1
   template:
@@ -102,12 +108,27 @@ spec:
             # exists as long as the Pod is running on that Node.
             # The data in an emptyDir volume is safe across container crashes.
             - "--storage.tsdb.path=/prometheus"
-            # How long to retain samples in the local storage. 
+            # How long to retain samples in the local storage.
             - "--storage.tsdb.retention=$(STORAGE_RETENTION)"
+            - "--web.console.libraries=/etc/prometheus/console_libraries"
+            - "--web.console.templates=/etc/prometheus/consoles"
+            - "--web.enable-lifecycle"
           ports:
             - containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
           env:
-            # environment vars are stored in prometheus-env configmap. 
+            # environment vars are stored in prometheus-env configmap.
             - name: STORAGE_RETENTION
               valueFrom:
                 configMapKeyRef:
@@ -125,7 +146,6 @@ spec:
             limits:
               memory: "700M"
               cpu: "500m"
-          
           volumeMounts:
             # prometheus config file stored in the given mountpath
             - name: prometheus-server-volume
@@ -137,14 +157,14 @@ spec:
             - name: rules-volume
               mountPath: /etc/prometheus-rules
       volumes:
-        # Prometheus Config file will be stored in this volume 
+        # Prometheus Config file will be stored in this volume
         - name: prometheus-server-volume
           configMap:
             name: prometheus-config
         # All the time series stored in this volume in form of .db file.
         - name: prometheus-storage-volume
           # containers in the Pod can all read and write the same files here.
-          emptyDir: {} 
+          emptyDir: {}
         # Rules defined in configmap will be stored in this volume
         - name: rules-volume
           configMap:
@@ -156,6 +176,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: prometheus-service
+  labels:
+    k8s-app: prometheus
 spec:
   selector: # exposes any pods with the following labels as a service
     name: prometheus-server
@@ -176,6 +198,8 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: node-exporter
+  labels:
+    k8s-app: node-exporter
 spec:
   template:
     metadata:
@@ -212,32 +236,32 @@ spec:
           mountPath: /root-disk
           readOnly: true
       # The Kubernetes scheduler’s default behavior works well for most cases
-      # -- for example, it ensures that pods are only placed on nodes that have 
-      # sufficient free resources, it ties to spread pods from the same set 
-      # (ReplicaSet, StatefulSet, etc.) across nodes, it tries to balance out 
+      # -- for example, it ensures that pods are only placed on nodes that have
+      # sufficient free resources, it ties to spread pods from the same set
+      # (ReplicaSet, StatefulSet, etc.) across nodes, it tries to balance out
       # the resource utilization of nodes, etc.
       #
       # But sometimes you want to control how your pods are scheduled. For example,
-      # perhaps you want to ensure that certain pods only schedule on nodes with 
-      # specialized hardware, or you want to co-locate services that communicate 
-      # frequently, or you want to dedicate a set of nodes to a particular set of 
+      # perhaps you want to ensure that certain pods only schedule on nodes with
+      # specialized hardware, or you want to co-locate services that communicate
+      # frequently, or you want to dedicate a set of nodes to a particular set of
       # users. Ultimately, you know much more about how your applications should be
       # scheduled and deployed than Kubernetes ever will.
       #
-      # “taints and tolerations,” allows you to mark (“taint”) a node so that no 
+      # “taints and tolerations,” allows you to mark (“taint”) a node so that no
       # pods can schedule onto it unless a pod explicitly “tolerates” the taint.
-      # toleration  is particularly useful for situations where most pods in 
+      # toleration  is particularly useful for situations where most pods in
       # the cluster should avoid scheduling onto the node. In our case we want
-      # node-exporter to run on master node also i.e, we want to collect metrics 
+      # node-exporter to run on master node also i.e, we want to collect metrics
       # from master node. That's why tolerations added.
       # if removed master's node metrics can't be scrapped by prometheus.
       tolerations:
       - effect: NoSchedule
         operator: Exists
       volumes:
-        # A hostPath volume mounts a file or directory from the host node’s 
+        # A hostPath volume mounts a file or directory from the host node’s
         # filesystem.For example, some uses for a hostPath are:
-        # running a container that needs access to Docker internals; use a hostPath 
+        # running a container that needs access to Docker internals; use a hostPath
         # of /var/lib/docker
         # running cAdvisor in a container; use a hostPath of /dev/cgroups
         - name: data-disk

--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_OPENEBS_PROMETHEUS",
-      "label": "OpenEBS Prometheus",
+      "name": "DS_PROMDASH",
+      "label": "Promdash",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -14,41 +14,53 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.5.2"
+      "version": "5.2.0"
     },
     {
       "type": "panel",
       "id": "graph",
       "name": "Graph",
-      "version": ""
+      "version": "5.0.0"
     },
     {
       "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
-      "version": "1.0.0"
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "singlestat",
       "name": "Singlestat",
-      "version": ""
+      "version": "5.0.0"
     },
     {
       "type": "panel",
       "id": "text",
       "name": "Text",
-      "version": ""
+      "version": "5.0.0"
     }
   ],
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "${DS_PROMDASH}",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "limit": 100,
+        "name": "Annotations & Alerts",
+        "showIn": 0,
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "hideControls": false,
   "id": null,
+  "iteration": 1531390236560,
   "links": [
     {
       "icon": "info",
@@ -60,573 +72,572 @@
       "url": "http://docs.openebs.io/"
     }
   ],
-  "refresh": false,
-  "rows": [
+  "panels": [
     {
-      "collapse": false,
-      "height": 328,
-      "panels": [
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "description": "Elapsed time since Volume was provisioned",
+      "format": "m",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
-          "description": "Elapsed time since Volume was provisioned",
-          "format": "m",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 10,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "OpenEBS_volume_uptime{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/60",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "refId": "A",
-              "step": 30
-            }
-          ],
-          "thresholds": "",
-          "title": "Uptime",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
+          "name": "value to text",
+          "value": 1
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(50, 172, 45, 0.97)",
-            "rgba(237, 81, 40, 0.89)",
-            "rgba(245, 54, 54, 0.9)"
-          ],
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
-          "description": "Capacity Used by the Volume",
-          "format": "decgbytes",
-          "gauge": {
-            "maxValue": 5,
-            "minValue": 0,
-            "show": true,
-            "thresholdLabels": false,
-            "thresholdMarkers": false
-          },
-          "id": 2,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": true,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false
-          },
-          "tableColumn": "__name__",
-          "targets": [
-            {
-              "expr": "OpenEBS_actual_used{openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "",
-              "refId": "A",
-              "step": 30
-            }
-          ],
-          "thresholds": "4,5",
-          "title": "Capacity",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "OpenEBS_jiva_volume_uptime{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/60",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": "",
+      "title": "Uptime",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#3f6833",
+        "rgba(237, 81, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "description": "Capacity Used by the Volume",
+      "format": "decgbytes",
+      "gauge": {
+        "maxValue": 5,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": false
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
         },
         {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "__name__",
+      "targets": [
+        {
+          "expr": "OpenEBS_jiva_size_of_volume{openebs_pv=~\"$OpenEBS\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 30
+        }
+      ],
+      "thresholds": "",
+      "title": "Capacity",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMDASH}",
+      "format": "decgbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 12,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "OpenEBS_jiva_actual_used{openebs_pv=~\"$OpenEBS\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 15
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": "2h",
+      "timeShift": null,
+      "title": "Storage Usage",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "content": "<img src=\"https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png\" alt=\"OpenEBS logo\" style=\"height: 40px;\">\n<span style=\"font-family: 'Open Sans', 'Helvetica Neue', Helvetica; font-size: 25px;vertical-align: text-top;color: #bbbfc2;margin-left: 10px;\">OpenEBS</span>\n\n<p style=\"margin-top: 10px;\">You're monitoring OpenEBS Volumes using Prometheus. For more information, check out the <a href=\"http://openebs.io/\">OpenEBS</a> and <a href=\"http://prometheus.io/\">Prometheus</a> projects. If you would like to retain this volume monitoring data and much more, sign-up for <a href=\"http://mayaonline.io/\">MayaOnline</a> </p>",
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 11,
+      "links": [],
+      "mode": "html",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "IOPS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(OpenEBS_jiva_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Reads}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "increase(OpenEBS_jiva_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{Writes}}",
+          "refId": "B",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
           "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "id": 12,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "span": 3,
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": true
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "OpenEBS_actual_used{openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "intervalFactor": 1,
-              "refId": "A",
-              "step": 15
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": "2h",
-          "timeShift": null,
-          "title": "Storage Usage",
-          "type": "singlestat",
-	  "hideTimeOverride": true,
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "avg"
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
         },
         {
-          "content": "<img src=\"https://raw.githubusercontent.com/openebs/chitrakala/master/OpenEBS%20logo/openebs%20logos-03.png\" alt=\"OpenEBS logo\" style=\"height: 40px;\">\n<span style=\"font-family: 'Open Sans', 'Helvetica Neue', Helvetica; font-size: 25px;vertical-align: text-top;color: #bbbfc2;margin-left: 10px;\">OpenEBS</span>\n\n<p style=\"margin-top: 10px;\">You're monitoring OpenEBS Volumes using Prometheus. For more information, check out the <a href=\"http://openebs.io/\">OpenEBS</a> and <a href=\"http://prometheus.io/\">Prometheus</a> projects. If you would like to retain this volume monitoring data and much more, sign-up for <a href=\"http://mayaonline.io/\">MayaOnline</a> </p>",
-          "id": 11,
-          "links": [],
-          "mode": "html",
-          "span": 3,
-          "title": "",
-          "transparent": true,
-          "type": "text"
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Dashboard Row",
-      "titleSize": "h6"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "Throughput",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
-          "description": "IOPS",
-          "fill": 1,
-          "id": 3,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "rightSide": true,
-            "sideWidth": 350,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_iops{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Reads}}",
-              "refId": "A",
-              "step": 2
-            },
-            {
-              "expr": "OpenEBS_write_iops{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "intervalFactor": 2,
-              "legendFormat": "{{Writes}}",
-              "refId": "B",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "IOPS",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "none",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "expr": "increase(OpenEBS_jiva_read_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Read Throughput}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "increase(OpenEBS_jiva_write_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Write Throughput}}",
+          "refId": "B",
+          "step": 2
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "IOPS Graph",
-      "titleSize": "h6"
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     },
     {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMDASH}",
+      "description": "Latency",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": false,
+        "max": true,
+        "min": true,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
-          "description": "Throughput",
-          "fill": 1,
-          "id": 9,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "rightSide": true,
-            "sideWidth": 350,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "connected",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_block_count_per_second{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/(1024*1024)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Read Throughput}}",
-              "refId": "A",
-              "step": 2
-            },
-            {
-              "expr": "OpenEBS_write_block_count_per_second{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/(1024*1024)",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Write Throughput}}",
-              "refId": "B",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Throughput",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "MBs",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "expr": "((increase(OpenEBS_jiva_read_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(OpenEBS_jiva_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Read Latency}}",
+          "refId": "A",
+          "step": 2
+        },
+        {
+          "expr": "((increase(OpenEBS_jiva_write_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(OpenEBS_jiva_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{Write Latency}}",
+          "refId": "B",
+          "step": 2
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Throughput Graph",
-      "titleSize": "h6"
-    },
-    {
-      "collapse": false,
-      "height": 275,
-      "panels": [
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_OPENEBS_PROMETHEUS}",
-          "description": "Latency",
-          "fill": 1,
-          "id": 5,
-          "legend": {
-            "alignAsTable": true,
-            "avg": true,
-            "current": false,
-            "rightSide": true,
-            "sideWidth": 350,
-            "max": true,
-            "min": true,
-            "show": true,
-            "total": false,
-            "values": true
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "percentage": false,
-          "pointradius": 5,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "span": 12,
-          "stack": true,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "OpenEBS_read_latency{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Read Latency}}",
-              "refId": "A",
-              "step": 2
-            },
-            {
-              "expr": "OpenEBS_write_latency{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}",
-              "format": "time_series",
-              "hide": false,
-              "intervalFactor": 2,
-              "legendFormat": "{{Write Latency}}",
-              "refId": "B",
-              "step": 2
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Latency",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "s",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": false
-            }
-          ]
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
         }
       ],
-      "repeat": null,
-      "repeatIteration": null,
-      "repeatRowId": null,
-      "showTitle": false,
-      "title": "Latency Graph",
-      "titleSize": "h6"
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
-  "schemaVersion": 14,
+  "refresh": false,
+  "schemaVersion": 16,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -634,14 +645,14 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_OPENEBS_PROMETHEUS}",
+        "datasource": "${DS_PROMDASH}",
         "hide": 0,
         "includeAll": false,
         "label": "OpenEBS Volume",
         "multi": false,
         "name": "OpenEBS",
         "options": [],
-        "query": "label_values(OpenEBS_size_of_volume, openebs_pv)",
+        "query": "label_values(OpenEBS_jiva_size_of_volume, openebs_pv)",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -684,5 +695,6 @@
   },
   "timezone": "",
   "title": "OpenEBS Volume Stats",
+  "uid": "JOHe1vdiz",
   "version": 2
-}
+} 

--- a/k8s/openebs-pg-dashboard.json
+++ b/k8s/openebs-pg-dashboard.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_PROMDASH",
-      "label": "Promdash",
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "OpenEBS Prometheus",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -45,7 +45,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "${DS_PROMDASH}",
+        "datasource": "${DS_OPENEBS_PROMETHEUS}",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -60,7 +60,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "iteration": 1531390236560,
+  "iteration": 1532616818599,
   "links": [
     {
       "icon": "info",
@@ -82,7 +82,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "description": "Elapsed time since Volume was provisioned",
       "format": "m",
       "gauge": {
@@ -135,7 +135,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "OpenEBS_jiva_volume_uptime{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/60",
+          "expr": "openebs_volume_uptime{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}/60",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -165,7 +165,7 @@
         "rgba(237, 81, 40, 0.89)",
         "rgba(245, 54, 54, 0.9)"
       ],
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "description": "Capacity Used by the Volume",
       "format": "decgbytes",
       "gauge": {
@@ -218,7 +218,7 @@
       "tableColumn": "__name__",
       "targets": [
         {
-          "expr": "OpenEBS_jiva_size_of_volume{openebs_pv=~\"$OpenEBS\"}",
+          "expr": "openebs_size_of_volume{openebs_pv=~\"$OpenEBS\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -249,7 +249,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "format": "decgbytes",
       "gauge": {
         "maxValue": 100,
@@ -302,7 +302,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "OpenEBS_jiva_actual_used{openebs_pv=~\"$OpenEBS\"}",
+          "expr": "openebs_actual_used{openebs_pv=~\"$OpenEBS\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -344,7 +344,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "description": "IOPS",
       "fill": 1,
       "gridPos": {
@@ -380,7 +380,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(OpenEBS_jiva_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
+          "expr": "increase(openebs_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -389,7 +389,7 @@
           "step": 2
         },
         {
-          "expr": "increase(OpenEBS_jiva_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
+          "expr": "increase(openebs_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/60",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{Writes}}",
@@ -442,7 +442,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "description": "Throughput",
       "fill": 1,
       "gridPos": {
@@ -478,7 +478,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(OpenEBS_jiva_read_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
+          "expr": "increase(openebs_read_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -487,7 +487,7 @@
           "step": 2
         },
         {
-          "expr": "increase(OpenEBS_jiva_write_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
+          "expr": "increase(openebs_write_block_count{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])/(1024*1024*60)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -541,7 +541,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "${DS_PROMDASH}",
+      "datasource": "${DS_OPENEBS_PROMETHEUS}",
       "description": "Latency",
       "fill": 1,
       "gridPos": {
@@ -577,7 +577,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "((increase(OpenEBS_jiva_read_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(OpenEBS_jiva_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
+          "expr": "((increase(openebs_read_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(openebs_reads{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -586,7 +586,7 @@
           "step": 2
         },
         {
-          "expr": "((increase(OpenEBS_jiva_write_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(OpenEBS_jiva_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
+          "expr": "((increase(openebs_write_time{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m]))/(increase(openebs_writes{job=\"openebs-volumes\", openebs_pv=~\"$OpenEBS\"}[1m])))/1000000",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -645,14 +645,14 @@
       {
         "allValue": null,
         "current": {},
-        "datasource": "${DS_PROMDASH}",
+        "datasource": "${DS_OPENEBS_PROMETHEUS}",
         "hide": 0,
         "includeAll": false,
         "label": "OpenEBS Volume",
         "multi": false,
         "name": "OpenEBS",
         "options": [],
-        "query": "label_values(OpenEBS_jiva_size_of_volume, openebs_pv)",
+        "query": "label_values(openebs_size_of_volume, openebs_pv)",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -697,4 +697,4 @@
   "title": "OpenEBS Volume Stats",
   "uid": "JOHe1vdiz",
   "version": 2
-} 
+}


### PR DESCRIPTION
On branch US2355-dashboard
Changes to be committed:
	modified:   openebs-monitoring-pg.yaml
	modified:   openebs-pg-dashboard.json

1. Why is this change necessary?
-  PR openebs/maya#379 involves lot of change in logic w.r.t stats calculation
   so existing dashboard will not work.
-  To incorporate those changes in the dashboard.

2. How does it address the issue?
-  This commit make changes in the PromQL and dashboard JSON to get the
   cumulative stats.

3. What side effects does this change have?
-  Docker images with tags < 0.6.0 will not be compatible with this dashboard.

4. How to verify this change?
-  Make sure you are using the m-exporter's image tag > `0.6.0`
-  Deploy the openebs-monitoring-pg.yaml on kubernetes cluster.
-  Import the new dashboard and it should work.

5. Any specific message for reviewer ?
-  Added namespace field in the Prometheus's template.
-  Replaced the job name from `openebs-prometheus-server` to `prometheus` only.
   Prometheus's dashboard is breaking with the current specs, because grafana is autoconfigured with
   job name `prometheus`.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>