### PR TITLE
Added new URL for dashboard

### DIFF
--- a/k8s/vagrant/README.md
+++ b/k8s/vagrant/README.md
@@ -123,6 +123,13 @@ Starting to serve on 127.0.0.1:8001
 ### Verify 
 
 Launch the URL http://127.0.0.1:8001/ui
+While accessing above URL if you see following Error.
+```
+Error: 'tls: oversized record received with length 20527'
+Trying to reach: 'https://10.244.4.2:9090/'
+```
+Launch the below URL 
+http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/#!/overview?namespace=default
 
 **Your local Kubernetes cluster with the dashboard is ready. The below steps are required only if you would like to run stateful applications with OpenEBS**
 

--- a/k8s/vagrant/README.md
+++ b/k8s/vagrant/README.md
@@ -123,13 +123,14 @@ Starting to serve on 127.0.0.1:8001
 ### Verify 
 
 Launch the URL http://127.0.0.1:8001/ui
-While accessing above URL if you see following Error.
+
+While accessing the above URL, if you see the following error, launch the URL http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/#!/overview?namespace=default
+
 ```
 Error: 'tls: oversized record received with length 20527'
 Trying to reach: 'https://10.244.4.2:9090/'
 ```
-Launch the below URL 
-http://127.0.0.1:8001/api/v1/namespaces/kube-system/services/http:kubernetes-dashboard:/proxy/#!/overview?namespace=default
+
 
 **Your local Kubernetes cluster with the dashboard is ready. The below steps are required only if you would like to run stateful applications with OpenEBS**
 


### PR DESCRIPTION
For accessing the kubernetes  dashboard locally,  added the new URL.

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR will help the users to access the kubernetes dashboard with new URL
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Issue number: 224
**Special notes for your reviewer**:
Found the issue while accessing the dashboard with old URL.With new URL provided the dashboard accessing is fine.

Signed-off-by: Prabhat kumar Thakur prabhat.thakur@cloudbyte.com