### PR TITLE
Included get node name task in kubelet-service-restart playbook

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/cleanup.yml
@@ -1,7 +1,7 @@
 ---
 
        - name: check the node is in Ready state after kubelet service start
-         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
+         shell: source ~/.profile; kubectl get nodes {{node_name.stdout}} | grep 'NotReady' | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: result1
@@ -24,7 +24,7 @@
              changed_when: True
 
            - name: Check the node is in Ready state after kubelet service start
-             shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
+             shell: source ~/.profile; kubectl get nodes {{node_name.stdout}} | grep 'NotReady' | grep 'none' | wc -l
              args:
                executable: /bin/bash
              register: result

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop-vars.yml
@@ -19,4 +19,3 @@ test_pod_regex: maya*|openebs*|pvc*|percona*
 
 test_log_path: setup/logs/kubelet_service_restart_test.log
 
-node_name: kubeminion-01

--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
@@ -98,6 +98,14 @@
        - debug:
            msg: "All the nodes are in ready state"
          when: (node_count)| int == (ready_node_cout.stdout)| int
+ 
+       - name: Get the node name 
+         shell: source ~/.profile; kubectl get nodes | awk {'print $1'} | awk 'FNR == 2 {print}'
+         args:
+           executable: /bin/bash
+         register: node_name
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
 
        - name: Stop kubelet service in one of the node
          shell: source ~/.profile; systemctl stop kubelet.service
@@ -110,7 +118,7 @@
 
 
        - name: check the node is in NotReady state after kubelet service is stopped
-         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep NotReady | wc -l
+         shell: source ~/.profile; kubectl get nodes {{node_name.stdout}} | grep NotReady | wc -l
          args:
            executable: /bin/bash
          register: result
@@ -141,7 +149,7 @@
 
 
        - name: check the node is in Ready state after kubelet service start
-         shell: source ~/.profile; kubectl get nodes {{node_name}} | grep 'NotReady' | grep 'none' | wc -l
+         shell: source ~/.profile; kubectl get nodes {{node_name.stdout}} | grep 'NotReady' | grep 'none' | wc -l
          args:
            executable: /bin/bash
          register: result


### PR DESCRIPTION
Signed-off-by: swarna <swarnalatha@mayadata.io>

**What this PR does / why we need it**:
Included get node name task to check the status of the node after kubelet service stop/start.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@gprasath Please review this PR.
