### PR TITLE
modifies node-eviction-out-of-disk.yml

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -179,7 +179,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Check the available replicas in deployment
-         shell: kubectl get deploy -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $6}'
+         shell: kubectl get deploy -n {{ namespace }} | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $2}'
          args:
            executable: /bin/bash
          register: available_pods

--- a/e2e/ansible/playbooks/resiliency/test-data-integrity/test-di-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-data-integrity/test-di-cleanup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Delete the snapshot claim
-  shell: source ~/.profile; kubectl delete -f "{{ ressult_kube_home.stdout}}/{{ snapshot_claim }}" -n "{{ namespace }}"
+  shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout}}/{{ snapshot_claim }}" -n "{{ namespace }}"
   args:
     executable: /bin/bash
   register: delete_claim

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -72,7 +72,7 @@
          args:
            executable: /bin/bash
          register: sc_out
-         until: "'created' in sc_out.stdout"
+         until: "'configured' in sc_out.stdout"
          delay: 10
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -145,7 +145,7 @@
            timeout: 120
 
        - name: 3b) Set replica deployment with node affinity policy
-         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -n {{ namespace }} -p "$(cat replica_patch.yaml)"
+         shell: kubectl patch deployment "{{ deploy_name.stdout }}" -n {{ namespace }} -p "$(cat {{ result_kube_home.stdout }}/replica_patch.yaml)"
          args:
            executable: /bin/bash
          register: patch_out


### PR DESCRIPTION
Signed-off-by: Shashank Ranjan <ranjanshashank855@gmail.com>

**What this PR does / why we need it**:
1: Modified node-eviction-out-of-disk.yml to run n GKE.
2: Rectifies a typo error in test-k8s-drain-nodes.
3:Rectifies a typo error in test-data-integrity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
