### PR TITLE
Ansible role to Add a disk in GCP nodes

### DIFF
--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -1,6 +1,9 @@
 ---
 - include: pre-requisites.yml
 
+- include: setup-disks.yml
+  when: cluster_type == "managed"
+
 - include: setup-kubernetes.yml
 
 - include: setup-stern.yml

--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -11,4 +11,3 @@
 - include: setup-openebs.yml
 
 - include: run-tests.yml 
-

--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -91,3 +91,7 @@ build_type: normal
 
 # In case , if you want to deploy openebs in the cluster in managed kubernetes services, specify "cluster_type= managed". By default specifying the cluster_type to local.
 cluster_type: hosted
+
+# This allows us to select the tool to create the disks based on the cloud the disks are being created on:
+# Accepted Entries: GCP, AWS
+cloud_provider: GCP

--- a/e2e/ansible/roles/k8s-gke/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-gke/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ansible_connection: local
-cluster_zone: "{{ lookup ('env','CLUSTER_ZONE') }}"
+cluster_zone: "{{ lookup ('env','ZONE') }}"
 disk_size: 100
 disk_type: pd-standard
 disk_count: 2 

--- a/e2e/ansible/roles/k8s-gke/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-gke/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+ansible_connection: local
+cluster_zone: "{{ lookup ('env','CLUSTER_ZONE') }}"
+disk_size: 100
+disk_type: pd-standard
+disk_count: 2 
+

--- a/e2e/ansible/roles/k8s-gke/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-gke/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Get the details of the available nodes
+  shell: kubectl get nodes | grep gke | awk {'print $1'}
+  args:
+    executable: /bin/bash
+  register: result_node
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Creating random name for the disks
+  shell: echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2
+  args:
+    executable: /bin/bash
+  register: name
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+- name: Creating the required number of disk 
+  shell: >
+    for ((i=0; i< "{{ disk_count }}"; i++));do
+      gcloud compute disks create {{ item }}-{{ name.stdout }}-${i}  --size "{{ disk_size }}" --type "{{ disk_type }}" --zone "{{ cluster_zone }}" &&
+      gcloud compute instances attach-disk {{ item }} --disk {{ item }}-{{ name.stdout }}-${i} --zone "{{ cluster_zone }}"
+    done
+  args:
+    executable: /bin/bash 
+  register: result_disk
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  with_items: "{{ result_node.stdout_lines }}"

--- a/e2e/ansible/setup-disks.yml
+++ b/e2e/ansible/setup-disks.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+    - {role: k8s-gke, when: cloud_provider == "GCP"} 


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

**What this PR does / why we need it**:
This PR will be the ansible role to add the additional blank disk in the GCP nodes. 
In this role  `setup-disk.yml`  will add a default of 100GB of two standard persistent disk in each nodes of the cluster.

Note: Before running this role give the cluster zone details in environmental variable
for ex : `export ZONE="us-central1-a"`
@ksatchit , @yudaykiran , @gprasath , @dargasudarshan  can you please review this PR.