### PR TITLE
Removing Setup disk role in ci file

### DIFF
--- a/e2e/ansible/ci.yml
+++ b/e2e/ansible/ci.yml
@@ -1,9 +1,6 @@
 ---
 - include: pre-requisites.yml
 
-- include: setup-disks.yml
-  when: cluster_type == "managed"
-
 - include: setup-kubernetes.yml
 
 - include: setup-stern.yml


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

**What this PR does / why we need it**:

Removed the setup-disk in gke role in ci.yml file. Because of detach and remove the disk, role is not present at this time. It will include once the delete disk role is available.

@yudaykiran can you review this PR