### PR TITLE
Include find module to search for panic and RO states in test result log file.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
@@ -218,6 +218,14 @@
      always:
        - block:
 
+           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/find_regex.yml"
+             vars:
+               string:
+                 - 'panic'
+                 - 'Read-only'
+               path: "{{result_kube_home.stdout}}/{{test_log_path}}"
+               destination_node: "{{groups['kubernetes-kubemasters'].0}}"
+
            - include: cleanup.yml
 
            - name: Test Cleanup Passed

--- a/e2e/ansible/playbooks/resiliency/test-node-failure/test-node-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-failure/test-node-failure.yml
@@ -105,6 +105,14 @@
      always:
        - block:
 
+           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/find_regex.yml"
+             vars:
+               string:
+                 - 'panic'
+                 - 'Read-only'
+               path: "{{result_kube_home.stdout}}/{{test_log_path}}"
+               destination_node: "{{groups['kubernetes-kubemasters'].0}}"
+
            - include: cleanup.yml
 
            - name: Test Cleanup Passed

--- a/e2e/ansible/playbooks/utils/find_regex.yml
+++ b/e2e/ansible/playbooks/utils/find_regex.yml
@@ -1,0 +1,24 @@
+---
+- name: Find regex in the log file
+  shell: grep -i  {{item}} {{ path }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{ destination_node }}"
+  register: result
+  ignore_errors: true
+  with_items: 
+    - "{{ string }}"
+  
+- name: Add observations to the log file
+  lineinfile:
+    dest: "{{ path }}"
+    line: 'Observation'
+  delegate_to: "{{ destination_node }}"
+
+- name: Add observations to the log file
+  blockinfile:
+    dest: "{{ path }}"
+    block:  "{{ item.stdout }}"
+  delegate_to: "{{ destination_node }}"
+  with_items: 
+    - "{{ result.results }}"


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include find module to search for panic and RO states in test result log file.
- Included this task file in kubelet-service stop and node failure test playbooks to add observation section with the keywords Read-only and panic.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
