### PR TITLE
Adds default namespace for maya-apiserver-server service

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -103,6 +103,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: maya-apiserver-service
+  namespace: default
 spec:
   ports:
   - name: api
@@ -164,6 +165,7 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepoolclaims.openebs.io
+  namespace: default
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io
@@ -187,6 +189,7 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: storagepools.openebs.io
+  namespace: default
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io
@@ -209,6 +212,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: openebs-standard
+   namespace: default
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"
@@ -221,6 +225,7 @@ kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
   name: volumepolicies.openebs.io
+  namespace: default
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: openebs.io


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR adds a default namespace to maya-apiserver-service .
- This is needed because if we apply the operator from a different namespace other than default the service is created in that namespace  and provisioner is not able to connect to api server .

**Special notes for your reviewer**:
- When openebs operator is applied through litmus book the mayapiserver service is getting created in litmus namespace and leads provisoner to crashloop error

```ubuntu@kubemaster-01:/vagrant/litmus/Providers/OpenEBS/Installers/Operator/0.5.4/litmusbook$ kubectl get pods
NAME                                   READY     STATUS             RESTARTS   AGE
maya-apiserver-9679b678-qlzdk          1/1       Running            0          47m
openebs-provisioner-55ff5cd67f-c48v7   0/1       CrashLoopBackOff   13         47m
```
```ubuntu@kubemaster-01:/vagrant/litmus/Providers/OpenEBS/Installers/Operator/0.5.4/litmusbook$ kubectl get svc --all-namespaces
NAMESPACE     NAME                     TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
default       kubernetes               ClusterIP   10.96.0.1      <none>        443/TCP         16h
kube-system   kube-dns                 ClusterIP   10.96.0.10     <none>        53/UDP,53/TCP   16h
kube-system   kubernetes-dashboard     ClusterIP   10.108.67.44   <none>        80/TCP          16h
litmus        maya-apiserver-service   ClusterIP   10.96.8.19     <none>        5656/TCP        55m
```
