### PR TITLE
Modified the storage class deletion check condition which impacts the…

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -50,7 +50,7 @@
          args:
            executable: /bin/bash
          register: sc_out
-         until: "'deleted' not in sc_out.stdout"
+         until: "'deleted' in sc_out.stdout"
          delay: 10
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"


### PR DESCRIPTION
… upcoming tests in CI

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- The check condition implemented to ensure the deletion of storage class is incorrect. As an impact, the deletion check task fails, so 'openebs-percona' storage class was not created. This impacts the upcoming tests whichever uses 'opeenbs-percona' storage class for application deployment.