### PR TITLE
Disabling the feature gate values in openebs-operator ansible role

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -9,6 +9,12 @@
   delay: 5
   retries: 3
 
+- name: Disable the feature gate in operator.yaml
+  replace:
+    path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
+    regexp: 'value: "true"'
+    replace: 'value: "false"'
+
 - name: Change snapshot label to name from app
   shell: "sed -i 's/app: openebs-snapshot-controller/name: openebs-snapshot-controller/g' {{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
   args:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- Replacing the OPENEBS_IO_CAS_TEMPLATE_FEATURE_GATE value to false in openebs-operator.yaml before deploying it.
- By default, it is enabled now. Due to this , PV creation is failing.