### PR TITLE
Including the task that checks if ndm is running in all the nodes in …

### DIFF
--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -9,7 +9,7 @@
   delay: 5
   retries: 3
 
-- name: Change m-apiserver image to desired tag in operator YAML
+- name: Change the images of openebs resources to desired tag in operator YAML
   replace:
     path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}" 
     regexp: "{{item}}:[\\w.-]+"
@@ -20,6 +20,7 @@
     - openebs-k8s-provisioner
     - snapshot-controller
     - snapshot-provisioner
+    - node-disk-manager-amd64
 
 - block:
 
@@ -74,6 +75,21 @@
   delay: 120
   retries: 15
   with_items: "{{ labels.stdout_lines }}"
+
+- name: Getting the number of nodes
+  shell: source ~/.profile; kubectl get nodes | grep '<none>' | wc -l
+  args:
+    executable: /bin/bash
+  register: node_count
+
+- name: Confirm if node-disk-manager is running in all the nodes
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} --selector=app=node-disk-manager | grep Running | wc -l
+  args:
+    executable: /bin/bash
+  register: ndm_count
+  until: (node_count.stdout)|int == (ndm_count.stdout)|int
+  delay: 30
+  retries: 15
 
 - name: Get maya-apiserver pod name
   shell: source ~/.profile; kubectl get pods -n {{ namespace }} --selector=name=maya-apiserver


### PR DESCRIPTION
…operator role

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Fetching the node count.
- Checking if ndm pods are running in all the nodes.

```
giri@vagrant-host:~/oebs/openebs/e2e/ansible$ ansible-playbook setup-openebs.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/oebs/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/oebs/openebs/e2e/ansible/ansible.cfg as config file

PLAYBOOK: setup-openebs.yml ********************************************************************************************************************************************************************************
2 plays in setup-openebs.yml

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-operator-helm : 1) Getting the home directory of kubernetes master.] *********************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:13
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : Install helm client] *****************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:19
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : wait_for] ****************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:28
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 2a) Tiller setup.] *******************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:30
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 3) Checking if the tiller pod is created.] *******************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:39
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 4) Checking if the tiller service account already exists.] ***************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:50
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 5) Checking if the tiller cluster role binding already exists.] **********************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:72
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 6) Copying the patch yaml file to kubernetes master.] ********************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:92
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 6a) Updating the tiller-deploy deployment with the service account.] *****************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:97
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 7) Installing openebs using stable charts.] ******************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:108
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 8) Checking if the provisioner is up.] ***********************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:121
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 8a) Checking if the openebs-apiserver is up.] ****************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:130
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 8b) Checking of the snapshot-operator is up.] ****************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:139
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [k8s-openebs-operator-helm : 9) Creating the default storage classes] *********************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator-helm/tasks/main.yaml:148
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}
META: ran handlers
META: ran handlers

PLAY [kubernetes-kubemasters] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [kubemaster01]
META: ran handlers

TASK [k8s-openebs-operator : Download YAML for openebs operator] *******************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:2
changed: [kubemaster01] => {"attempts": 1, "changed": true, "checksum_dest": "967d0bd87307650a858a552939d91b8d0030a05a", "checksum_src": "e8068d742ef1ce7ff40c4e5df481ddfaba632ca4", "dest": "/home/ubuntu/openebs-operator.yaml", "gid": 1000, "group": "ubuntu", "md5sum": "c98a7bd0d89912f972c48ac0bd678fa3", "mode": "0664", "msg": "OK (17283 bytes)", "owner": "ubuntu", "size": 17283, "src": "/tmp/tmpa2s8bK", "state": "file", "status_code": 200, "uid": 1000, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml"}

TASK [k8s-openebs-operator : Change the images of openebs resources to desired tag in operator YAML] *******************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:12
ok: [kubemaster01] => (item=m-apiserver) => {"changed": false, "item": "m-apiserver", "msg": ""}
changed: [kubemaster01] => (item=jiva) => {"changed": true, "item": "jiva", "msg": "2 replacements made"}
ok: [kubemaster01] => (item=openebs-k8s-provisioner) => {"changed": false, "item": "openebs-k8s-provisioner", "msg": ""}
ok: [kubemaster01] => (item=snapshot-controller) => {"changed": false, "item": "snapshot-controller", "msg": ""}
ok: [kubemaster01] => (item=snapshot-provisioner) => {"changed": false, "item": "snapshot-provisioner", "msg": ""}
ok: [kubemaster01] => (item=node-disk-manager-amd64) => {"changed": false, "item": "node-disk-manager-amd64", "msg": ""}

TASK [k8s-openebs-operator : Get kubernetes master name] ***************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:27
changed: [kubemaster01] => {"changed": true, "cmd": "hostname", "delta": "0:00:00.010459", "end": "2018-08-08 07:34:58.475250", "rc": 0, "start": "2018-08-08 07:34:58.464791", "stderr": "", "stderr_lines": [], "stdout": "kubemaster-01", "stdout_lines": ["kubemaster-01"]}

TASK [k8s-openebs-operator : Get kubernetes master status] *************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:33
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get nodes | grep kubemaster-01 | awk '{print $2}'", "delta": "0:00:02.794998", "end": "2018-08-08 07:35:02.873061", "rc": 0, "start": "2018-08-08 07:35:00.078063", "stderr": "", "stderr_lines": [], "stdout": "Ready", "stdout_lines": ["Ready"]}

TASK [k8s-openebs-operator : debug] ************************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:43
skipping: [kubemaster01] => {"changed": false, "skip_reason": "Conditional result was False"}
META: 

TASK [k8s-openebs-operator : Start the log aggregator to capture operator logs] ****************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:54
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; nohup stern \"maya*|openebs*\" --since 1m >\"/home/ubuntu/setup/logs/operator.log\" &", "delta": "0:00:01.008661", "end": "2018-08-08 07:35:05.563226", "rc": 0, "start": "2018-08-08 07:35:04.554565", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [k8s-openebs-operator : Deploy the openebs operator yml] **********************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:59
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; kubectl apply -f /home/ubuntu/openebs-operator.yaml | grep deployment | awk '{print $2}' | tr -d '\"'", "delta": "0:00:03.344653", "end": "2018-08-08 07:35:10.118393", "rc": 0, "start": "2018-08-08 07:35:06.773740", "stderr": "", "stderr_lines": [], "stdout": "maya-apiserver\nopenebs-provisioner\nopenebs-snapshot-operator", "stdout_lines": ["maya-apiserver", "openebs-provisioner", "openebs-snapshot-operator"]}

TASK [k8s-openebs-operator : Confirm provisioner & apiserver are running] **********************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:69
FAILED - RETRYING: Confirm provisioner & apiserver are running (15 retries left).
changed: [kubemaster01] => (item=maya-apiserver) => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get pods --selector=name=maya-apiserver -n openebs | grep Running |wc -l", "delta": "0:00:00.537986", "end": "2018-08-08 07:37:15.949245", "item": "maya-apiserver", "rc": 0, "start": "2018-08-08 07:37:15.411259", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [kubemaster01] => (item=openebs-provisioner) => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods --selector=name=openebs-provisioner -n openebs | grep Running |wc -l", "delta": "0:00:01.145353", "end": "2018-08-08 07:37:18.129122", "item": "openebs-provisioner", "rc": 0, "start": "2018-08-08 07:37:16.983769", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [kubemaster01] => (item=openebs-snapshot-operator) => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods --selector=name=openebs-snapshot-operator -n openebs | grep Running |wc -l", "delta": "0:00:01.022816", "end": "2018-08-08 07:37:20.111670", "item": "openebs-snapshot-operator", "rc": 0, "start": "2018-08-08 07:37:19.088854", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}

TASK [k8s-openebs-operator : Getting the number of nodes] **************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:79
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; kubectl get nodes | grep '<none>' | wc -l", "delta": "0:00:01.431170", "end": "2018-08-08 07:37:22.436675", "rc": 0, "start": "2018-08-08 07:37:21.005505", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [k8s-openebs-operator : Confirm if node-disk-manager is running in all the nodes] *********************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:85
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n openebs --selector=app=node-disk-manager | grep Running | wc -l", "delta": "0:00:00.896079", "end": "2018-08-08 07:37:24.545824", "rc": 0, "start": "2018-08-08 07:37:23.649745", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [k8s-openebs-operator : Get maya-apiserver pod name] **************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:94
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; kubectl get pods -n openebs --selector=name=maya-apiserver", "delta": "0:00:01.660172", "end": "2018-08-08 07:37:27.316316", "rc": 0, "start": "2018-08-08 07:37:25.656144", "stderr": "", "stderr_lines": [], "stdout": "NAME                             READY     STATUS    RESTARTS   AGE\nmaya-apiserver-56665fc6f-lxfmk   1/1       Running   0          2m", "stdout_lines": ["NAME                             READY     STATUS    RESTARTS   AGE", "maya-apiserver-56665fc6f-lxfmk   1/1       Running   0          2m"]}

TASK [k8s-openebs-operator : Create fact for pod name] *****************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:100
ok: [kubemaster01] => {"ansible_facts": {"pod_name": "maya-apiserver-56665fc6f-lxfmk"}, "changed": false}

TASK [k8s-openebs-operator : Confirm that maya-cli is available in the maya-apiserver pod] *****************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:104
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; kubectl exec maya-apiserver-56665fc6f-lxfmk -c maya-apiserver -n openebs -- mayactl version", "delta": "0:00:03.845822", "end": "2018-08-08 07:37:32.824535", "failed_when_result": false, "rc": 0, "start": "2018-08-08 07:37:28.978713", "stderr": "", "stderr_lines": [], "stdout": "Version: v0.6.0-unreleased\nGit commit: 86185a65b7dd9b2f7f76eec65d04f9fa0af81a20\nGO Version: go1.9.1\nGO ARCH: amd64\nGO OS: linux\nm-apiserver url:  http://10.1.2.70:5656\nm-apiserver status:  running\nProvider:  KUBERNETES", "stdout_lines": ["Version: v0.6.0-unreleased", "Git commit: 86185a65b7dd9b2f7f76eec65d04f9fa0af81a20", "GO Version: go1.9.1", "GO ARCH: amd64", "GO OS: linux", "m-apiserver url:  http://10.1.2.70:5656", "m-apiserver status:  running", "Provider:  KUBERNETES"]}

TASK [k8s-openebs-operator : Download YAML for openebs storage classes] ************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:111
ok: [kubemaster01] => {"attempts": 1, "changed": false, "checksum_dest": "fab9e051439f0ccf6545b22dc62ed9eb09fe745b", "checksum_src": "fab9e051439f0ccf6545b22dc62ed9eb09fe745b", "dest": "/home/ubuntu/openebs-storageclasses.yaml", "gid": 1000, "group": "ubuntu", "md5sum": "29b4065e434d33be47ab82b78b4b4b00", "mode": "0664", "msg": "OK (2529 bytes)", "owner": "ubuntu", "size": 2529, "src": "/tmp/tmpbjAmUh", "state": "file", "status_code": 200, "uid": 1000, "url": "https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-storageclasses.yaml"}

TASK [k8s-openebs-operator : Deploy the openebs storageclasses yml] ****************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:121
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; kubectl apply -f /home/ubuntu/openebs-storageclasses.yaml", "delta": "0:00:01.056101", "end": "2018-08-08 07:37:42.054537", "rc": 0, "start": "2018-08-08 07:37:40.998436", "stderr": "", "stderr_lines": [], "stdout": "storageclass.storage.k8s.io \"openebs-standalone\" configured\nstorageclass.storage.k8s.io \"openebs-percona\" configured\nstorageclass.storage.k8s.io \"openebs-jupyter\" configured\nstorageclass.storage.k8s.io \"openebs-mongodb\" configured\nstorageclass.storage.k8s.io \"openebs-cassandra\" configured\nstorageclass.storage.k8s.io \"openebs-redis\" configured\nstorageclass.storage.k8s.io \"openebs-kafka\" configured\nstorageclass.storage.k8s.io \"openebs-zk\" configured\nstorageclass.storage.k8s.io \"openebs-es-data-sc\" configured", "stdout_lines": ["storageclass.storage.k8s.io \"openebs-standalone\" configured", "storageclass.storage.k8s.io \"openebs-percona\" configured", "storageclass.storage.k8s.io \"openebs-jupyter\" configured", "storageclass.storage.k8s.io \"openebs-mongodb\" configured", "storageclass.storage.k8s.io \"openebs-cassandra\" configured", "storageclass.storage.k8s.io \"openebs-redis\" configured", "storageclass.storage.k8s.io \"openebs-kafka\" configured", "storageclass.storage.k8s.io \"openebs-zk\" configured", "storageclass.storage.k8s.io \"openebs-es-data-sc\" configured"]}

TASK [k8s-openebs-operator : Confirm that openebs storage classes are created] *****************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:126
changed: [kubemaster01] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get sc", "delta": "0:00:00.850064", "end": "2018-08-08 07:37:43.544986", "rc": 0, "start": "2018-08-08 07:37:42.694922", "stderr": "", "stderr_lines": [], "stdout": "NAME                          PROVISIONER                                                AGE\nopenebs-cassandra             openebs.io/provisioner-iscsi                               12d\nopenebs-cstor-default-0.7.0   openebs.io/provisioner-iscsi                               2m\nopenebs-es-data-sc            openebs.io/provisioner-iscsi                               12d\nopenebs-jiva-default-0.7.0    openebs.io/provisioner-iscsi                               2m\nopenebs-jupyter               openebs.io/provisioner-iscsi                               12d\nopenebs-kafka                 openebs.io/provisioner-iscsi                               12d\nopenebs-mongodb               openebs.io/provisioner-iscsi                               12d\nopenebs-percona               openebs.io/provisioner-iscsi                               1d\nopenebs-redis                 openebs.io/provisioner-iscsi                               12d\nopenebs-snapshot-promoter     volumesnapshot.external-storage.k8s.io/snapshot-promoter   2m\nopenebs-standalone            openebs.io/provisioner-iscsi                               12d\nopenebs-standard              openebs.io/provisioner-iscsi                               2m\nopenebs-zk                    openebs.io/provisioner-iscsi                               12d\nsnapshot-promoter             volumesnapshot.external-storage.k8s.io/snapshot-promoter   19d", "stdout_lines": ["NAME                          PROVISIONER                                                AGE", "openebs-cassandra             openebs.io/provisioner-iscsi                               12d", "openebs-cstor-default-0.7.0   openebs.io/provisioner-iscsi                               2m", "openebs-es-data-sc            openebs.io/provisioner-iscsi                               12d", "openebs-jiva-default-0.7.0    openebs.io/provisioner-iscsi                               2m", "openebs-jupyter               openebs.io/provisioner-iscsi                               12d", "openebs-kafka                 openebs.io/provisioner-iscsi                               12d", "openebs-mongodb               openebs.io/provisioner-iscsi                               12d", "openebs-percona               openebs.io/provisioner-iscsi                               1d", "openebs-redis                 openebs.io/provisioner-iscsi                               12d", "openebs-snapshot-promoter     volumesnapshot.external-storage.k8s.io/snapshot-promoter   2m", "openebs-standalone            openebs.io/provisioner-iscsi                               12d", "openebs-standard              openebs.io/provisioner-iscsi                               2m", "openebs-zk                    openebs.io/provisioner-iscsi                               12d", "snapshot-promoter             volumesnapshot.external-storage.k8s.io/snapshot-promoter   19d"]}

TASK [k8s-openebs-operator : Terminate the log aggregator] *************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml:135
changed: [kubemaster01] => {"changed": true, "cmd": "source ~/.profile; killall stern", "delta": "0:00:00.092257", "end": "2018-08-08 07:37:44.441920", "rc": 0, "start": "2018-08-08 07:37:44.349663", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
kubemaster01               : ok=18   changed=14   unreachable=0    failed=0 
```