### PR TITLE
Deleting deployments, pods and volumes forcefully in pre-check playbook

### DIFF
--- a/e2e/ansible/pre-check.yml
+++ b/e2e/ansible/pre-check.yml
@@ -20,19 +20,44 @@
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
       register: result
 
-    - name: Get list of pv's for all namespaces
+    - name: Delete the PVCs if there are any...
+      shell: source ~/.profile; kubectl delete pvc --all -n {{ item }} --grace-period=0 --force
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      with_items: "{{ result.stdout_lines }}"
+      when: item != 'kube-system' and item != 'openebs' and item != 'kube-public'
+
+    - name: Delete the deployments if there are any...
+      shell: source ~/.profile; kubectl delete deployments --all -n {{ item }} --grace-period=0 --force
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      with_items: "{{ result.stdout_lines }}"
+      when: item != 'kube-system' and item != 'openebs' and item != 'kube-public'
+
+    - name: Delete the pods if there are any...
+      shell: source ~/.profile; kubectl delete pods --all -n {{ item }} --grace-period=0 --force
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      with_items: "{{ result.stdout_lines }}"
+      when: item != 'kube-system' and item != 'openebs' and item != 'kube-public'
+
+    - name: Get list of pvs in all namespaces
       shell: source ~/.profile; kubectl get pv --no-headers | awk {'print $1'}
       args:
         executable: /bin/bash
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
       register: list_pv
 
-    - name: Delete pv's 
+    - name: Delete pvs if there are any...
       shell: source ~/.profile; kubectl delete pv {{ item }} 
       args:
         executable: /bin/bash
       delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
       with_items: "{{ list_pv.stdout_lines }}"
+      ignore_errors: true
     
     - name: Delete namespaces which are not required
       shell: source ~/.profile; kubectl delete ns {{ item }} --grace-period=0 --force


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>


**What this PR does / why we need it**:
- In case if there are any residues, it impacts the next test-run in CI setup. This cleanup playbook will delete all the unwanted resources forcefully with grace period 0.
- Deleting deployments, PVC and pods forcefully.


Sample test run output:

```
giri@vagrant-host:~/oebs/openebs/e2e/ansible$ ansible-playbook pre-check.yml -vv
ansible-playbook 2.4.3.0
  config file = /home/giri/oebs/openebs/e2e/ansible/ansible.cfg
  configured module search path = [u'/home/giri/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
Using /home/giri/oebs/openebs/e2e/ansible/ansible.cfg as config file

PLAYBOOK: pre-check.yml ************************************************************************************************************************************************************************************
1 plays in pre-check.yml

PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [localhost]
META: ran handlers

TASK [Cleanup /var/openebs] ********************************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:8
changed: [localhost -> None] => (item=kubeminion01) => {"changed": true, "item": "kubeminion01", "path": "/var/openebs", "state": "absent"}
changed: [localhost -> None] => (item=kubeminion02) => {"changed": true, "item": "kubeminion02", "path": "/var/openebs", "state": "absent"}
changed: [localhost -> None] => (item=kubeminion03) => {"changed": true, "item": "kubeminion03", "path": "/var/openebs", "state": "absent"}

TASK [List available namespaces] ***************************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:16
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get ns --no-headers | awk {'print $1'}", "delta": "0:00:02.788719", "end": "2018-08-09 04:34:08.411598", "rc": 0, "start": "2018-08-09 04:34:05.622879", "stderr": "", "stderr_lines": [], "stdout": "nani\ndefault\ngiri\nkube-public\nkube-system\nopenebs\nsathya", "stdout_lines": ["nani", "default", "giri", "kube-public", "kube-system", "openebs", "sathya"]}

TASK [Delete the PVCs if there are any...] *****************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:23
changed: [localhost -> None] => (item=nani) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pvc --all -n nani --grace-period=0 --force", "delta": "0:00:01.403887", "end": "2018-08-09 04:34:11.277579", "item": "nani", "rc": 0, "start": "2018-08-09 04:34:09.873692", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "No resources found", "stdout_lines": ["No resources found"]}
changed: [localhost -> None] => (item=default) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pvc --all -n default --grace-period=0 --force", "delta": "0:00:01.147724", "end": "2018-08-09 04:34:14.135464", "item": "default", "rc": 0, "start": "2018-08-09 04:34:12.987740", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "persistentvolumeclaim \"demo-vol1-claim\" deleted", "stdout_lines": ["persistentvolumeclaim \"demo-vol1-claim\" deleted"]}
changed: [localhost -> None] => (item=giri) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pvc --all -n giri --grace-period=0 --force", "delta": "0:00:00.569920", "end": "2018-08-09 04:34:15.622867", "item": "giri", "rc": 0, "start": "2018-08-09 04:34:15.052947", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "persistentvolumeclaim \"jenkins-claim\" deleted", "stdout_lines": ["persistentvolumeclaim \"jenkins-claim\" deleted"]}
skipping: [localhost] => (item=kube-public) => {"changed": false, "item": "kube-public", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-system) => {"changed": false, "item": "kube-system", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=openebs) => {"changed": false, "item": "openebs", "skip_reason": "Conditional result was False"}
changed: [localhost -> None] => (item=sathya) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pvc --all -n sathya --grace-period=0 --force", "delta": "0:00:00.433458", "end": "2018-08-09 04:34:17.376852", "item": "sathya", "rc": 0, "start": "2018-08-09 04:34:16.943394", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "persistentvolumeclaim \"demo-vol1-claim\" deleted", "stdout_lines": ["persistentvolumeclaim \"demo-vol1-claim\" deleted"]}

TASK [Delete the deployments if there are any...] **********************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:32
changed: [localhost -> None] => (item=nani) => {"changed": true, "cmd": "source ~/.profile; kubectl delete deployments --all -n nani --grace-period=0 --force", "delta": "0:00:00.741609", "end": "2018-08-09 04:34:19.190746", "item": "nani", "rc": 0, "start": "2018-08-09 04:34:18.449137", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "No resources found", "stdout_lines": ["No resources found"]}
changed: [localhost -> None] => (item=default) => {"changed": true, "cmd": "source ~/.profile; kubectl delete deployments --all -n default --grace-period=0 --force", "delta": "0:00:05.826989", "end": "2018-08-09 04:34:26.095229", "item": "default", "rc": 0, "start": "2018-08-09 04:34:20.268240", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "deployment.extensions \"percona\" deleted\ndeployment.extensions \"pvc-ba246a83-9b8c-11e8-a103-02b983f0a4db-ctrl\" deleted\ndeployment.extensions \"pvc-ba246a83-9b8c-11e8-a103-02b983f0a4db-rep\" deleted", "stdout_lines": ["deployment.extensions \"percona\" deleted", "deployment.extensions \"pvc-ba246a83-9b8c-11e8-a103-02b983f0a4db-ctrl\" deleted", "deployment.extensions \"pvc-ba246a83-9b8c-11e8-a103-02b983f0a4db-rep\" deleted"]}
changed: [localhost -> None] => (item=giri) => {"changed": true, "cmd": "source ~/.profile; kubectl delete deployments --all -n giri --grace-period=0 --force", "delta": "0:00:07.771085", "end": "2018-08-09 04:34:34.810240", "item": "giri", "rc": 0, "start": "2018-08-09 04:34:27.039155", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "deployment.extensions \"jenkins\" deleted\ndeployment.extensions \"pvc-decb9e96-9b8c-11e8-a103-02b983f0a4db-ctrl\" deleted", "stdout_lines": ["deployment.extensions \"jenkins\" deleted", "deployment.extensions \"pvc-decb9e96-9b8c-11e8-a103-02b983f0a4db-ctrl\" deleted"]}
skipping: [localhost] => (item=kube-public) => {"changed": false, "item": "kube-public", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-system) => {"changed": false, "item": "kube-system", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=openebs) => {"changed": false, "item": "openebs", "skip_reason": "Conditional result was False"}
changed: [localhost -> None] => (item=sathya) => {"changed": true, "cmd": "source ~/.profile; kubectl delete deployments --all -n sathya --grace-period=0 --force", "delta": "0:00:08.710837", "end": "2018-08-09 04:34:45.331563", "item": "sathya", "rc": 0, "start": "2018-08-09 04:34:36.620726", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "deployment.extensions \"percona\" deleted\ndeployment.extensions \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-ctrl\" deleted\ndeployment.extensions \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-rep\" deleted", "stdout_lines": ["deployment.extensions \"percona\" deleted", "deployment.extensions \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-ctrl\" deleted", "deployment.extensions \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-rep\" deleted"]}

TASK [Delete the pods if there are any...] *****************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:41
changed: [localhost -> None] => (item=nani) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pods --all -n nani --grace-period=0 --force", "delta": "0:00:00.757067", "end": "2018-08-09 04:34:47.686248", "item": "nani", "rc": 0, "start": "2018-08-09 04:34:46.929181", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "No resources found", "stdout_lines": ["No resources found"]}
changed: [localhost -> None] => (item=default) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pods --all -n default --grace-period=0 --force", "delta": "0:00:01.329557", "end": "2018-08-09 04:34:50.038685", "item": "default", "rc": 0, "start": "2018-08-09 04:34:48.709128", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"percona-b98f87dbd-ht2kv\" deleted", "stdout_lines": ["pod \"percona-b98f87dbd-ht2kv\" deleted"]}
changed: [localhost -> None] => (item=giri) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pods --all -n giri --grace-period=0 --force", "delta": "0:00:00.789971", "end": "2018-08-09 04:34:51.751047", "item": "giri", "rc": 0, "start": "2018-08-09 04:34:50.961076", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"pvc-decb9e96-9b8c-11e8-a103-02b983f0a4db-ctrl-6f4b7b9d8d-zfbjv\" deleted", "stdout_lines": ["pod \"pvc-decb9e96-9b8c-11e8-a103-02b983f0a4db-ctrl-6f4b7b9d8d-zfbjv\" deleted"]}
skipping: [localhost] => (item=kube-public) => {"changed": false, "item": "kube-public", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-system) => {"changed": false, "item": "kube-system", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=openebs) => {"changed": false, "item": "openebs", "skip_reason": "Conditional result was False"}
changed: [localhost -> None] => (item=sathya) => {"changed": true, "cmd": "source ~/.profile; kubectl delete pods --all -n sathya --grace-period=0 --force", "delta": "0:00:01.013631", "end": "2018-08-09 04:34:54.293961", "item": "sathya", "rc": 0, "start": "2018-08-09 04:34:53.280330", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "pod \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-ctrl-65b58467fd-mhvq9\" deleted", "stdout_lines": ["pod \"pvc-53131011-9b8d-11e8-a103-02b983f0a4db-ctrl-65b58467fd-mhvq9\" deleted"]}

TASK [Get list of pvs in all namespaces] *******************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:50
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get pv --no-headers | awk {'print $1'}", "delta": "0:00:00.665886", "end": "2018-08-09 04:34:55.903978", "rc": 0, "start": "2018-08-09 04:34:55.238092", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete pvs if there are any...] **********************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:58
skipping: [localhost] => {"changed": false, "results": [], "skipped_reason": "No items in the list"}

TASK [Delete namespaces which are not required] ************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:66
changed: [localhost -> None] => (item=nani) => {"changed": true, "cmd": "source ~/.profile; kubectl delete ns nani --grace-period=0 --force", "delta": "0:00:00.690710", "end": "2018-08-09 04:34:58.120215", "item": "nani", "rc": 0, "start": "2018-08-09 04:34:57.429505", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "namespace \"nani\" deleted", "stdout_lines": ["namespace \"nani\" deleted"]}
skipping: [localhost] => (item=default) => {"changed": false, "item": "default", "skip_reason": "Conditional result was False"}
changed: [localhost -> None] => (item=giri) => {"changed": true, "cmd": "source ~/.profile; kubectl delete ns giri --grace-period=0 --force", "delta": "0:00:00.734512", "end": "2018-08-09 04:34:59.760474", "item": "giri", "rc": 0, "start": "2018-08-09 04:34:59.025962", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "namespace \"giri\" deleted", "stdout_lines": ["namespace \"giri\" deleted"]}
skipping: [localhost] => (item=kube-public) => {"changed": false, "item": "kube-public", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-system) => {"changed": false, "item": "kube-system", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=openebs) => {"changed": false, "item": "openebs", "skip_reason": "Conditional result was False"}
changed: [localhost -> None] => (item=sathya) => {"changed": true, "cmd": "source ~/.profile; kubectl delete ns sathya --grace-period=0 --force", "delta": "0:00:00.636046", "end": "2018-08-09 04:35:01.696240", "item": "sathya", "rc": 0, "start": "2018-08-09 04:35:01.060194", "stderr": "warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely.", "stderr_lines": ["warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. The resource may continue to run on the cluster indefinitely."], "stdout": "namespace \"sathya\" deleted", "stdout_lines": ["namespace \"sathya\" deleted"]}

TASK [List namespaces after deletion] **********************************************************************************************************************************************************************
task path: /home/giri/oebs/openebs/e2e/ansible/pre-check.yml:75
FAILED - RETRYING: List namespaces after deletion (15 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get ns --no-headers | awk {'print $1'}", "delta": "0:00:01.354740", "end": "2018-08-09 04:35:37.251920", "rc": 0, "start": "2018-08-09 04:35:35.897180", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-system\nopenebs", "stdout_lines": ["default", "kube-public", "kube-system", "openebs"]}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=9    changed=8    unreachable=0    failed=0   
```