### PR TITLE
Enhancing the e2e test playbooks generic to run on specified storage engine

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -49,7 +49,22 @@
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
            replace: 'cassandra-0.cassandra.{{ namespace }}.svc.cluster.local'
+  
+       - name: 2d) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-cassandra'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
 
+       - name: 2d) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-cassandra'
+           replace: '{{ jiva_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
 
        - name: Creating namespace for cassandra
          shell: source ~/.profile; kubectl create ns {{ namespace }}

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -54,6 +54,22 @@
            line: "              \"storage\": \"{{postgres_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
+           regexp: 'openebs-standard'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
+
+       - name:  Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
+           regexp: 'openebs-standard'
+           replace: '{{ jiva_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
+
        - name: 4a) Get the number of statefulset details from set.json
          command: cat {{ result_kube_home.stdout }}/crunchy-postgres/set.json
          register: jsonfile

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -5,7 +5,6 @@
 
 ###############################################################################################
 #Test Steps:
-
 #1.Check whether the OpenEBS components are deployed.
 #2.Deployed jenkins application pod with any version (Here version=2.124).
 #3.Download the test artifacts to k8s master.(jenkins-cli.war , change_onfig.sh, config.xml file for job creation).
@@ -43,20 +42,34 @@
          url: "{{ jenkins_link }}"
          dest: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
 
-
      - name: 2a) Replace jenkins pod version
        replace:
          path: "{{ result_kube_home.stdout }}/jenkins.yml"
          regexp: "{{ver_lts}}"
          replace: "{{ver_2_124}}"
        delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-    
+
+     - name: 2c) Replace storage-class to use cstor storage engine
+       replace:
+         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+         regexp: 'openebs-standard'
+         replace: '{{ cstor_sc }}'
+       delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       when:  storage_engine  == 'cStor'    
+
+     - name: 2c) Replace storage-class to use cstor storage engine
+       replace:
+         path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+         regexp: 'openebs-standard'
+         replace: '{{ jiva_sc }}'
+       delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       when:  storage_engine  == 'jiva'   
+
      - name: Create namespace for deployment.
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
        vars:
           status: create
           ns: "{{ namespace }}" 
-
       
      - name: 3) Deploy jenkins pod 
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
@@ -85,9 +98,6 @@
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: jenkins_pod_name
 
-
-     
-
      - name: 4) Download Jenkins-cli.jar file inside /var/jenkins_home of pod.
        shell: >
           source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{namespace}} 
@@ -98,7 +108,6 @@
        register: result
        delay: 30
        until: result.rc == 0
-
 
      - name: 4a)  Copy job configuration files to master.
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
@@ -149,7 +158,6 @@
        wait_for:
            timeout: 60
 
- 
      - name: 6)  Create and Build one sample job inside pod.
        shell: >
          source ~/.profile; kubectl exec {{ jenkins_pod_name.stdout }} -n {{ namespace }} 
@@ -175,7 +183,6 @@
          regexp: "{{ver_2_124}}"
          replace: "{{ver_2_125}}"
        delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
 
      - name: 7a)  Deploy jenkins pod Again
        include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
@@ -211,7 +218,6 @@
        delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
        register: version
        failed_when: "'jenkins/jenkins:2.125' not in version.stdout"
-       
          
      - name: 8b) Create a new build from existing  job inside pod.
        shell: > 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
@@ -41,6 +41,22 @@
            line: "      storage: \"{{jupyter_server_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: 2d) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: 'openebs-jupyter'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
+
+       - name: 2d) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: 'openebs-jupyter'
+           replace: '{{ jiva_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
+
        - name: 3) Deploy jupyter notebook server pod
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
          vars:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -52,6 +52,22 @@
            line: "      storage: \"{{percona_mysql_vol_size}}\""
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+       - name: 2c) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: 'openebs-percona'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
+
+       - name: 2c) Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
+           regexp: 'openebs-percona'
+           replace: '{{ jiva_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
+
        - name: 4) Create test specific namespace
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
          vars:

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -80,7 +80,7 @@
          replace:
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'openebs-cassandra'
-           replace: '{{ jiva_sc }}"
+           replace: '{{ jiva_sc }}'
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'jiva'
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -68,13 +68,27 @@
            regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
            replace: 'cassandra-0.cassandra.{{ namespace }}.svc.cluster.local'
 
+       - name: Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-cassandra'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
+
+       - name: Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-cassandra'
+           replace: '{{ jiva_sc }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
+
        - name: Creating namespace for cassandra
          include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
          vars:
            status: create
            ns: "{{ namespace }}"
-
-
 
        - name: Get the number of nodes in the cluster
          shell: source {{ profile }}; kubectl get nodes | grep 'Ready' | grep 'none' | wc -l


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Update the percona, jupyter, crunchy postgress and cassandra deployment test playbooks to run on specified storage_engine from all.yml file.
- Update the scale up cassandra and jenkins upgrade test playbooks to run on specified storage_engine from all.yml
- all.yml updates are tracked through different PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
