### PR TITLE
Ansible role to create custom storage class depending on the storage engine

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -94,7 +94,7 @@ cluster_type: managed
 
 #Storage engine type. The possible value can either be 'cstor' or 'jiva'
 
-storage_engine: cstor
+storage_engine: cStor
 
 #Custom storage class names
 

--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -90,7 +90,16 @@ kubeconfig: .kube/config
 build_type: normal
 
 # In case , if you want to deploy openebs in the cluster in managed kubernetes services, specify "cluster_type= managed". By default specifying the cluster_type to local.
-cluster_type: hosted
+cluster_type: managed
+
+#Storage engine type. The possible value can either be 'cstor' or 'jiva'
+
+storage_engine: cstor
+
+#Custom storage class names
+
+cstor_sc: openebs-cstor-e2e
+jiva_sc: openebs-jiva-e2e
 
 # This allows us to select the tool to create the disks based on the cloud the disks are being created on:
 # Accepted Entries: GCP, AWS

--- a/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
@@ -1,0 +1,14 @@
+
+---
+
+pool_name: pool1
+
+
+replica_count: 3
+
+
+tag: ci
+
+
+
+

--- a/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
@@ -37,7 +37,7 @@
       until: "'created' in sc.stdout"
       delay: 15
       retries: 5
-  when: storage_engine == 'cstor'
+  when: storage_engine == 'cStor'
 
 - name: Remove the copied templates
   file:

--- a/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
@@ -34,6 +34,7 @@
       shell: source ~/.profile; kubectl apply -f {{result_kube_home.stdout}}/default-cstor.j2
       args:
         executable: /bin/bash
+      register: sc
       until: "'created' in sc.stdout"
       delay: 15
       retries: 5

--- a/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Get $HOME of K8s master for kubernetes user
+  shell: source ~/.profile; echo $HOME
+  args:
+    executable: /bin/bash
+  register: result_kube_home
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  changed_when: true
+
+- template:
+    src: default-jiva.j2
+    dest: "{{ result_kube_home.stdout }}"
+
+- template:
+    src: default-cstor.j2
+    dest: "{{ result_kube_home.stdout }}"
+
+- block:
+     
+    - name: Create storage class
+      shell: source ~/.profile; kubectl apply -f {{result_kube_home.stdout}}/default-jiva.j2
+      args:
+        executable: /bin/bash
+      register: sc
+      until: "'created' in sc.stdout"
+      delay: 15
+      retries: 5
+
+  when: storage_engine == 'jiva'
+
+- block:
+
+    - name: Create storage class
+      shell: source ~/.profile; kubectl apply -f {{result_kube_home.stdout}}/default-cstor.j2
+      args:
+        executable: /bin/bash
+      until: "'created' in sc.stdout"
+      delay: 15
+      retries: 5
+  when: storage_engine == 'cstor'
+
+- name: Remove the copied templates
+  file:
+    path: "{{result_kube_home.stdout}}/{{item}}"
+    state: absent
+  with_items:
+    - default-jiva.j2
+    - default-cstor.j2
+

--- a/e2e/ansible/roles/k8s-custom-storageclass/templates/default-cstor.j2
+++ b/e2e/ansible/roles/k8s-custom-storageclass/templates/default-cstor.j2
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ cstor_sc }}
+  annotations:
+    cas.openebs.io/create-volume-template: cstor-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: cstor-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: {{ pool_name }}
+provisioner: openebs.io/provisioner-iscsi

--- a/e2e/ansible/roles/k8s-custom-storageclass/templates/default-jiva.j2
+++ b/e2e/ansible/roles/k8s-custom-storageclass/templates/default-jiva.j2
@@ -1,0 +1,18 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{jiva_sc}}
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:{{tag}}
+      - name: ReplicaImage
+        value: openebs/jiva:{{tag}}
+      - name: ReplicaCount
+        value: "{{replica_count}}"
+      - name: StoragePool
+        value: {{pool_name}}
+provisioner: openebs.io/provisioner-iscsi


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
-Added three variables (storage_engine, cstor_sc, jiva_sc) in all.yml. These storage class names will be referred in all the test playbooks.
-This ansible role copies the templates with storage class specifications to master and creates the storage class based on the storage engine.
- Finally, after successful creation, deleting the copied templates in k8s master.
