### PR TITLE
Assigning different pool names to cstor and jiva storageclasses.

### DIFF
--- a/e2e/ansible/roles/k8s-cStorPool/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-cStorPool/defaults/main.yml
@@ -1,7 +1,4 @@
 ---
-
-poolname: pool1
-
+poolname: cstor-default-pool
 pooltype: striped
-
 storage_engine: cStor

--- a/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
@@ -1,7 +1,7 @@
 
 ---
 
-cstor_pool_name: pool1
+cstor_pool_name: cstor-default-pool
 
 jiva_pool_name: default
 

--- a/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-custom-storageclass/defaults/main.yml
@@ -1,11 +1,11 @@
 
 ---
 
-pool_name: pool1
+cstor_pool_name: pool1
 
+jiva_pool_name: default
 
 replica_count: 3
-
 
 tag: ci
 

--- a/e2e/ansible/roles/k8s-custom-storageclass/templates/default-cstor.j2
+++ b/e2e/ansible/roles/k8s-custom-storageclass/templates/default-cstor.j2
@@ -9,5 +9,5 @@ metadata:
     cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
     cas.openebs.io/config: |
       - name: StoragePoolClaim
-        value: {{ pool_name }}
+        value: {{ cstor_pool_name }}
 provisioner: openebs.io/provisioner-iscsi

--- a/e2e/ansible/roles/k8s-custom-storageclass/templates/default-jiva.j2
+++ b/e2e/ansible/roles/k8s-custom-storageclass/templates/default-jiva.j2
@@ -14,5 +14,5 @@ metadata:
       - name: ReplicaCount
         value: "{{replica_count}}"
       - name: StoragePool
-        value: {{pool_name}}
+        value: {{ jiva_pool_name }}
 provisioner: openebs.io/provisioner-iscsi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Assigning different pool names to cstor and jiva storageclasses.
- Using the default pool for jiva, which is created by the CAS Template installation.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>