### PR TITLE
Modified namespace utils task to re-set the cleanup failure flag in a rescue section

### DIFF
--- a/e2e/ansible/playbooks/utils/namespace_task.yml
+++ b/e2e/ansible/playbooks/utils/namespace_task.yml
@@ -41,4 +41,14 @@
      delay: 30
      retries: 15
 
+   - name: Test Cleanup Passed
+     set_fact:
+        cflag: "Cleanup Passed"
+
+  rescue:
+
+   - name: Test Cleanup Failed
+     set_fact:
+        cflag: "Cleanup Failed"
+
   when: status == "delete"

--- a/e2e/ansible/playbooks/utils/namespace_task.yml
+++ b/e2e/ansible/playbooks/utils/namespace_task.yml
@@ -37,10 +37,6 @@
      delay: 30
      retries: 15
 
-   - name: Test Cleanup Passed
-     set_fact:
-        cflag: "Cleanup Passed"
-
   rescue:
 
    - name: Test Cleanup Failed

--- a/e2e/ansible/playbooks/utils/namespace_task.yml
+++ b/e2e/ansible/playbooks/utils/namespace_task.yml
@@ -1,5 +1,4 @@
 ---
-
 - block:
 
    - name: Create test specific namespace.
@@ -20,10 +19,7 @@
 
   when: status == "create"
 
-
-
 - block:
-
 
    - name: Deletion of test specific  namespace.
      shell: source ~/.profile; kubectl delete ns {{ ns }}


### PR DESCRIPTION
signed-off-by: vibhor995 <vibhor.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**This PR will ensure slack notification task will run even if the namespace cleanup task is failing**

   


@dargasudarshan @ksatchit 
