### PR TITLE
checking pod existence through label in percona,drain-nodes and singl…

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/k8s-percona-openebs-pod-cleanup.yml
@@ -8,19 +8,18 @@
          register: pv
          changed_when: True
 
-
        - name: Delete percona deployment
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+         include_tasks: "{{utils_path}}/delete_deploy.yml"
          vars:
            app_yml: "{{ percona_file }}"
            ns: "{{namespace}}"
 
        - name: Confirm percona pod has been deleted
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+         include_tasks: "{{utils_path}}/delete_deploy_check.yml"
          vars:
            ns: "{{namespace}}"
-           app: percona
-
+           lkey: name
+           lvalue: percona
 
        - name: Confirm percona pvc pod has been deleted
          shell: source ~/.profile; kubectl get pods -n {{ namespace }}

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/openebs-percona-diffns-pod.yml
@@ -25,13 +25,14 @@
 
 
        - name: Check status of maya-apiserver
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{ operator_ns }}"
-           app: maya-apiserver
+           lkey: name
+           lvalue: maya-apiserver
 
        - name: Creating  percona namespace to deploy percona application
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+         include_tasks: "{{utils_path}}/namespace_task.yml"
          vars:
            status: create
            ns: "{{ namespace }}"
@@ -44,7 +45,7 @@
 
 
        - name: Replace volume-claim name with test parameters
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         include_tasks: "{{utils_path}}/regex_task.yml"
          vars:
            path: "{{ result_kube_home.stdout }}/demo-percona-mysql-pvc.yaml"
            regex1: "{{replace_item}}"
@@ -52,16 +53,17 @@
 
 
        - name: Create percona deployment with OpenEBS storage
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         include_tasks: "{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_file }}"
            ns: "{{namespace}}"
 
        - name: Check percona pod is running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{namespace}}"
-           app: percona
+           lkey: name
+           lvalue: percona
 
 
        - name: Get IP address of percona mysql pod
@@ -150,11 +152,11 @@
 
          always:
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+           - include_tasks: "{{utils_path}}/stern_task.yml"
              vars:
                status: stop
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+           - include_tasks: "{{utils_path}}/namespace_task.yml"
              vars:
                status: delete
                ns: "{{ namespace }}"

--- a/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/percona-openebs-ownnamespace/pre-requisites.yml
@@ -6,6 +6,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 
-- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+- include_tasks: "{{utils_path}}/stern_task.yml"
   vars:
     status: start

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -1,17 +1,17 @@
 ---
 
 - name: Delete percona deployment
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  include_tasks: "{{utils_path}}/delete_deploy.yml"
   vars:
     app_yml: "{{ percona_file }}"
     ns: "{{namespace}}"
 
 - name: Confirm percona pod has been deleted
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  include_tasks: "{{utils_path}}/delete_deploy_check.yml"
   vars:
     ns: "{{namespace}}"
-    app: percona
-
+    lkey: name
+    lvalue: percona
 
 - name: uncordon the node which is drained
   shell: source ~/.profile; kubectl uncordon {{ node1.stdout }}

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/pre-requisites.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/pre-requisites.yml
@@ -7,6 +7,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: True
 
-- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+- include_tasks: "{{utils_path}}/stern_task.yml"
   vars:
     status: start

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -37,13 +37,12 @@
          set_fact:
             node_count: " {{ node_out.stdout}}"
 
-
        - name: Check status of maya-apiserver
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{ operator_ns }}"
-           app: maya-apiserver
-
+           lkey: name
+           lvalue: maya-apiserver
 
        - name: Obtaining storage classes yaml
          shell: source ~/.profile; kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
@@ -69,7 +68,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Create namespace to deploy application
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+         include_tasks: "{{utils_path}}/namespace_task.yml"
          vars:
             status: create
             ns: "{{ namespace }}"
@@ -87,11 +86,11 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Check percona pod is running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{namespace}}"
-           app: percona
-
+           lkey: name
+           lvalue: percona
 
        - name: Check if the replica pods are created and running
          shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | grep -i running |wc -l
@@ -104,14 +103,12 @@
          ignore_errors: true
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-
        - name: Get PV name
          shell: source ~/.profile; kubectl get pv -n {{ namespace }}| grep openebs-percona | awk '{print $1}'
          args:
            executable: /bin/bash
          register: pv_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
 
        - name: Copy replica_patch.yaml to master
          copy:
@@ -126,14 +123,12 @@
          register: node1
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-
        - name: Get the node name where replica2 is scheduled
          shell: source ~/.profile; kubectl get po -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | awk '{print $7}' | awk 'FNR == 2 {print}'
          args:
            executable: /bin/bash
          register: node2
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
 
        - name: Update replica1 node name in replica_patch file
          replace:
@@ -142,7 +137,6 @@
            replace: '{{ node1.stdout }}'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-
        - name: Update replica2 node name in replica_patch file
          replace:
            path: "{{ result_kube_home.stdout }}/{{ patch_file }}"
@@ -150,14 +144,12 @@
            replace: '{{ node2.stdout }}'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-
        - name: Get the deployment name
          shell: source ~/.profile; kubectl get deploy -n {{ namespace }} |grep "{{ pv_name.stdout }}" | grep rep |awk '{print $1}'
          args:
            executable: /bin/bash
          register: deploy_name
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
 
        - name: Apply the node affinity property
          shell: source ~/.profile; kubectl patch deployment "{{ deploy_name.stdout }}" -n {{ namespace }} -p "$(cat replica_patch.yaml)"
@@ -168,7 +160,6 @@
          delay: 20
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
 
        - name: Drain the node where replica is scheduled
          shell: source ~/.profile; kubectl drain {{ node1.stdout }} --ignore-daemonsets --force
@@ -187,7 +178,6 @@
          retries: 5
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          ignore_errors: true
-
 
        - name: Check if the replica is in pending state after node drain
          shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide | grep "{{ pv_name.stdout }}" | grep rep | grep Pending
@@ -235,11 +225,11 @@
 
          always:
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+           - include_tasks: "{{utils_path}}/stern_task.yml"
              vars:
                status: stop
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+           - include_tasks: "{{utils_path}}/namespace_task.yml"
              vars:
                status: delete
                ns: "{{ namespace }}"

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-cleanup.yml
@@ -8,16 +8,17 @@
   changed_when: true
 
 - name: Delete percona mysql pod
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy.yml"
+  include_tasks: "{{utils_path}}/delete_deploy.yml"
   vars:
     ns: "{{ namespace }}"
     app_yml: "{{ percona_files.0 }}"
 
 - name: Check status of percona
-  include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/delete_deploy_check.yml"
+  include_tasks: "{{utils_path}}/delete_deploy_check.yml"
   vars:
     ns: "{{ namespace }}"
-    app: percona
+    lkey: name
+    lvalue: percona
 
 - name: Confirm pvc pod has been deleted
   shell: source ~/.profile; kubectl get pods -n {{ namespace }}

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-prereq.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure-prereq.yml
@@ -7,6 +7,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 
-- include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+- include_tasks: "{{utils_path}}/stern_task.yml"
   vars:
     status: start

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
@@ -29,7 +29,7 @@
        ###################################################
 
        - name: Copy the chaoskube specs to kubemaster
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/copy_task.yml"
+         include_tasks: "{{utils_path}}/copy_task.yml"
          vars:
            destination_node: "{{groups['kubernetes-kubemasters'].0}}"
            files_to_copy:
@@ -37,7 +37,7 @@
              - "{{ percona_files }}"
 
        - name: Replace volume-claim name with test parameters
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/regex_task.yml"
+         include_tasks: "{{utils_path}}/regex_task.yml"
          vars:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
            regex1: "{{replace_item}}"
@@ -51,13 +51,14 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
        - name: Check status of maya-api server
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ operator_ns }}"
-            app: maya-api
+            lkey: name
+            lvalue: maya-apiserver
 
        - name: Create test specific namespace
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+         include_tasks: "{{utils_path}}/namespace_task.yml"
          vars:
             status: create
             ns: "{{ namespace }}"
@@ -68,16 +69,17 @@
        # deploy percona w/ a liveness check for DB writes)#
        ####################################################
 
-       - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+       - include_tasks: "{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ chaoskube_files }}"
            ns: "{{ namespace }}"
 
        - name: Check whether chaoskube infrastructure is created
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ namespace }}"
-            app: chaoskube
+            lkey: app
+            lvalue: chaoskube
 
        - name: Set chaoskube pod name to variable
          set_fact:
@@ -92,16 +94,17 @@
          failed_when: "'configmap' and 'created' not in result.stdout"
 
        - name: Create percona deployment with OpenEBS storage
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_task.yml"
+         include_tasks: "{{utils_path}}/deploy_task.yml"
          vars:
            app_yml: "{{ percona_files.0 }}"
            ns: "{{ namespace }}"
 
        - name: Check whether percona application is running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ namespace }}"
-            app: percona
+            lkey: name
+            lvalue: percona
 
        - name: Wait for 120s to ensure liveness check starts
          wait_for:
@@ -210,10 +213,11 @@
        ########################################################
 
        - name: Confirm percona pod is still running
-         include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/deploy_check.yml"
+         include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
             ns: "{{ namespace }}"
-            app: percona
+            lkey: name
+            lvalue: percona
 
        ########################################################
        #                        CLEANUP                       #
@@ -267,11 +271,11 @@
 
          always:
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/stern_task.yml"
+           - include_tasks: "{{utils_path}}/stern_task.yml"
              vars:
                status: stop
 
-           - include_tasks: "{{ansible_env.HOME}}/{{utils_path}}/namespace_task.yml"
+           - include_tasks: "{{utils_path}}/namespace_task.yml"
              vars:
                status: delete
                ns: "{{ namespace }}"


### PR DESCRIPTION
…e-replica-failure playbooks

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- Checking the deployment status using pod labels in percona-own-namespace, drain nodes and single-replica-failure playbooks.
- updated the utils path in the above playbooks.