### PR TITLE
Add label to cassandra loadgen job specification to aid deployment checks 

### DIFF
--- a/k8s/demo/cassandra/cassandra-loadgen.yaml
+++ b/k8s/demo/cassandra/cassandra-loadgen.yaml
@@ -7,6 +7,8 @@ spec:
   template:
     metadata:
       name: cassandra-loadgen
+      labels:
+        app: cassandra-loadgen
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adds label "cassandra-loadgen" to the job spec of the same name to aid deployment checks in e2e/CI tests. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
