### PR TITLE
Obtaining PV name from its respective PVC in node-affinity and drain …

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -45,7 +45,7 @@
            lvalue: maya-apiserver
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -58,7 +58,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -103,12 +103,13 @@
          ignore_errors: true
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Get PV name
-         shell: source ~/.profile; kubectl get pv -n {{ namespace }}| grep openebs-percona | awk '{print $1}'
+       - name: Obtaining the PV name
+         shell: source ~/.profile; kubectl get pvc -n {{ namespace }} --no-headers | awk {'print  $3'}
          args:
            executable: /bin/bash
          register: pv_name
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}" 
+
 
        - name: Copy replica_patch.yaml to master
          copy:

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -38,7 +38,7 @@
             lvalue: maya-apiserver
 
        - name: 2) Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -69,7 +69,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3a) Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-percona; sleep 10; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -108,13 +108,15 @@
          ignore_errors: true
 
        # Getting PV name
-       - name: 5b) Obtain PV name
-         shell: source ~/.profile; kubectl get pv | grep openebs-percona | awk '{print $1}'
+       
+       - name: 5b) Obtaining the PV name.
+         shell: source ~/.profile; kubectl get pvc -n {{ namespace }} --no-headers | awk {'print $3'}
          args:
            executable: /bin/bash
          register: pv_name
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"  
 
+       
        - name: 5c) Copy replica_patch.yaml to master
          copy:
            src: "{{ patch_file }}"


### PR DESCRIPTION
…nodes playbooks and using openebs-standard storage class

Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>


**What this PR does / why we need it**:
- Using PVC name to find out its PV name in node-affinity playbook before patching the deployment.
- Did the above change in drain nodes playbook also.
- Instead of openebs-percona storage class, using openebs-standard in the above two playbooks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
