### PR TITLE
Include cassandra loadgen and scaleup cassandra test playbooks to run on their own namespace.

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -56,7 +56,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name: 2d) Replace storage-class to use cstor storage engine
+       - name: 2d) Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -28,21 +28,18 @@
          vars:
            url: "{{ cassandra_service_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ svc_yaml_alias }}"
-           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2a) Download YAML for cassandra statefulset
          include_tasks: "{{utils_path}}/get_url.yml"
          vars:
            url: "{{ cassandra_stateful_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
-           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2b) Download YAML for cassandra loadgen
          include_tasks: "{{utils_path}}/get_url.yml"
          vars:
            url: "{{ cassandra_loadgen_link }}"
            dest: "{{ result_kube_home.stdout }}/{{ loadgen_yaml_alias }}"
-           delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 2c) Replace the default namespace in cassandra statefulset yaml
          replace:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-cassandra-pod/k8s-cassandra-pod.yml
@@ -49,6 +49,7 @@
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
            replace: 'cassandra-0.cassandra.{{ namespace }}.svc.cluster.local'
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   
        - name: 2d) Replace storage-class to use cstor storage engine
          replace:

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-crunchy-postgres/k8s-crunchy-pg.yml
@@ -30,7 +30,6 @@
            ns: "{{ operator_ns }}"
            lvalue: maya-apiserver
            lkey: name
-
  
        - name: 2) Replace 'tree/master' with 'trunk' in the crunchy-postgres link
          debug:
@@ -64,7 +63,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name:  Replace storage-class to use cstor storage engine
+       - name:  Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/crunchy-postgres/set.json"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -35,7 +35,6 @@
           ns: "{{ operator_ns }}"
           lkey: name
           lvalue: maya-apiserver 
-
       
      - name: 2)  Download YAML for jenkins 
        include_tasks: "{{utils_path}}/get_url.yml"
@@ -67,7 +66,7 @@
        when:  storage_engine  == 'jiva'   
 
      - name: Create namespace for deployment.
-       include_tasks: "{utils_path}}/namespace_task.yml"
+       include_tasks: "{{utils_path}}/namespace_task.yml"
        vars:
           status: create
           ns: "{{ namespace }}" 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
@@ -57,7 +57,7 @@
        delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
        when:  storage_engine  == 'cStor'    
 
-     - name: 2c) Replace storage-class to use cstor storage engine
+     - name: 2c) Replace storage-class to use jiva storage engine
        replace:
          path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
          regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-jupyter-server-pod/k8s-jupyter-pod.yml
@@ -50,7 +50,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name: 2d) Replace storage-class to use cstor storage engine
+       - name: 2d) Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-percona-mysql-pod/k8s-percona-pod.yml
@@ -61,7 +61,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name: 2c) Replace storage-class to use cstor storage engine
+       - name: 2c) Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/{{ pod_yaml_alias }}"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -28,7 +28,6 @@
 
        - include: pre-requisites.yml
 
-
        - name: Download YAML for cassandra service
          get_url:
            url: "{{ cassandra_service_link }}"
@@ -67,6 +66,7 @@
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'cassandra-0.cassandra.default.svc.cluster.local'
            replace: 'cassandra-0.cassandra.{{ namespace }}.svc.cluster.local'
+         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Replace storage-class to use cstor storage engine
          replace:
@@ -101,7 +101,6 @@
          set_fact:
             node_count: " {{ node_out.stdout}}"
 
-
        - name: Replace the replica count in cassandra statefulset yaml
          replace:
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
@@ -130,9 +129,8 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          with_items: "{{ cassandra_artifacts }}"
 
-
        - name: Confirm cassandra pod status is running
-         shell: source {{ profile }}; kubectl get pods -n {{ namespace }} | grep cassandra | grep Running | wc -l
+         shell: source {{ profile }}; kubectl get pods -n {{ namespace }} -l app=cassandra | grep Running | wc -l
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -17,7 +17,6 @@
 
 #############################################################################################################
 
-
 - hosts: localhost
 
   vars_files:
@@ -150,7 +149,7 @@
          retries: 5
 
        - name: Confirm scaled up cassandra pod status is running
-         shell: source {{ profile }}; kubectl get pods -n {{ namespace }} | grep cassandra | grep Running | wc -l
+         shell: source {{ profile }}; kubectl get pods -n {{ namespace }} -l app=cassandra | grep Running | wc -l
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-cassandra-pods/test-scaleup-cassandra-pods.yml
@@ -75,7 +75,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name: Replace storage-class to use cstor storage engine
+       - name: Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -100,7 +100,7 @@
            timeout: 120
 
        - name:  Get node on which application pod is scheduled
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide | grep percona | awk {'print $7'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l name=percona --no-headers | awk {'print $7'}
          args:
            executable: /bin/bash
          register: node_name

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -58,7 +58,7 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          when:  storage_engine  == 'cStor'
 
-       - name: Replace storage-class to use cstor storage engine
+       - name: Replace storage-class to use jiva storage engine
          replace:
            path: "{{ result_kube_home.stdout }}/percona.yaml"
            regexp: 'openebs-standard'

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -49,6 +49,22 @@
            regex1: "{{replace_item}}"
            regex2: "{{replace_with}}"
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       
+       - name: Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-standard'
+           replace: '{{ cstor_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'cStor'
+
+       - name: Replace storage-class to use cstor storage engine
+         replace:
+           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           regexp: 'openebs-standard'
+           replace: '{{ jiva_sc }}'
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         when:  storage_engine  == 'jiva'
 
        ####################################################
        #           2) Deploy Application                  #

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -116,7 +116,7 @@
            timeout: 120
 
        - name:  Get node on which application pod is scheduled
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l name=percona --no-headers | awk {'print $7'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l name=percona --no-headers -o custom-columns=:spec.nodeName
          args:
            executable: /bin/bash
          register: node_name

--- a/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
+++ b/e2e/ansible/playbooks/resiliency/test-node-eviction-out-of-disk/test-node-eviction-out-of-disk.yml
@@ -52,7 +52,7 @@
        
        - name: Replace storage-class to use cstor storage engine
          replace:
-           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           path: "{{ result_kube_home.stdout }}/percona.yaml"
            regexp: 'openebs-standard'
            replace: '{{ cstor_sc }}'
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
@@ -60,7 +60,7 @@
 
        - name: Replace storage-class to use cstor storage engine
          replace:
-           path: "{{ result_kube_home.stdout }}/{{ stateful_yaml_alias }}"
+           path: "{{ result_kube_home.stdout }}/percona.yaml"
            regexp: 'openebs-standard'
            replace: '{{ jiva_sc }}'
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
@@ -11,7 +11,7 @@
   changed_when: true
 
 - name: Get replica pod name
-  shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | shuf -n1 | awk 'FNR == 1 {print}' | awk {'print $1'}
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs/replica=jiva-replica | shuf -n1 | awk 'FNR == 1 {print}' | awk {'print $1'}
   args:
     executable: /bin/bash
   register: result

--- a/e2e/ansible/run-tests.yml
+++ b/e2e/ansible/run-tests.yml
@@ -24,7 +24,7 @@
 # TC DETAILS: Test openebs behaviour when kubelet service is not running on one of the node
 # TC NOTES:
 #
-#- include: playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
+- include: playbooks/resiliency/test-kubelet-service-stop/test-kubelet-service-stop.yml
 ##########################################################################################
 # TC NAME: 3) test-kubectl-snapshot
 # TC DETAILS: Test to perform basic snapshot/clones using k8s api's
@@ -79,7 +79,7 @@
 # TC DETAILS: Creates a mysql application snapshot on openebs volume and restore database 
 # TC NOTES:           
 #    
-#- include: playbooks/feature/snapshots/percona-mysql/mysql-snapshot.yml
+- include: playbooks/feature/snapshots/percona-mysql/mysql-snapshot.yml
 #
 ###########################################################################################
 # TC NAME: 11) basic-ha-pod-reschedule  
@@ -124,7 +124,7 @@
 # TC DETAILS: Tests resiliency upon lossy connectivity to openebs replica caused by pumba
 # TC NOTES:
 #
-- include: playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+#- include: playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
 ##########################################################################################
 # TC NAME: 18) node_loss_simulation_via_eviction_taint
 # TC DETAILS: Simulates node loss by applying disk pressure taints to evict all pods
@@ -151,7 +151,7 @@
 # TC NAME: 22) Application-upgrade-test
 # TC DETAILS: Verify data availability post application rolling upgrade.
 # TC NOTES:
-- include: playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+#- include: playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
 ##########################################################################################
 # TC NAME: 23) pvc-svc-deletion-check
 # TC DETAILS: Test to verify successful deletion of svc and pvc
@@ -180,7 +180,17 @@
 #
 - include: playbooks/hyperconverged/test-k8s-storage-pool/test-storage-pool.yml
 ##########################################################################################
-
+# TC NAME: 17) volume_replica_lossy_network_with_quorum
+# TC DETAILS: Tests resiliency upon lossy connectivity to openebs replica caused by pumba
+# TC NOTES:
+#
+- include: playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+##########################################################################################
+# TC NAME: 22) Application-upgrade-test
+# TC DETAILS: Verify data availability post application rolling upgrade.
+# TC NOTES:
+- include: playbooks/hyperconverged/test-k8s-jenkins-upgrade/k8s-jenkins-upgrade.yml
+##########################################################################################
 # TC NAME: pre-check
 # TC DETAILS: Delete residue of playbooks before running the run-tests again
 # TC NOTES:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Updating cassandra playbooks to deploy application in its own namespace.
- Updating node-eviction test to run with cStor engine
- Fixed syntax error in jenkins upgrade test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
