### PR TITLE
Add RunTask CRD and fix jiva cas template for volume list

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -36,7 +36,16 @@ rules:
   resources: ["customresourcedefinitions"]
   verbs: [ "get", "list", "create" ]
 - apiGroups: ["*"]
-  resources: [ "disks","storagepoolclaims","storagepools","cstorpools","cstorvolumereplicas","cstorvolumes","castemplates"]
+  resources: [ "disks"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "storagepoolclaims","storagepools"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "castemplates","runtasks"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpools","cstorvolumereplicas","cstorvolumes"]
   verbs: ["*" ]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
@@ -318,6 +327,29 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - cast
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: runtasks.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: runtasks
+    # singular name to be used as an alias on the CLI and for display
+    singular: runtask
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: RunTask
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - rtask
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1287,7 +1287,7 @@ data:
     options: |-
       labelSelector: openebs.io/controller-service=jiva-controller-svc
   post: |
-    {{- $servicePairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/pv},clusterIP={@.spec.clusterIP};{end}` | trim | default "" | splitList ";" -}}
+    {{- $servicePairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/persistent-volume},clusterIP={@.spec.clusterIP};{end}` | trim | default "" | splitList ";" -}}
     {{- $servicePairs | keyMap "volumeList" .ListItems | noop -}}
 ---
 apiVersion: v1
@@ -1310,7 +1310,7 @@ data:
     options: |-
       labelSelector: openebs.io/controller=jiva-controller
   post: |
-    {{- $controllerPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/pv},controllerIP={@.status.podIP},controllerStatus={@.status.containerStatuses[*].ready};{end}` | trim | default "" | splitList ";" -}}
+    {{- $controllerPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/persistent-volume},controllerIP={@.status.podIP},controllerStatus={@.status.containerStatuses[*].ready};{end}` | trim | default "" | splitList ";" -}}
     {{- $controllerPairs | keyMap "volumeList" .ListItems | noop -}}
 ---
 apiVersion: v1
@@ -1333,7 +1333,7 @@ data:
     options: |-
       labelSelector: openebs.io/replica=jiva-replica
   post: |
-    {{- $replicaPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/pv},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity={@.metadata.labels.openebs\.io/capacity};{end}` | trim | default "" | splitList ";" -}}
+    {{- $replicaPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/persistent-volume},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity={@.metadata.labels.openebs\.io/capacity};{end}` | trim | default "" | splitList ";" -}}
     {{- $replicaPairs | keyMap "volumeList" .ListItems | noop -}}
 ---
 apiVersion: v1


### PR DESCRIPTION
Add the RunTask CRD to the openebs-operator. Along with this, refactored the cluster role binding to split the CRDs based on the components from where they come. For example - ndm, m-apiserver, cas-templates, cstor, etc,. 

Also fixed the issue with jiva volume list, where I missed (in my previous PR #1741) to change pv to persistent-volume in the list volume cas templates.  

