### PR TITLE
Update test-network-failure replica test to fetch replica pod name using k8s annotaions.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/percona.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-kubelet-service-stop/percona.yaml
@@ -55,7 +55,7 @@ apiVersion: v1
 metadata:
   name: demo-vol1-claim
 spec:
-  storageClassName: openebs-percona
+  storageClassName: openebs-standard
   accessModes:
     - ReadWriteOnce
   resources:

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -105,14 +105,14 @@
             lvalue: percona
 
        - name: Get the node details on which pvc-rep is scheduled
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide | grep rep | awk 'FNR == 1 {print}' | awk {'print $7'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l openebs/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}' | awk {'print $7'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: node_rep
 
        - name: Get the pvc-rep name
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep rep | awk 'FNR == 1 {print}' | awk {'print $1'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}'| awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"


### PR DESCRIPTION
Signed-off-by: sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Update test-network-failure replica test to fetch replica pod name using k8s annotaions.
- Update storage class for kubelet-service stop test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
