### PR TITLE
Using access-mode-check utility in replica quorum failure playbook.

### DIFF
--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
@@ -33,25 +33,10 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: true
 
-- name: Check if replica is rebuilded
-  shell: curl GET http://{{ SVC.stdout }}:9501/v1/replicas | grep createTypes | jq -r '.data[].mode' | grep 'RW'
-  args:
-    executable: /bin/bash
-  register: result
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  until: "result.stdout_lines | length  == 3"
-  delay: 60
-  retries: 10
-  changed_when: true
-
-- name: Verify replica pod status
-  shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs/replica=jiva-replica --no-headers | awk '{print $3}' | grep 'Running'
-  args:
-    executable: /bin/bash
-  register: result
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  until: "result.stdout_lines | length  == 3"
-  changed_when: true
+- name: Check if the replica is rebuilt
+  include_tasks: "{{utils_path}}/access-mode-check.yml"
+  vars:
+    ns: "{{ namespace }}"
 
 - name: Get the resourceVersion of the replica deployment
   shell: >
@@ -68,6 +53,4 @@
   debug:
     msg: "Verified replica pods were restarted by fault injection"
   failed_when: "rv_bef.stdout | int == rv_aft.stdout | int"
-
-
 

--- a/e2e/ansible/playbooks/utils/access-mode-check.yml
+++ b/e2e/ansible/playbooks/utils/access-mode-check.yml
@@ -11,9 +11,8 @@
          set_fact:
            pvname: "{{pv_name.stdout.split()[10] }}"
 
-
-       - name: Get the maya-apiser pod name
-         shell: source ~/.profile; kubectl get pods -n openebs | grep apiserver | awk '{print $1}'
+       - name: Get the maya-apiserver pod name
+         shell: source ~/.profile; kubectl get pods -n openebs -l name=maya-apiserver | awk '{print $1}'
          args:
            executable: /bin/bash
          register: mayapod
@@ -28,7 +27,6 @@
          delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
          changed_when: True
          failed_when: "pvname not in volname.stdout"
-
 
        - name: Get the replicas access mode
          shell: source ~/.profile; kubectl exec -it {{ mayapod.stdout }} -n openebs -- mayactl volume info --volname {{ volname.stdout.split()[2] }} -n {{ ns }}


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- curl command is observed to be not working as we expect in cloud. Replacing the tasks with the access mode check utility which in turn uses mayactl to check the replica status.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
