### PR TITLE
Fix fetching of volume capacity via cas-templates

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1334,7 +1334,7 @@ data:
     options: |-
       labelSelector: openebs.io/replica=jiva-replica
   post: |
-    {{- $replicaPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/persistent-volume},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity={@.metadata.labels.openebs\.io/capacity};{end}` | trim | default "" | splitList ";" -}}
+    {{- $replicaPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.openebs\.io/persistent-volume},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity={@.metadata.annotations.openebs\.io/capacity};{end}` | trim | default "" | splitList ";" -}}
     {{- $replicaPairs | keyMap "volumeList" .ListItems | noop -}}
 ---
 apiVersion: v1
@@ -1437,7 +1437,7 @@ data:
     {{- .TaskResult.readlistrep.items | notFoundErr "replica pod(s) not found" | saveIf "readlistrep.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistrep.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistrep.status" .TaskResult | noop -}}
-    {{- jsonpath .JsonResult `{.items[*].metadata.labels.openebs\.io/capacity}` | trim | saveAs "readlistrep.capacity" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult `{.items[*].metadata.annotations.openebs\.io/capacity}` | trim | saveAs "readlistrep.capacity" .TaskResult | noop -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1794,6 +1794,9 @@ data:
             openebs.io/replica: jiva-replica
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+          annotations:
+            openebs.io/capacity: {{ .Volume.capacity }}
+            openebs.io/storage-pool: {{ .Config.StoragePool.value }}
         spec:
           affinity:
             podAntiAffinity:


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

Volume Info and List commands were expecting the size to be under labels under the replica deployments. The size is added as an annotation rather than label.  The output after fixing is as follow:
```
bash-4.3# mayactl volume stats --volname default-demo-vol1-claim
Executing volume stats...

Portal Details :
---------------
IQN     :   iqn.2016-09.com.openebs.jiva:default-demo-vol1-claim
Volume  :   default-demo-vol1-claim
Portal  :   10.51.242.121:3260
Size    :   5G


Replica Stats :
----------------
REPLICA       STATUS      DATAUPDATEINDEX
--------      -------     ---------------- 
10.48.2.7     running     2396     
10.48.1.8     running     2396     
10.48.0.8     running     2396     


Performance Stats :
--------------------
r/s      w/s      r(MB/s)      w(MB/s)      rLat(ms)      wLat(ms)
----     ----     --------     --------     ---------     ---------
0        6        0.000        0.031        0.000         6.586    


Capacity Stats :
---------------
LOGICAL(GB)      USED(GB)
------------     ---------
0.364            0.363    
```