### PR TITLE
Modified bootstrapper and updater to handle jiva and cstor tests

### DIFF
--- a/e2e/ansible/files/updater.py
+++ b/e2e/ansible/files/updater.py
@@ -28,11 +28,10 @@ def update_testrail_with_status(args):
     testrail_client = get_testrail_client(args)
     suites, err = get_json_file_data(os.path.expanduser('~') + '/mapping.json')
     if err != None:
-        #print('error - %s' % err)
         print('TestRail Update Failed.')
         return err
     try:
-        suite_run_id = suites['platforms']['GKE']['suites'][args['suite_id']]
+        suite_run_id = suites[args['engine_type']][args['suite_id']]
         r = testrail_client.send_post('add_result_for_case/' + str(suite_run_id) + '/' + args['case_id'],
                                         {
                                             'status_id': args['status_id']
@@ -42,11 +41,11 @@ def update_testrail_with_status(args):
         print('TestRail Updated.')
         return None
     except testrail.APIError as e:
-        #print('failed due to api error, error - %s' % e)
+        # print('failed due to api error, error - %s' % e)
         print('TestRail Update Failed.')
         return e
     except KeyError as e:
-        #print('Key not found, error - %s' % e)
+        # print('Key not found, error - %s' % e)
         print('TestRail Update Failed.')
         return e
 
@@ -58,6 +57,7 @@ def main():
     parser.add_argument('-sid', '--suite-id', help = 'suite id to update test case in testrail', required = True)
     parser.add_argument('-cid', '--case-id', help = 'case id for which result is to be updated', required = True)
     parser.add_argument('-stid', '--status-id', help = 'status id i.e result test passed or failed', required = True)
+    parser.add_argument('-et', '--engine-type', help = 'storage engine type', required = True)
     args = vars(parser.parse_args())
     update_testrail_with_status(args)
 


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> Modified bootstarpper and updater to work with cstor and jiva tests.
-> With this commit bootstrapper will generate two ansible playbooks for jiva and cstor respectively .
-> Updater will now be requiring storage engine type (jiva/cstor).
-> Plan creation format ``` BUILD_<STORAGE_ENGINE_TYPE>_<BUILD_NUMBER>_<YYYY-MM-DD>```.
-> Test_suite.yaml format:
```
TestRailProjectID: 1
CommonTestSuite:
    - 21:
        Exclude:
    - 22:
        Exclude:
JivaTestSuite:
    - 18:
        Exclude:
            - 7
CstorTestSuite:
    - 18:
        Exclude:
```
**Special notes for your reviewer**:
-> Proof of working :
![screenshot from 2018-08-16 03-20-31](https://user-images.githubusercontent.com/15130992/44175300-6833d000-a103-11e8-9f1b-1eaf6e578501.png)
