### PR TITLE
Changing the namespace name in replica-node-affinity playbook

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-vars.yml
@@ -11,7 +11,7 @@ test_pod_regex: maya*|openebs*|pvc*|percona*|
 
 test_log_path: setup/logs/node_affinity_test.log
 
-namespace: replica-affinity
+namespace: node-affinity
 
 test_suite_id: 826
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Earlier the namespace used was 'replica-affinity'. Due to recent change in the pod naming convention, failed to fetch the replica count and the replica name. In order to avoid this, changed the namespace name.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
