### PR TITLE
Include scaleup openebs replicas to use latest storage class annotation for replica count.

### DIFF
--- a/e2e/ansible/playbooks/feature/snapshots/simple-volume/snapshot.yml
+++ b/e2e/ansible/playbooks/feature/snapshots/simple-volume/snapshot.yml
@@ -158,7 +158,7 @@
            executable: /bin/bash
          register: result_snap
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-         failed_when: "'Created' not in result_snap.stdout"
+         failed_when: "'created' not in result_snap.stdout"
 
        - name: Confirm successful snapshot creation
          shell: >

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -53,8 +53,8 @@
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
            path: "{{ create_sc }}"
-           regexp: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
-           replace: 'openebs.io/jiva-replica-count: "{{ (node_count |int) }}"'
+           regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
+           replace: '      - name: ReplicaCount\n        value: "{{ (node_count |int) }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Apply storage class yaml

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -53,8 +53,8 @@
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
            path: "{{ create_sc }}"
-           regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-           replace: '      - name: ReplicaCount\n        value: "{{ (node_count |int) }}"'
+           regexp: '      - name: ReplicaCount\n        value: "2"'
+           replace: '      - name: ReplicaCount\n        value: "{{ node_count }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Apply storage class yaml

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -29,7 +29,6 @@
 
        - include: pre-requisites.yml
 
-
        - name: Check if maya-apiserver is running
          include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
@@ -64,7 +63,7 @@
             node_count: " {{ node_out.stdout}}"
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-percona -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -72,12 +71,12 @@
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
            path: "{{ create_sc }}"
-           regexp: 'openebs.io/jiva-replica-count: "3"'
-           replace: 'openebs.io/jiva-replica-count: "{{ (node_count) |int-1 }}"'
+           regexp: '      - name: ReplicaCount\n        value: "3"'
+           replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-percona; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -186,7 +185,7 @@
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: result
-         until: (node_count)| int == (result.stdout)|int
+         until: node_out.stdout == result.stdout
          delay: 120
          retries: 30
 


### PR DESCRIPTION
Signed-off-by: sudarshan <sudarshan.darga@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Include scaleup openebs replicas to use latest storage class annotation for replica count.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
