### PR TITLE
Including k8s-master's home directory in the copy/replace tasks

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -38,7 +38,7 @@
   replace:
     path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
     regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-    replace: '      - name: ReplicaCount\n        value: 3'
+    replace: '      - name: ReplicaCount\n        value: "3"'
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name:  Apply storage class yaml

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -36,13 +36,13 @@
 
 - name: Replace the replica count in openebs-storageclasses yaml
   replace:
-    path: "{{ create_sc }}"
+    path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
     regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
     replace: '      - name: ReplicaCount\n        value: 3'
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name:  Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -3,7 +3,7 @@
 - name: Delete percona deployment
   include_tasks: "{{utils_path}}/delete_deploy.yml"
   vars:
-    app_yml: "{{ percona_file }}"
+    app_yml: "{{ percona }}"
     ns: "{{namespace}}"
 
 - name: Confirm percona pod has been deleted
@@ -25,28 +25,11 @@
   changed_when: True
 
 - name: Delete storage class 
-  shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out
   until: "'deleted' in sc_out.stdout"
-  delay: 10
-  retries: 5
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-- name: Replace the replica count in openebs-storageclasses yaml
-  replace:
-    path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
-    regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-    replace: '      - name: ReplicaCount\n        value: "3"'
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-- name:  Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
-  args:
-    executable: /bin/bash
-  register: sc_out
-  until: "'created' in sc_out.stdout"
   delay: 10
   retries: 5
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -58,4 +41,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
      - "{{test_artifacts}}"
+     - "{{ percona }}"
+     - "{{ create_sc }}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
@@ -1,4 +1,4 @@
-test_name: verifiy_kubectl_drain_behaviour
+test_name: verify_kubectl_drain_behaviour
 
 test_log_path: setup/logs/kubectl-drain-behaviour.log
 
@@ -6,16 +6,13 @@ test_pod_regex: maya*|openebs*|pvc*|percona*
 
 profile: ~/.profile
 
-percona_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/percona-openebs-deployment.yaml 
+percona: percona-openebs-deployment.yaml
 
 patch_file: replica_patch.yaml
 
-create_sc: storage-class.yml
-
-percona_file: percona-openebs-deployment.yaml
+create_sc: storage-class.yaml
 
 test_artifacts:
-  -  storage-class.yml
   -  replica_patch.yaml
 
 namespace: drain-node

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/percona-openebs-deployment.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/percona-openebs-deployment.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      tolerations:
+      - key: "ak"
+        value: "av"
+        operator: "Equal"
+        effect: "NoSchedule"
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-application
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/storage-class.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/storage-class.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: openebs-affinity
+  name: openebs-application
   annotations:
     cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
     cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -35,20 +35,24 @@
 
        - name: Fetch the node count from stdout
          set_fact:
-            node_count: " {{ node_out.stdout}}"
+            node_count: "{{ node_out.stdout}}"
 
-       - name: Check status of maya-apiserver
+       - name: Check the status of maya-apiserver
          include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{ operator_ns }}"
            lkey: name
            lvalue: maya-apiserver
 
-       - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+       - name: Copy the specs to K8s master
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items:
+           - "{{ create_sc }}"
+           - "{{ percona }}"
+
 
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
@@ -57,8 +61,8 @@
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
+       - name: Create new storage class
+         shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -73,14 +77,8 @@
             status: create
             ns: "{{ namespace }}"
 
-       - name: Get percona spec and liveness scripts
-         get_url:
-           url: "{{ percona_link }}"
-           dest: "{{ result_kube_home.stdout }}"
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
-
        - name: Deploy percona application
-         shell: source {{ profile }}; kubectl apply -f {{ percona_link }} -n {{ namespace }}
+         shell: source ~/.profile; kubectl apply -f "{{ percona }}" -n "{{ namespace }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -45,20 +45,20 @@
            lvalue: maya-apiserver
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "3"'
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/percona.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/percona.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona
+  labels:
+    name: percona
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona 
+  template: 
+    metadata:
+      labels: 
+        name: percona
+    spec:
+      tolerations:
+      - key: "ak"
+        value: "av"
+        operator: "Equal"
+        effect: "NoSchedule"
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-vol1
+      volumes:
+        - name: demo-vol1
+          persistentVolumeClaim:
+            claimName: demo-vol1-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol1-claim
+spec:
+  storageClassName: openebs-affinity
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-mysql
+  labels:
+    name: percona-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona
+

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
@@ -15,7 +15,7 @@
   retries: 5
 
 - name: Delete storage class
-  shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out
@@ -27,13 +27,15 @@
 
 - name: Replace the replica count in openebs-storageclasses yaml
   replace:
-    path: "{{ create_sc }}"
+    path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
     regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-    replace: '      - name: ReplicaCount\n        value: "{{ (node_count |int) }}"'
+    replace: '      - name: ReplicaCount\n        value: "3"'
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
+# Creating openebs-standard storage class with default replica count.
+
 - name: Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
@@ -5,7 +5,7 @@
     timeout: 50
 
 - name: Delete Percona deployment
-  shell: source ~/.profile; kubectl delete -f "{{ percona_link }}" -n "{{namespace}}"
+  shell: source ~/.profile; kubectl delete -f "{{ percona }}" -n "{{namespace}}"
   args:
     executable: /bin/bash
   register: del_out
@@ -25,26 +25,6 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   changed_when: True
 
-- name: Replace the replica count in openebs-storageclasses yaml
-  replace:
-    path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
-    regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-    replace: '      - name: ReplicaCount\n        value: "3"'
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-
-# Creating openebs-standard storage class with default replica count.
-
-- name: Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
-  args:
-    executable: /bin/bash
-  register: sc_out
-  until: "'created' in sc_out.stdout"
-  delay: 10
-  retries: 5
-  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
-  changed_when: True
-
 - name: Remove copied files
   file:
     path: "{{ item }}"
@@ -52,5 +32,6 @@
   with_items:
     - "{{ result_kube_home.stdout }}/{{ patch_file }}"
     - "{{ result_kube_home.stdout }}/{{ create_sc }}"
+    - "{{ result_kube_home.stdout }}/{{ percona }}"
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-vars.yml
@@ -5,7 +5,7 @@ patch_file: replica_patch.yml
 
 create_sc: storage-class.yaml
 
-percona_link: https://raw.githubusercontent.com/openebs/openebs/master/k8s/demo/percona/demo-percona-mysql-pvc.yaml
+percona: percona.yaml
 
 test_pod_regex: maya*|openebs*|pvc*|percona*|
 

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -37,11 +37,21 @@
             lkey: name
             lvalue: maya-apiserver
 
-       - name: 2) Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout}}/{{ create_sc }}"
-         args:
-           executable: /bin/bash
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+            #       - name: 2) Obtaining storage classes yaml
+            #shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout}}/{{ create_sc }}"
+            #args:
+            #executable: /bin/bash
+            #delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+       - name: Copy the specs to K8s master
+         copy:
+           src: "{{ item }}"
+           dest: "{{ result_kube_home.stdout }}"
+         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+         with_items:
+           - "{{ create_sc }}"
+           - "{{ percona }}"
+
 
        - name: 2b) Create test specific namespace
          include_tasks: "{{utils_path}}/namespace_task.yml"
@@ -68,8 +78,9 @@
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
-       - name: 3a) Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
+
+       - name: 3a) create a new storage class
+         shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -79,7 +90,7 @@
          retries: 5
 
        - name: 4) Deploying Percona Application
-         shell: source ~/.profile; kubectl apply -f "{{ percona_link }}" -n "{{namespace}}"
+         shell: source ~/.profile; kubectl apply -f "{{ percona }}" -n "{{namespace}}"
          args:
            executable: /bin/bash
          register: app_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -37,11 +37,6 @@
             lkey: name
             lvalue: maya-apiserver
 
-            #       - name: 2) Obtaining storage classes yaml
-            #shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout}}/{{ create_sc }}"
-            #args:
-            #executable: /bin/bash
-            #delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Copy the specs to K8s master
          copy:

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -38,7 +38,7 @@
             lvalue: maya-apiserver
 
        - name: 2) Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout}}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -63,13 +63,13 @@
 
        - name: 3) Replace the replica count in storage classes yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "3"'
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3a) Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/storage-class.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/storage-class.yaml
@@ -1,0 +1,32 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:ci
+      - name: ReplicaImage
+        value: openebs/jiva:ci
+      - name: VolumeMonitorImage
+        value: openebs/m-exporter:ci
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"cas.openebs.io/config":"- name: ControllerImage\n  value: openebs/jiva:ci\n- name: ReplicaImage\n  value: openebs/jiva:ci\n- name: VolumeMonitorImage\n  value: openebs/m-exporter:ci\n- name: ReplicaCount\n  value: \"3\"\n- name: StoragePool\n  value: default\n","cas.openebs.io/create-volume-template":"jiva-volume-create-default-0.7.0","cas.openebs.io/delete-volume-template":"jiva-volume-delete-default-0.7.0","cas.openebs.io/read-volume-template":"jiva-volume-read-default-0.7.0"},"creationTimestamp":"2018-08-17T05:20:19Z","name":"openebs-standard","namespace":"","resourceVersion":"279938","selfLink":"/apis/storage.k8s.io/v1/storageclasses/openebs-standard","uid":"3b8d834d-a1dd-11e8-8267-42010a800feb"},"parameters":{"openebs.io/capacity":"5G","openebs.io/jiva-replica-count":"3","openebs.io/storage-pool":"default","openebs.io/volume-monitor":"true"},"provisioner":"openebs.io/provisioner-iscsi","reclaimPolicy":"Delete"}
+  creationTimestamp: 2018-08-17T06:00:56Z
+  name: openebs-affinity
+  resourceVersion: "283412"
+  selfLink: /apis/storage.k8s.io/v1/storageclasses/openebs-standard
+  uid: e8246f83-a1e2-11e8-8267-42010a800feb
+parameters:
+  openebs.io/capacity: 5G
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/storage-pool: default
+  openebs.io/volume-monitor: "true"
+provisioner: openebs.io/provisioner-iscsi
+reclaimPolicy: Delete

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -40,7 +40,7 @@
          changed_when: true
 
        - name: Delete storage class
-         shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -50,15 +50,17 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          changed_when: True
 
+# Creating openebs-standard storage class with default replica count.
+
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
-           path: "{{ create_sc }}"
-           regexp: '      - name: ReplicaCount\n        value: "2"'
-           replace: '      - name: ReplicaCount\n        value: "{{ node_count }}"'
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
+           regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
+           replace: '      - name: ReplicaCount\n        value: "3"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Apply storage class yaml
-         shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -74,5 +76,6 @@
            state: absent
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          with_items:
-           - "{{percona_files}}"
+           - "{{ percona_files }}"
+           - "{{ create_sc }}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -63,20 +63,20 @@
             node_count: " {{ node_out.stdout}}"
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "3"'
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep-cleanup.yml
@@ -15,7 +15,7 @@
   changed_when: true
 
 - name: Delete percona mysql pod
-  include_tasks: "{{ ansible_env.HOME }}/{{ utils_path }}/delete_deploy.yml"
+  include_tasks: "{{ utils_path }}/delete_deploy.yml"
   vars:
     ns: "{{ namespace }}"
     app_yml: "{{ percona_files.0 }}"

--- a/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure/test-nw-failure-cleanup.yml
@@ -31,7 +31,7 @@
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
-  until: "pv.stdout in result.stdout"
+  until: "pv.stdout not in result.stdout"
   delay: 30
   retries: 10
   changed_when: true


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- In managed k8s-cluster, fails to find out the file in the home directory sometimes unless home directory has been added before the destination.
- So, home directory has been added in both the main playbook and its associated cleanup file.
- The changes were included in drain-nodes, replica-node-affinity and scaleup-storage-replicas playbooks.
- Using new storage class with lesser number of replicas in replica-node-affinity and k8d-drain-node playbooks