### PR TITLE
Mofified playbooks to include k8s home directory in copy/replace tasks

### DIFF
--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/cleanup.yml
@@ -25,7 +25,7 @@
   changed_when: True
 
 - name: Delete storage class 
-  shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl delete -f "{{result_kube_home.stdout}}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out
@@ -38,11 +38,11 @@
   replace:
     path: "{{ create_sc }}"
     regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
-    replace: '      - name: ReplicaCount\n        value: 3'
+    replace: '      - name: ReplicaCount\n        value: "3"'
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name:  Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out
@@ -58,4 +58,5 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   with_items:
      - "{{test_artifacts}}"
+     - "{{ create_sc }}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/kubectl-drain-vars.yml
@@ -15,7 +15,6 @@ create_sc: storage-class.yml
 percona_file: percona-openebs-deployment.yaml
 
 test_artifacts:
-  -  storage-class.yml
   -  replica_patch.yaml
 
 namespace: drain-node

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-drain-nodes/test-drain-nodes.yml
@@ -45,7 +45,7 @@
            lvalue: maya-apiserver
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -58,7 +58,7 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity-cleanup.yml
@@ -15,7 +15,7 @@
   retries: 5
 
 - name: Delete storage class
-  shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out
@@ -27,13 +27,13 @@
 
 - name: Replace the replica count in openebs-storageclasses yaml
   replace:
-    path: "{{ create_sc }}"
+    path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
     regexp: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
     replace: '      - name: ReplicaCount\n        value: "{{ (node_count |int) }}"'
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name: Apply storage class yaml
-  shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+  shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
   args:
     executable: /bin/bash
   register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-replica-node-affinity/replica-node-affinity.yml
@@ -38,7 +38,7 @@
             lvalue: maya-apiserver
 
        - name: 2) Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -63,13 +63,13 @@
 
        - name: 3) Replace the replica count in storage classes yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "3"'
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: 3a) Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; sleep 10; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/cleanup.yml
@@ -40,7 +40,7 @@
          changed_when: true
 
        - name: Delete storage class
-         shell: source ~/.profile; kubectl delete -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -52,13 +52,13 @@
 
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "2"'
            replace: '      - name: ReplicaCount\n        value: "{{ node_count }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Apply storage class yaml
-         shell: source ~/.profile; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out
@@ -75,4 +75,5 @@
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          with_items:
            - "{{percona_files}}"
+           - "{{ create_sc }}"
 

--- a/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-scaleup-storage-replicas/test-scaleup-storage-replicas.yml
@@ -63,20 +63,20 @@
             node_count: " {{ node_out.stdout}}"
 
        - name: Obtaining storage classes yaml
-         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ create_sc }}"
+         shell: source ~/.profile; kubectl get sc openebs-standard -o yaml > "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Replace the replica count in openebs-storageclasses yaml
          replace:
-           path: "{{ create_sc }}"
+           path: "{{ result_kube_home.stdout }}/{{ create_sc }}"
            regexp: '      - name: ReplicaCount\n        value: "3"'
            replace: '      - name: ReplicaCount\n        value: "{{ (node_count) |int-1 }}"'
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
        - name: Delete the existing storage class and create new one
-         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ create_sc }}"
+         shell: source ~/.profile; kubectl delete sc openebs-standard; kubectl apply -f "{{ result_kube_home.stdout }}/{{ create_sc }}"
          args:
            executable: /bin/bash
          register: sc_out


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- In drain-node cleanup, modified the regex in replace task to include the string within double quotes
- Added k8s home directory in all the copy/replace tasks in drain-nodes, replica-node-affinity and scaleup-storage-replicas playbooks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
