### PR TITLE
Decreased the length of the generated name for disk, due to gcloudsdk limit.

### DIFF
--- a/e2e/ansible/roles/k8s-gke-attach/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-gke-attach/tasks/main.yml
@@ -7,7 +7,7 @@
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
 
 - name: Creating random name for the disks
-  shell: echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2
+  shell: test=(echo $(mktemp)| tr '[:upper:]' '[:lower:]' | cut -d '.' -f 2) && echo ${test::-4}
   args:
     executable: /bin/bash
   register: name


### PR DESCRIPTION




<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Decreased the length of the generated name for disk, due to gcloudsdk limit.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>