### PR TITLE
Removing the stale iscsi session and target from all the nodes

### DIFF
--- a/e2e/ansible/pre-check.yml
+++ b/e2e/ansible/pre-check.yml
@@ -53,3 +53,20 @@
       delay: 30
       retries: 15
 
+    - name: Logging out the stale iscsi sessions
+      shell: iscsiadm -m node -u
+      args:
+        executable: /bin/bash
+      become: true
+      delegate_to: "{{ item }}"
+      with_items: "{{groups['kubernetes-kubeminions']}}" 
+      ignore_errors: yes
+
+    - name: Deleting the stale targets
+      shell: iscsiadm -m node -o delete
+      args:
+        executable: /bin/bash
+      become: true
+      delegate_to: "{{ item }}"
+      with_items: "{{groups['kubernetes-kubeminions']}}"
+      ignore_errors: yes


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Deleting the stale iscsi sessions in all the nodes.
- Delete the stale targets in all the nodes with ignore_errors tag.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:


```
PLAYBOOK: pre-check.yml ************************************************************************************************************************************************************************************
1 plays in pre-check.yml

PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:1
ok: [localhost]
META: ran handlers

TASK [Cleanup /var/openebs] ********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:8
changed: [localhost -> None] => (item=kubeminion01) => {"changed": true, "item": "kubeminion01", "path": "/var/openebs", "state": "absent"}
changed: [localhost -> None] => (item=kubeminion02) => {"changed": true, "item": "kubeminion02", "path": "/var/openebs", "state": "absent"}
changed: [localhost -> None] => (item=kubeminion03) => {"changed": true, "item": "kubeminion03", "path": "/var/openebs", "state": "absent"}

TASK [List available namespaces] ***************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:16
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get ns --no-headers | awk {'print $1'}", "delta": "0:00:14.154441", "end": "2018-08-20 18:45:45.762608", "rc": 0, "start": "2018-08-20 18:45:31.608167", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-system\nopenebs", "stdout_lines": ["default", "kube-public", "kube-system", "openebs"]}

TASK [Get list of pv's for all namespaces] *****************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:23
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get pv --no-headers | awk {'print $1'}", "delta": "0:00:00.918864", "end": "2018-08-20 18:45:46.930616", "rc": 0, "start": "2018-08-20 18:45:46.011752", "stderr": "No resources found.", "stderr_lines": ["No resources found."], "stdout": "", "stdout_lines": []}

TASK [Delete pv's] *****************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:30
skipping: [localhost] => {"changed": false, "results": [], "skipped_reason": "No items in the list"}

TASK [Delete namespaces which are not required] ************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:37
skipping: [localhost] => (item=default) => {"changed": false, "item": "default", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-public) => {"changed": false, "item": "kube-public", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=kube-system) => {"changed": false, "item": "kube-system", "skip_reason": "Conditional result was False"}
skipping: [localhost] => (item=openebs) => {"changed": false, "item": "openebs", "skip_reason": "Conditional result was False"}
skipping: [localhost] => {"changed": false, "msg": "All items completed", "results": [{"_ansible_ignore_errors": true, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "default", "skip_reason": "Conditional result was False", "skipped": true}, {"_ansible_ignore_errors": true, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "kube-public", "skip_reason": "Conditional result was False", "skipped": true}, {"_ansible_ignore_errors": true, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "kube-system", "skip_reason": "Conditional result was False", "skipped": true}, {"_ansible_ignore_errors": true, "_ansible_item_result": true, "_ansible_no_log": false, "changed": false, "item": "openebs", "skip_reason": "Conditional result was False", "skipped": true}]}

TASK [List namespaces after deletion] **********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:46
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get ns --no-headers | awk {'print $1'}", "delta": "0:00:01.353306", "end": "2018-08-20 18:45:48.646111", "rc": 0, "start": "2018-08-20 18:45:47.292805", "stderr": "", "stderr_lines": [], "stdout": "default\nkube-public\nkube-system\nopenebs", "stdout_lines": ["default", "kube-public", "kube-system", "openebs"]}
TASK [Logging out the stale iscsi sessions] ****************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:56
failed: [localhost -> None] (item=kubeminion01) => {"changed": true, "cmd": "iscsiadm -m node -u", "delta": "0:00:00.003947", "end": "2018-08-20 13:15:52.304130", "item": "kubeminion01", "msg": "non-zero return code", "rc": 21, "start": "2018-08-20 13:15:52.300183", "stderr": "iscsiadm: No matching sessions found", "stderr_lines": ["iscsiadm: No matching sessions found"], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=kubeminion02) => {"changed": true, "cmd": "iscsiadm -m node -u", "delta": "0:00:00.091868", "end": "2018-08-20 13:15:56.440322", "item": "kubeminion02", "rc": 0, "start": "2018-08-20 13:15:56.348454", "stderr": "", "stderr_lines": [], "stdout": "Logging out of session [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260]\nLogout of [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260] successful.", "stdout_lines": ["Logging out of session [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260]", "Logout of [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260] successful."]}
changed: [localhost -> None] => (item=kubeminion03) => {"changed": true, "cmd": "iscsiadm -m node -u", "delta": "0:00:00.449778", "end": "2018-08-20 13:16:00.912878", "item": "kubeminion03", "rc": 0, "start": "2018-08-20 13:16:00.463100", "stderr": "", "stderr_lines": [], "stdout": "Logging out of session [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260]\nLogging out of session [sid: 2, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.240.212,3260]\nLogging out of session [sid: 3, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.247.128,3260]\nLogging out of session [sid: 4, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.252.117,3260]\nLogging out of session [sid: 5, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.253.211,3260]\nLogging out of session [sid: 6, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.244.120,3260]\nLogout of [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260] successful.\nLogout of [sid: 2, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.240.212,3260] successful.\nLogout of [sid: 3, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.247.128,3260] successful.\nLogout of [sid: 4, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.252.117,3260] successful.\nLogout of [sid: 5, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.253.211,3260] successful.\nLogout of [sid: 6, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.244.120,3260] successful.", "stdout_lines": ["Logging out of session [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260]", "Logging out of session [sid: 2, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.240.212,3260]", "Logging out of session [sid: 3, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.247.128,3260]", "Logging out of session [sid: 4, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.252.117,3260]", "Logging out of session [sid: 5, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.253.211,3260]", "Logging out of session [sid: 6, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.244.120,3260]", "Logout of [sid: 1, target: iqn.2016-09.com.openebs.jiva:nodeeviction-test-node-eviction, portal: 10.19.248.251,3260] successful.", "Logout of [sid: 2, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.240.212,3260] successful.", "Logout of [sid: 3, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.247.128,3260] successful.", "Logout of [sid: 4, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.252.117,3260] successful.", "Logout of [sid: 5, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.253.211,3260] successful.", "Logout of [sid: 6, target: iqn.2016-09.com.openebs.jiva:scaleup-storage-test-scaleup-storage, portal: 10.19.244.120,3260] successful."]}
...ignoring

TASK [Deleting the stale targets] **************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/pre-check.yml:65
failed: [localhost -> None] (item=kubeminion01) => {"changed": true, "cmd": "iscsiadm -m node -o delete", "delta": "0:00:00.004056", "end": "2018-08-20 13:16:05.111794", "item": "kubeminion01", "msg": "non-zero return code", "rc": 21, "start": "2018-08-20 13:16:05.107738", "stderr": "iscsiadm: No records found", "stderr_lines": ["iscsiadm: No records found"], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=kubeminion02) => {"changed": true, "cmd": "iscsiadm -m node -o delete", "delta": "0:00:00.004859", "end": "2018-08-20 13:16:09.142375", "item": "kubeminion02", "rc": 0, "start": "2018-08-20 13:16:09.137516", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=kubeminion03) => {"changed": true, "cmd": "iscsiadm -m node -o delete", "delta": "0:00:00.007228", "end": "2018-08-20 13:16:13.183486", "item": "kubeminion03", "rc": 0, "start": "2018-08-20 13:16:13.176258", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=7    changed=6    unreachable=0    failed=0
```