### PR TITLE
Add sparse spc and sc in openebs-config yaml

### DIFF
--- a/k8s/openebs-config.yaml
+++ b/k8s/openebs-config.yaml
@@ -49,6 +49,35 @@ spec:
 #      - disk-66a74896b61c60dcdaf7c7a76fde0ebb
 #      - disk-b34b3f97840872da9aa0bac1edc9578a
 ---
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: cstor-pool-default-sparse-0.7.0
+  annotations:
+    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
+    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
+spec:
+  name: cstor-pool-default-sparse-0.7.0
+  type: sparse
+  maxPools: 3
+  poolSpec:
+    poolType: striped
+    cacheFile: /tmp/pool1.cache
+    overProvisioning: false
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-default-sparse-0.7.0
+  annotations:
+    cas.openebs.io/create-volume-template: cstor-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: cstor-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "cstor-pool-default-sparse-0.7.0"
+provisioner: openebs.io/provisioner-iscsi
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/k8s/openebs-config.yaml
+++ b/k8s/openebs-config.yaml
@@ -32,7 +32,7 @@ metadata:
     cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
 spec:
   name: cstor-pool-default-0.7.0
-  type: openebs-cstor
+  type: disk
   maxPools: 3
   poolSpec:
     poolType: striped
@@ -48,35 +48,6 @@ spec:
 #      - disk-0c84c169ab2f398b92914f56dad41f81
 #      - disk-66a74896b61c60dcdaf7c7a76fde0ebb
 #      - disk-b34b3f97840872da9aa0bac1edc9578a
----
-apiVersion: openebs.io/v1alpha1
-kind: StoragePoolClaim
-metadata:
-  name: cstor-pool-default-sparse-0.7.0
-  annotations:
-    cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
-    cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
-spec:
-  name: cstor-pool-default-sparse-0.7.0
-  type: sparse
-  maxPools: 3
-  poolSpec:
-    poolType: striped
-    cacheFile: /tmp/pool1.cache
-    overProvisioning: false
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: openebs-cstor-default-sparse-0.7.0
-  annotations:
-    cas.openebs.io/create-volume-template: cstor-volume-create-default-0.7.0
-    cas.openebs.io/delete-volume-template: cstor-volume-delete-default-0.7.0
-    cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
-    cas.openebs.io/config: |
-      - name: StoragePoolClaim
-        value: "cstor-pool-default-sparse-0.7.0"
-provisioner: openebs.io/provisioner-iscsi
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass


### PR DESCRIPTION
This commit will do following:

1. Add spc for sparse pool.
2. Add storage class(sc) to refer the spc(storagepoolclaim)

This will help in automatic provisioning of sparse pools and a SC(storage class) will be created referring to the sparse pool.

**NOTE**:
Above will be configured as a part of openebs installation meaning , installing openebs will provision a sparse pool and a storage class referring to it.

The size of sparse file (disk) to be used can be configured in ndm-operator.yaml 
See(ndm-operator.yaml file in) following PR: 
```
- name: SPARSE_FILE_SIZE
           value: "1073741824"
```
https://github.com/openebs/node-disk-manager/pull/68/files 
As well ndm-operator will be a part of openebs-operator yaml.(So you may need to configure the sparse file size there only).

The size of persistentvolumeclaim must not exceed the sparse file size as well the number of cstor pools provisioned should be always greater or equal to replicaCount.

By default the replica count is 3 if not specified in pvc or sc.
Please go through following PR for more info : 
https://github.com/openebs/maya/pull/452

Signed-off-by: sonasingh46 <sonasingh46@gmail.com>


**Special notes for your reviewer**:
This PR can be merged only after the merge of following PR:
https://github.com/openebs/maya/pull/452