### PR TITLE
 Update label and annotations of Jiva run tasks

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -5,27 +5,27 @@ metadata:
   name: cstor-pool-create-default-0.7.0
 spec:
   defaultConfig:
-  # CstorPoolImage is the container image that executes zpool replication and 
+  # CstorPoolImage is the container image that executes zpool replication and
   # communicates with cstor iscsi target
   - name: CstorPoolImage
     value: openebs/cstor-pool:ci
-  # CstorPoolMgmtImage runs cstor pool and cstor volume replica related CRUD 
+  # CstorPoolMgmtImage runs cstor pool and cstor volume replica related CRUD
   # operations
   - name: CstorPoolMgmtImage
     value: openebs/cstor-pool-mgmt:ci
-  # HostPathType is a hostPath volume i.e. mounts a file or directory from the 
-  # host node’s filesystem into a Pod. 'DirectoryOrCreate' value  ensures 
+  # HostPathType is a hostPath volume i.e. mounts a file or directory from the
+  # host node’s filesystem into a Pod. 'DirectoryOrCreate' value  ensures
   # nothing exists at the given path i.e. an empty directory will be created.
   - name: HostPathType
     value: DirectoryOrCreate
-  # RunNamespace is the namespace where namespaced resources related to pool 
+  # RunNamespace is the namespace where namespaced resources related to pool
   # will be placed
   - name: RunNamespace
     value: openebs
   taskNamespace: openebs
   run:
     tasks:
-    # Following are the list of run tasks executed in this order to 
+    # Following are the list of run tasks executed in this order to
     # create a cstor storage pool
     - cstor-pool-create-listdisk-default-0.7.0
     - cstor-pool-create-listnode-default-0.7.0
@@ -194,7 +194,7 @@ spec:
               mountPath: /tmp
             - name: udev
               mountPath: /run/udev
-              # To avoid clash between terminating and restarting pod 
+              # To avoid clash between terminating and restarting pod
               # in case older zrepl gets deleted faster, we keep initial delay
             lifecycle:
               postStart:
@@ -1264,9 +1264,9 @@ spec:
   meta: |
     {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
     id: listlistsvc
-    repeatWith: 
+    repeatWith:
       metas:
-      {{- range $k, $ns := $nss }} 
+      {{- range $k, $ns := $nss }}
       - runNamespace: {{ $ns }}
       {{- end }}
     apiVersion: v1
@@ -1287,9 +1287,9 @@ spec:
   meta: |
     {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
     id: listlistctrl
-    repeatWith: 
-      metas: 
-      {{- range $k, $ns := $nss }} 
+    repeatWith:
+      metas:
+      {{- range $k, $ns := $nss }}
       - runNamespace: {{ $ns }}
       {{- end }}
     apiVersion: v1
@@ -1310,9 +1310,9 @@ spec:
   meta: |
     {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
     id: listlistrep
-    repeatWith: 
-      metas: 
-      {{- range $k, $ns := $nss }} 
+    repeatWith:
+      metas:
+      {{- range $k, $ns := $nss }}
       - runNamespace: {{ $ns }}
       {{- end }}
     apiVersion: v1
@@ -1362,9 +1362,23 @@ spec:
             vsm.openebs.io/replica-status: {{ $replicaStatus | replace "true" "running" | replace "false" "notready" }}
             vsm.openebs.io/controller-status: {{ $controllerStatus | replace "true" "running" | replace "false" "notready" | replace " " "," }}
             vsm.openebs.io/targetportals: {{ $clusterIP }}:3260
+            openebs.io/controller-ips: {{ $controllerIP }}
+            openebs.io/cluster-ips: {{ $clusterIP }}
+            openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ $name }}
+            openebs.io/replica-count: {{ $replicaIP | default "" | splitList ", " | len }}
+            openebs.io/volume-size: {{ $capacity }}
+            openebs.io/replica-ips: {{ $replicaIP }}
+            openebs.io/replica-status: {{ $replicaStatus | replace "true" "running" | replace "false" "notready" }}
+            openebs.io/controller-status: {{ $controllerStatus | replace "true" "running" | replace "false" "notready" | replace " " "," }}
+            openebs.io/targetportals: {{ $clusterIP }}:3260
         spec:
           capacity: {{ $capacity }}
+          iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
+          targetPortal: {{ .TaskResult.readlistsvc.clusterIP }}:3260
+          replicas: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
           casType: jiva
+          targetIP: {{ .TaskResult.readlistsvc.clusterIP }}
+          targetPort: 3260
     {{- end -}}
 ---
 apiVersion: openebs.io/v1alpha1
@@ -1454,11 +1468,22 @@ spec:
         vsm.openebs.io/replica-status: {{ .TaskResult.readlistrep.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
         vsm.openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
         vsm.openebs.io/targetportals: {{ .TaskResult.readlistsvc.clusterIP }}:3260
+        openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
+        openebs.io/cluster-ips: {{ .TaskResult.readlistsvc.clusterIP }}
+        openebs.io/iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
+        openebs.io/replica-count: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
+        openebs.io/volume-size: {{ $capacity }}
+        openebs.io/replica-ips: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | join "," }}
+        openebs.io/replica-status: {{ .TaskResult.readlistrep.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
+        openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
+        openebs.io/targetportals: {{ .TaskResult.readlistsvc.clusterIP }}:3260
     spec:
       capacity: {{ $capacity }}
       targetPortal: {{ .TaskResult.readlistsvc.clusterIP }}:3260
       iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
       replicas: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
+      targetIP: {{ .TaskResult.readlistsvc.clusterIP }}
+      targetPort: 3260
       casType: jiva
 ---
 apiVersion: openebs.io/v1alpha1
@@ -1588,7 +1613,7 @@ spec:
                     nodeSelectorTerms:
                     - matchExpressions:
                       {{- range $k, $v := $nodeAffinityRSIEVal }}
-                      - 
+                      -
                       {{- range $kk, $vv := $v }}
                         {{ $kk }}: {{ $vv }}
                       {{- end }}
@@ -1822,7 +1847,7 @@ spec:
           tolerations:
           {{- if ne $isEvictionTolerations "false" }}
           {{- range $k, $v := $evictionTolerationsVal }}
-          - 
+          -
           {{- range $kk, $vv := $v }}
             {{ $kk }}: {{ $vv }}
           {{- end }}
@@ -1856,6 +1881,8 @@ spec:
       targetPortal: {{ .TaskResult.createputsvc.clusterIP }}:3260
       iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
       replicas: {{ .Config.ReplicaCount.value }}
+      targetIP: {{ .TaskResult.readlistsvc.clusterIP }}
+      targetPort: 3260
       casType: jiva
 ---
 apiVersion: openebs.io/v1alpha1


### PR DESCRIPTION
**What this PR does / why we need it**:
This commit will change the all the annotations and label key prefix to 'openebs.io' in jiva run tasks config maps. (Related to https://github.com/openebs/maya/pull/456)

Older jiva annotations are kept for backward compatibility

**Special notes for your reviewer**:
Annotations are keep for sometime until we fix the mayactl code to schema, which will be part of next PR's in maya
```json
{  
   "items":[  
      {  
         "apiVersion":"v1alpha1",
         "kind":"CASVolume",
         "metadata":{  
            "annotations":{  
               "vsm.openebs.io/cluster-ips":"10.0.0.179",
               "vsm.openebs.io/iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
               "vsm.openebs.io/replica-count":"1",
               "vsm.openebs.io/volume-size":"5G",
               "vsm.openebs.io/controller-ips":"172.17.0.6",
               "vsm.openebs.io/controller-status":"running,running",
               "vsm.openebs.io/replica-ips":"172.17.0.7",
               "vsm.openebs.io/replica-status":"running",
               "vsm.openebs.io/targetportals":"10.0.0.179:3260"

               "openebs.io/cluster-ips":"10.0.0.179",
               "openebs.io/iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
               "openebs.io/replica-count":"1",
               "openebs.io/volume-size":"5G",
               "openebs.io/controller-ips":"172.17.0.6",
               "openebs.io/controller-status":"running,running",
               "openebs.io/replica-ips":"172.17.0.7",
               "openebs.io/replica-status":"running",
               "openebs.io/targetportals":"10.0.0.179:3260"
            },
            "name":"default-percona-pvc",
            "namespace":"default"
         },
         "spec":{  
            "capacity":"5G",
            "iqn":"iqn.2016-09.com.openebs.cstor:default-percona-pvc",
            "replicas":"1",
            "targetIP":"10.0.0.179",
            "targetPort":"3260",
            "targetPortal":"10.0.0.179:3260"
         },
         "status":{  
            "Message":"",
            "Phase":"",
            "Reason":""
         }
      }
   ],
   "kind":"CASVolumeList",
   "metadata":{  

   },
   "metalist":{  

   }
}
```
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>
