### PR TITLE
Update NDM operator to create sparse disks

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -530,7 +530,7 @@ spec:
         command:
         - /usr/sbin/ndm
         - start
-        image: openebs/node-disk-manager-amd64:ci
+        image: openebs/node-disk-manager-amd64:v0.1.0-RC2
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -543,12 +543,24 @@ spec:
           mountPath: /run/udev
         - name: procmount
           mountPath: /host/mounts
+        - name: sparsepath
+          mountPath: /var/openebs
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
+        - name: SPARSE_FILE_DIR
+          value: "/var/openebs"
+        # Size(bytes) of the sparse file to be created.
+        - name: SPARSE_FILE_SIZE
+          value: "10737418240"
+        # Specify the number of sparse files to be created
+        - name: SPARSE_FILE_COUNT
+          value: "1"
       volumes:
       - name: config
         configMap:
@@ -562,4 +574,7 @@ spec:
       - name: procmount
         hostPath:
           path: /proc/1/mounts
+      - name: sparsepath
+        hostPath:
+          path: /var/openebs
 ---


### PR DESCRIPTION
This PR update the openebs-operator to use the latest NDM released image with sparse disk support. Sparse disks of 10G will be created on each node where NDM is started under the /var/openebs directory. 

Signed-off-by: kmova <kiran.mova@mayadata.io>

