### PR TITLE
Update openebs-operator variable to list volumes of cstor and jiva

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -110,7 +110,7 @@ spec:
         # OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME sets the cas template name to
         # list volumes. This is a mandatory env variable.
         - name: OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME
-          value: "jiva-volume-list-default-0.7.0"
+          value: "jiva-volume-list-default-0.7.0,cstor-volume-list-default-0.7.0"
         # OPENEBS_IO_INSTALL_CONFIG_NAME provides the name of configmap related
         # to maya install
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> This PR updates OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME env variable in openebs operator to list both jiva and cstor volumes.

