### PR TITLE
Fix jiva volume list run task

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1373,11 +1373,11 @@ spec:
             openebs.io/targetportals: {{ $clusterIP }}:3260
         spec:
           capacity: {{ $capacity }}
-          iqn: iqn.2016-09.com.openebs.jiva:{{ .Volume.owner }}
-          targetPortal: {{ .TaskResult.readlistsvc.clusterIP }}:3260
+          iqn: iqn.2016-09.com.openebs.jiva:{{ $name }}
+          targetPortal: {{ $clusterIP }}:3260
           replicas: {{ .TaskResult.readlistrep.podIP | default "" | splitList " " | len }}
           casType: jiva
-          targetIP: {{ .TaskResult.readlistsvc.clusterIP }}
+          targetIP: {{ $clusterIP }}
           targetPort: 3260
     {{- end -}}
 ---


### PR DESCRIPTION
```json
{
   "items":[
      {
         "apiVersion":"v1alpha1",
         "kind":"CASVolume",
         "metadata":{
            "annotations":{
               "openebs.io/replica-status":"running",
               "vsm.openebs.io/cluster-ips":"10.0.0.54",
               "vsm.openebs.io/replica-count":"1",
               "vsm.openebs.io/volume-size":"5G",
               "openebs.io/cluster-ips":"10.0.0.54",
               "openebs.io/replica-count":"1",
               "openebs.io/replica-ips":"172.17.0.6",
               "vsm.openebs.io/targetportals":"10.0.0.54:3260",
               "openebs.io/controller-status":"running,running",
               "vsm.openebs.io/controller-ips":"172.17.0.4",
               "vsm.openebs.io/replica-ips":"172.17.0.6",
               "vsm.openebs.io/iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
               "openebs.io/controller-ips":"172.17.0.4",
               "openebs.io/iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
               "openebs.io/targetportals":"10.0.0.54:3260",
               "openebs.io/volume-size":"5G",
               "vsm.openebs.io/controller-status":"running,running",
               "vsm.openebs.io/replica-status":"running"
            },
            "name":"default-percona-pvc",
            "namespace":"default"
         },
         "spec":{
            "capacity":"5G",
            "iqn":"iqn.2016-09.com.openebs.jiva:default-percona-pvc",
            "replicas":"1",
            "targetIP":"10.0.0.54",
            "targetPort":"3260",
            "targetPortal":"10.0.0.54:3260"
         },
         "status":{
            "Message":"",
            "Phase":"",
            "Reason":""
         }
      }
   ],
   "kind":"CASVolumeList",
   "metadata":{

   },
   "metalist":{

   }
}
```


Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>