### PR TITLE
Refactor cStor Pool deployment template 

### DIFF
--- a/k8s/demo/percona/percona-openebs-cstor-sparse-deployment.yaml
+++ b/k8s/demo/percona/percona-openebs-cstor-sparse-deployment.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: percona-cstor
+  labels:
+    name: percona-cstor
+spec:
+  replicas: 1
+  selector: 
+    matchLabels:
+      name: percona-cstor
+  template: 
+    metadata:
+      labels: 
+        name: percona-cstor
+    spec:
+      tolerations:
+      - key: "ak"
+        value: "av"
+        operator: "Equal"
+        effect: "NoSchedule"
+      containers:
+        - resources:
+            limits:
+              cpu: 0.5
+          name: percona-cstor
+          image: percona
+          args:
+            - "--ignore-db-dir"
+            - "lost+found"
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: k8sDem0
+          ports:
+            - containerPort: 3306
+              name: percona
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: demo-cstor-vol1
+      volumes:
+        - name: demo-cstor-vol1
+          persistentVolumeClaim:
+            claimName: demo-cstor-sparse-vol1-claim
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-cstor-sparse-vol1-claim
+spec:
+  storageClassName: openebs-cstor-sparse
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: percona-cstor-mysql
+  labels:
+    name: percona-cstor-mysql
+spec:
+  ports:
+    - port: 3306
+      targetPort: 3306
+  selector:
+      name: percona-cstor
+

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -544,7 +544,7 @@ spec:
         - name: procmount
           mountPath: /host/mounts
         - name: sparsepath
-          mountPath: /var/openebs
+          mountPath: /var/openebs/sparse
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -554,7 +554,7 @@ spec:
         # specify the directory where the sparse files need to be created.
         # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR
-          value: "/var/openebs"
+          value: "/var/openebs/sparse"
         # Size(bytes) of the sparse file to be created.
         - name: SPARSE_FILE_SIZE
           value: "10737418240"
@@ -576,5 +576,5 @@ spec:
           path: /proc/1/mounts
       - name: sparsepath
         hostPath:
-          path: /var/openebs
+          path: /var/openebs/sparse
 ---

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -25,9 +25,15 @@ spec:
   # will be placed
   - name: RunNamespace
     value: openebs
-  # MemoryLimit specifies the max memory that can be used by the pool pods.
-  - name: MemoryLimit
-    value: 2Gi
+  # ResourceLimits allow you to set the limits on memory and cpu for pool pods
+  # The resource and limit value should be in the same format as expected by
+  # Kubernetes. Example:
+  #- name: ResourceLimits
+  #  value: |-
+  #      memory: 1Gi
+  # By default, the resource limits are disabled. 
+  - name: ResourceLimits
+    value: "false"
   taskNamespace: openebs
   run:
     tasks:
@@ -177,6 +183,8 @@ spec:
     {{- $resourceNames := jsonpath .JsonResult `pkey=names,{.metadata.name}=;` | trim | default "" | splitList ";" -}}
     {{- $resourceNames | keyMap "resourceNameList" .ListItems | noop -}}
   task: |
+    {{- $setResourceLimits := .Config.ResourceLimits.value | default "false" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.ResourceLimits.value -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -201,9 +209,13 @@ spec:
           containers:
           - name: cstor-pool
             image: {{ .Config.CstorPoolImage.value }}
+            {{- if ne $setResourceLimits "false" }}
             resources:
               limits:
-                memory: {{ .Config.MemoryLimit.value }}
+              {{- range $rKey, $rLimit := $resourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             ports:
             - containerPort: 12000
               protocol: TCP
@@ -258,7 +270,7 @@ spec:
           - name: tmp
             hostPath:
               # From host, dir called /var/openebs/shared-<uid> is created to avoid clash if two replicas run on same node.
-              path: /var/openebs/shared-a2b
+              path: /var/openebs/shared-{{.Storagepool.owner}}
               type: {{ .Config.HostPathType.value }}
           - name: sparse
             hostPath:

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -20,7 +20,7 @@ spec:
     value: DirectoryOrCreate
   # SparseDir is a hostPath directory where to look for sparse files
   - name: SparseDir
-    value: /var/openebs
+    value: /var/openebs/sparse
   # RunNamespace is the namespace where namespaced resources related to pool
   # will be placed
   - name: RunNamespace

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -18,10 +18,16 @@ spec:
   # nothing exists at the given path i.e. an empty directory will be created.
   - name: HostPathType
     value: DirectoryOrCreate
+  # SparseDir is a hostPath directory where to look for sparse files
+  - name: SparseDir
+    value: /var/openebs
   # RunNamespace is the namespace where namespaced resources related to pool
   # will be placed
   - name: RunNamespace
     value: openebs
+  # MemoryLimit specifies the max memory that can be used by the pool pods.
+  - name: MemoryLimit
+    value: 2Gi
   taskNamespace: openebs
   run:
     tasks:
@@ -195,6 +201,9 @@ spec:
           containers:
           - name: cstor-pool
             image: {{ .Config.CstorPoolImage.value }}
+            resources:
+              limits:
+                memory: {{ .Config.MemoryLimit.value }}
             ports:
             - containerPort: 12000
               protocol: TCP
@@ -210,7 +219,7 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: sparse
-              mountPath: /var/openebs
+              mountPath: {{ .Config.SparseDir.value }}
             - name: udev
               mountPath: /run/udev
               # To avoid clash between terminating and restarting pod
@@ -232,7 +241,7 @@ spec:
             - name: tmp
               mountPath: /tmp
             - name: sparse
-              mountPath: /var/openebs
+              mountPath: {{ .Config.SparseDir.value }}
             - name: udev
               mountPath: /run/udev
             env:
@@ -253,8 +262,8 @@ spec:
               type: {{ .Config.HostPathType.value }}
           - name: sparse
             hostPath:
-              path: /var/openebs
-              type: Directory
+              path: {{ .Config.SparseDir.value }}
+              type: {{ .Config.HostPathType.value }}
           - name: udev
             hostPath:
               path: /run/udev
@@ -2060,5 +2069,7 @@ metadata:
     cas.openebs.io/config: |
       - name: StoragePoolClaim
         value: "cstor-sparse-pool"
+      - name: SparseDir
+        value: /var/openebs
 provisioner: openebs.io/provisioner-iscsi
 ---


### PR DESCRIPTION
Made the following changes:
- Provided a capability to set resource limits on cStor Pods. (Default is false). Can be overriden by specifying the limits in the SPC. 
- Made the Sparse Dir configurable
- Made the shared directory between containers in cstor pool pod, specific to that pool claim

Also, added an example percona deployment that uses sparse pool storage class. 