### PR TITLE
Use defaultConfig ns instead of hardcoded ns.

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -31,7 +31,7 @@ spec:
   #- name: ResourceLimits
   #  value: |-
   #      memory: 1Gi
-  # By default, the resource limits are disabled. 
+  # By default, the resource limits are disabled.
   - name: ResourceLimits
     value: "false"
   taskNamespace: openebs
@@ -452,6 +452,8 @@ spec:
     value: openebs/m-exporter:ci
   - name: ReplicaCount
     value: "3"
+  - name: RunNamespace
+    value: openebs
   taskNamespace: openebs
   run:
     tasks:
@@ -467,6 +469,9 @@ kind: CASTemplate
 metadata:
   name: cstor-volume-delete-default-0.7.0
 spec:
+  defaultConfig:
+  - name: RunNamespace
+    value: openebs
   taskNamespace: openebs
   run:
     tasks:
@@ -486,6 +491,9 @@ metadata:
   name: cstor-volume-read-default-0.7.0
 spec:
   taskNamespace: openebs
+  defaultConfig:
+  - name: RunNamespace
+    value: openebs
   run:
     tasks:
     - cstor-volume-read-listtargetservice-default-0.7.0
@@ -499,6 +507,9 @@ metadata:
   name: cstor-volume-list-default-0.7.0
 spec:
   taskNamespace: openebs
+  defaultConfig:
+  - name: RunNamespace
+    value: openebs
   run:
     tasks:
     - cstor-volume-list-listtargetservice-default-0.7.0
@@ -515,7 +526,7 @@ metadata:
 spec:
   meta: |
     id: cvolcreatelistpool
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: openebs.io/v1alpha1
     kind: CStorPool
     action: list
@@ -545,7 +556,7 @@ spec:
     kind: Service
     action: put
     id: cvolcreateputsvc
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
   post: |
     {{- jsonpath .JsonResult `{.metadata.name}` | trim | saveAs "cvolcreateputsvc.objectName" .TaskResult | noop -}}
     {{- jsonpath .JsonResult `{.spec.clusterIP}` | trim | saveAs "cvolcreateputsvc.clusterIP" .TaskResult | noop -}}
@@ -584,7 +595,7 @@ spec:
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolume
     id: cvolcreateputvolume
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     action: put
   post: |
     {{- jsonpath .JsonResult `{.metadata.uid}` | trim | saveAs "cvolcreateputvolume.cstorid" .TaskResult | noop -}}
@@ -616,7 +627,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: apps/v1beta1
     kind: Deployment
     action: put
@@ -724,7 +735,7 @@ metadata:
 spec:
   meta: |
     apiVersion: openebs.io/v1alpha1
-    runNameSpace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     kind: CStorVolumeReplica
     action: put
     id: cstorvolumecreatereplica
@@ -809,7 +820,7 @@ spec:
     Create and save list of namespaces to $nss.
     Iterate over each namespace and perform list task
     */ -}}
-    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
+    {{- $nss := .Config.RunNamespace.value | default "" | splitList ", " -}}
     id: listlistsvc
     repeatWith:
       metas:
@@ -837,7 +848,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
+    {{- $nss := .Config.RunNamespace.value | default "" | splitList ", " -}}
     id: listlistctrl
     repeatWith:
       metas:
@@ -864,7 +875,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     id: listlistrep
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
@@ -925,7 +936,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: v1
     id: readlistsvc
     kind: Service
@@ -946,7 +957,7 @@ metadata:
 spec:
   meta: |
     id: readlistrep
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
     action: list
@@ -965,7 +976,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: v1
     kind: Pod
     action: list
@@ -1018,7 +1029,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     id: deletelistcsv
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolume
@@ -1039,7 +1050,7 @@ metadata:
 spec:
   meta: |
     id: deletelistsvc
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: v1
     kind: Service
     action: list
@@ -1063,7 +1074,7 @@ metadata:
 spec:
   meta: |
     id: deletelistctrl
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: apps/v1beta1
     kind: Deployment
     action: list
@@ -1083,7 +1094,7 @@ metadata:
 spec:
   meta: |
     id: deletelistcvr
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
     action: list
@@ -1107,7 +1118,7 @@ metadata:
 spec:
   meta: |
     id: deletedeletesvc
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: v1
     kind: Service
     action: delete
@@ -1122,7 +1133,7 @@ metadata:
 spec:
   meta: |
     id: deletedeletectrl
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     apiVersion: apps/v1beta1
     kind: Deployment
     action: delete
@@ -1136,7 +1147,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     id: deletedeletecvr
     action: delete
     kind: CStorVolumeReplica
@@ -1151,7 +1162,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: openebs
+    runNamespace: {{.Config.RunNamespace.value}}
     id: deletedeletecsv
     action: delete
     apiVersion: openebs.io/v1alpha1


### PR DESCRIPTION
cStor volume runtasks were making use of .Volume.runNamespace
or hardcoded 'openebs' namespace. This made it difficult to
update the namespace.

This commit initializes the namespace(taskNamespace) in default
config of cas template.

Signed-off-by: Prince Rachit Sinha <prince.rachit@mayadata.io>

Changes to be committed
	modified:   openebs-pre-release-features.yaml

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
