### PR TITLE
Add CAS Templates for list, info and delete of 0.6 jiva volumes.

### DIFF
--- a/e2e/ansible/playbooks/feature/ha/ha.yml
+++ b/e2e/ansible/playbooks/feature/ha/ha.yml
@@ -90,7 +90,7 @@
            - name: Get storage ctrl pod name
              shell: >
                source ~/.profile;
-               kubectl get pods -n {{ namespace }} -l openebs/controller=jiva-controller --no-headers
+               kubectl get pods -n {{ namespace }} -l openebs.io/controller=jiva-controller --no-headers
              args:
                executable: /bin/bash
              register: result
@@ -192,7 +192,7 @@
        - name: Check if ctrl pod is restarted within 30s
          shell: >
            source ~/.profile;
-           kubectl get pods -n {{ namespace }} -l openebs/controller=jiva-controller
+           kubectl get pods -n {{ namespace }} -l openebs.io/controller=jiva-controller
          args:
            executable: /bin/bash
          register: result

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-memleak/test-mem.py
@@ -8,7 +8,7 @@ import subprocess
 import time, os, sys
 list = []
 namespace = sys.argv[1]
-cmd_cntrl_name = "source ~/.profile; kubectl get pod -n %s -l openebs/controller=jiva-controller --no-headers | awk '{print $1}'" %(namespace)
+cmd_cntrl_name = "source ~/.profile; kubectl get pod -n %s -l openebs.io/controller=jiva-controller --no-headers | awk '{print $1}'" %(namespace)
 print cmd_cntrl_name
 out = subprocess.Popen(cmd_cntrl_name,stdout=subprocess.PIPE,shell=True)
 cntrl_name = out.communicate()

--- a/e2e/ansible/playbooks/hyperconverged/test-k8s-volume-taints/openebs-volumepolicies.yaml
+++ b/e2e/ansible/playbooks/hyperconverged/test-k8s-volume-taints/openebs-volumepolicies.yaml
@@ -16,12 +16,9 @@ data:
     Kind: Service
     metadata:
       labels:
-        openebs/controller-service: jiva-controller-service
         openebs.io/controller-service: jiva-controller-svc
         openebs.io/storage-engine-type: jiva
-        openebs/volume-provisioner: jiva
-        vsm: {{ .Volume.owner }}
-        openebs.io/pv: {{ .Volume.owner }}
+        openebs.io/persistent-volume: {{ .Volume.owner }}
       name: {{ .Volume.owner }}-ctrl-svc
     spec:
       ports:
@@ -34,10 +31,8 @@ data:
         protocol: TCP
         targetPort: 9501
       selector:
-        openebs/controller: jiva-controller
-        vsm: {{ .Volume.owner }}
         openebs.io/controller: jiva-controller
-        openebs.io/pv: {{ .Volume.owner }}
+        openebs.io/persistent-volume: {{ .Volume.owner }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -73,11 +68,8 @@ data:
     metadata:
       labels:
         openebs.io/storage-engine-type: jiva
-        openebs/volume-provisioner: jiva
-        openebs/controller: jiva-controller
         openebs.io/controller: jiva-controller
-        vsm: {{ .Volume.owner }}
-        openebs.io/pv: {{ .Volume.owner }}
+        openebs.io/persistent-volume: {{ .Volume.owner }}
       annotations:
         openebs.io/volume-monitor: "true"
         openebs.io/volume-type: jiva
@@ -86,19 +78,14 @@ data:
       replicas: 1
       selector:
         matchLabels:
-          monitoring: volume_exporter_prometheus
           openebs.io/controller: jiva-controller
-          openebs/controller: jiva-controller
-          openebs.io/pv: {{ .Volume.owner }}
-          vsm: {{ .Volume.owner }}
+          openebs.io/persistent-volume: {{ .Volume.owner }}
       template:
         metadata:
           labels:
             monitoring: volume_exporter_prometheus
             openebs.io/controller: jiva-controller
-            openebs/controller: jiva-controller
-            openebs.io/pv: {{ .Volume.owner }}
-            vsm: {{ .Volume.owner }}
+            openebs.io/persistent-volume: {{ .Volume.owner }}
         spec:
           containers:
           - args:
@@ -155,37 +142,28 @@ data:
     metadata:
       labels:
         openebs.io/storage-engine-type: jiva
-        openebs/volume-provisioner: jiva
-        openebs/replica: jiva-replica
         openebs.io/replica: jiva-replica
-        vsm: {{ .Volume.owner }}
-        openebs.io/pv: {{ .Volume.owner }}
+        openebs.io/persistent-volume: {{ .Volume.owner }}
       name: {{ .Volume.owner }}-rep
     spec:
       replicas: {{ .Policy.ReplicaCount.value }}
       selector:
         matchLabels:
-          openebs/replica: jiva-replica
           openebs.io/replica: jiva-replica
-          vsm: {{ .Volume.owner }}
-          openebs.io/pv: {{ .Volume.owner }}
+          openebs.io/persistent-volume: {{ .Volume.owner }}
       template:
         metadata:
           labels:
-            openebs/replica: jiva-replica
             openebs.io/replica: jiva-replica
-            vsm: {{ .Volume.owner }}
-            openebs.io/pv: {{ .Volume.owner }}
+            openebs.io/persistent-volume: {{ .Volume.owner }}
         spec:
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
                   matchLabels:
-                    openebs/replica: jiva-replica
                     openebs.io/replica: jiva-replica
-                    vsm: {{ .Volume.owner }}
-                    openebs.io/pv: {{ .Volume.owner }}
+                    openebs.io/persistent-volume: {{ .Volume.owner }}
                 topologyKey: kubernetes.io/hostname
           containers:
           - args:

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume-vars.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume-vars.yml
@@ -11,6 +11,6 @@ claim_name: percona-claim
 
 app_label: "name=percona"
 
-replica_label: "openebs/replica=jiva-replica"
+replica_label: "openebs.io/replica=jiva-replica"
 
 namespace: resize-volume

--- a/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml
+++ b/e2e/ansible/playbooks/hyperconverged/test-resize-jiva-volume/resize-volume.yml
@@ -169,7 +169,7 @@
           delegate_to: "{{ groups['kubernetes-kubemasters'].0}}"
 
         - name: Getting the replica pod names
-          shell:  kubectl get pods --all-namespaces --show-labels | grep openebs/replica=jiva-replica | awk {'print $2'} | awk 'FNR == {{ item }} {print}'
+          shell:  kubectl get pods --all-namespaces --show-labels | grep openebs.io/replica=jiva-replica | awk {'print $2'} | awk 'FNR == {{ item }} {print}'
           args:
             executable: /bin/bash
           register: pods

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/chaoskube.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/chaoskube.yaml
@@ -24,7 +24,7 @@ spec:
         #- --interval=10m
         
         # only target pods in the test environment
-        #- --labels=openebs/controller=jiva-controller
+        #- --labels=openebs.io/controller=jiva-controller
         
         # only consider pods with this annotation
         #- --annotations=chaos.alpha.kubernetes.io/enabled=true

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -117,7 +117,7 @@
        - name: Get the name of the volume ctrl deployment
          shell: >
            source ~/.profile; kubectl get deployments -n {{ namespace }}
-           -l openebs/controller=jiva-controller --no-headers
+           -l openebs.io/controller=jiva-controller --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -147,7 +147,7 @@
          shell: >
            source ~/.profile; kubectl exec {{ chaospod }} -n {{ namespace }}
            -- timeout -t {{ chaos_duration }} chaoskube
-           --labels 'openebs/controller=jiva-controller'
+           --labels 'openebs.io/controller=jiva-controller'
            --no-dry-run --interval={{ chaos_interval }}s
            --debug
            --namespaces={{ namespace }}

--- a/e2e/ansible/playbooks/resiliency/test-disk-failure/test-disk-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-disk-failure/test-disk-failure.yml
@@ -144,7 +144,7 @@
          include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{ namespace }}"
-           lkey: openebs/replica
+           lkey: openebs.io/replica
            lvalue: jiva-replica           
 
        - name: 8) Obtaining the replica pods running on specified node
@@ -269,7 +269,7 @@
          include_tasks: "{{utils_path}}/deploy_check.yml"
          vars:
            ns: "{{ namespace }}"
-           lkey: openebs/replica
+           lkey: openebs.io/replica
            lvalue: jiva-replica
 
        - name: 14) Get Controller SVC IP

--- a/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
+++ b/e2e/ansible/playbooks/resiliency/test-network-failure-rep/test-nw-failure-rep.yml
@@ -105,14 +105,14 @@
             lvalue: percona
 
        - name: Get the node details on which pvc-rep is scheduled
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l openebs/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}' | awk {'print $7'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -o wide -l openebs.io/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}' | awk {'print $7'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
          register: node_rep
 
        - name: Get the pvc-rep name
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}'| awk {'print $1'}
+         shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs.io/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}'| awk {'print $1'}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/inject_replica_quorum_failure.yml
@@ -11,7 +11,7 @@
   changed_when: true
 
 - name: Get replica pod name
-  shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}' | awk {'print $1'}
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} -l openebs.io/replica=jiva-replica --no-headers | awk 'FNR == 1 {print}' | awk {'print $1'}
   args:
     executable: /bin/bash
   register: result

--- a/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-replica-quorum-failure/test-replica-quorum-failure.yml
@@ -96,7 +96,7 @@
        - name: Get the name of the volume replica deployment
          shell: >
            source ~/.profile; kubectl get deployments -n {{ namespace }}
-           -l openebs/replica=jiva-replica --no-headers
+           -l openebs.io/replica=jiva-replica --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/chaoskube.yaml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/chaoskube.yaml
@@ -24,7 +24,7 @@ spec:
         #- --interval=10m
         
         # only target pods in the test environment
-        #- --labels=openebs/controller=jiva-controller
+        #- --labels=openebs.io/controller=jiva-controller
         
         # only consider pods with this annotation
         #- --annotations=chaos.alpha.kubernetes.io/enabled=true

--- a/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-single-replica-failure/test-single-replica-failure.yml
@@ -125,7 +125,7 @@
        - name: Get the name of the volume single replica deployment
          shell: >
            source ~/.profile; kubectl get deployments -n {{ namespace }}
-           -l openebs/replica=jiva-replica --no-headers
+           -l openebs.io/replica=jiva-replica --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -138,7 +138,7 @@
        - name: Get the name of the single replica pod to a variable
          shell: >
            source ~/.profile; kubectl get pods -n {{ namespace }}
-           -l openebs/replica=jiva-replica --no-headers
+           -l openebs.io/replica=jiva-replica --no-headers
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
@@ -193,7 +193,7 @@
          shell: >
            source ~/.profile; kubectl exec {{ chaospod }} -n {{ namespace }}
            -- timeout -t {{ chaos_duration }} chaoskube
-           --labels 'openebs/replica=jiva-replica'
+           --labels 'openebs.io/replica=jiva-replica'
            --no-dry-run --interval={{ chaos_interval }}s
            --debug
            --namespaces={{ namespace }}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -10,7 +10,7 @@ If this is your first time to Kubernetes, please go through these introductory t
 
 ## Usage
 
-### Installing OpenEBS on K8s
+### Installing Pre-released OpenEBS **_(at your own risk)_**
 ```
 kubectl apply -f openebs-operator.yaml
 ```

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -132,9 +132,9 @@ spec:
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.6.0"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.6.0"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "openebs/m-exporter:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
@@ -439,9 +439,9 @@ metadata:
     cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
     cas.openebs.io/config: |
       - name: ControllerImage
-        value: openebs/jiva:0.6.0
+        value: openebs/jiva:ci
       - name: ReplicaImage
-        value: openebs/jiva:0.6.0
+        value: openebs/jiva:ci
       - name: VolumeMonitorImage
         value: openebs/m-exporter:ci
       - name: ReplicaCount

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -110,7 +110,7 @@ spec:
         # OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME sets the cas template name to
         # list volumes. This is a mandatory env variable.
         - name: OPENEBS_IO_CAS_TEMPLATE_TO_LIST_VOLUME
-          value: "jiva-volume-list-default-0.7.0,cstor-volume-list-default-0.7.0"
+          value: "jiva-volume-list-default-0.6.0,jiva-volume-list-default-0.7.0,cstor-volume-list-default-0.7.0"
         # OPENEBS_IO_INSTALL_CONFIG_NAME provides the name of configmap related
         # to maya install
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1292,6 +1292,22 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
 metadata:
+  name: jiva-volume-delete-default-0.6.0
+spec:
+  taskNamespace: openebs
+  run:
+    tasks:
+    - jiva-volume-delete-listtargetservice-default-0.6.0
+    - jiva-volume-delete-listtargetdeployment-default-0.6.0
+    - jiva-volume-delete-listreplicadeployment-default-0.6.0
+    - jiva-volume-delete-deletetargetservice-default-0.7.0
+    - jiva-volume-delete-deletetargetdeployment-default-0.7.0
+    - jiva-volume-delete-deletereplicadeployment-default-0.7.0
+  output: jiva-volume-delete-output-default-0.7.0
+---
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
   name: jiva-volume-delete-default-0.7.0
 spec:
   taskNamespace: openebs
@@ -2092,6 +2108,25 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
+  name: jiva-volume-delete-listtargetservice-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: deletelistsvc
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Service
+    action: list
+    options: |-
+      labelSelector: openebs/controller-service=jiva-controller-service,openebs/vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "deletelistsvc.names" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistsvc.names | notFoundErr "controller service not found" | saveIf "deletelistsvc.notFoundErr" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistsvc.names | default "" | splitList " " | isLen 1 | not | verifyErr "total no. of controller services is not 1" | saveIf "deletelistsvc.verifyErr" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
   name: jiva-volume-delete-listtargetservice-default-0.7.0
   namespace: openebs
 spec:
@@ -2111,6 +2146,25 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
+  name: jiva-volume-delete-listtargetdeployment-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: deletelistctrl
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: list
+    options: |-
+      labelSelector: openebs/controller=jiva-controller,vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "deletelistctrl.names" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistctrl.names | notFoundErr "controller deployment not found" | saveIf "deletelistctrl.notFoundErr" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistctrl.names | default "" | splitList " " | isLen 1 | not | verifyErr "total no. of controller deployments is not 1" | saveIf "deletelistctrl.verifyErr" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
   name: jiva-volume-delete-listtargetdeployment-default-0.7.0
   namespace: openebs
 spec:
@@ -2126,6 +2180,25 @@ spec:
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "deletelistctrl.names" .TaskResult | noop -}}
     {{- .TaskResult.deletelistctrl.names | notFoundErr "controller deployment not found" | saveIf "deletelistctrl.notFoundErr" .TaskResult | noop -}}
     {{- .TaskResult.deletelistctrl.names | default "" | splitList " " | isLen 1 | not | verifyErr "total no. of controller deployments is not 1" | saveIf "deletelistctrl.verifyErr" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-delete-listreplicadeployment-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: deletelistrep
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    action: list
+    options: |-
+      labelSelector: openebs/replica=jiva-replica,vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "deletelistrep.names" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistrep.names | notFoundErr "replica deployment not found" | saveIf "deletelistrep.notFoundErr" .TaskResult | noop -}}
+    {{- .TaskResult.deletelistrep.names | default "" | splitList " " | isLen 1 | not | verifyErr "total no. of replica deployments is not 1" | saveIf "deletelistrep.verifyErr" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1187,6 +1187,7 @@ spec:
   taskNamespace: openebs
   run:
     tasks:
+    - jiva-volume-read-getpv-default-0.6.0
     - jiva-volume-read-listtargetservice-default-0.6.0
     - jiva-volume-read-listtargetpod-default-0.6.0
     - jiva-volume-read-listreplicapod-default-0.6.0
@@ -1656,7 +1657,7 @@ spec:
     {{- .TaskResult.readlistrep.items | notFoundErr "replica pod(s) not found" | saveIf "readlistrep.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistrep.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistrep.status" .TaskResult | noop -}}
-    {{- "0G" | saveAs "readlistrep.capacity" .TaskResult -}}
+    {{- .TaskResult.readgetpv.capacity | saveAs "readlistrep.capacity" .TaskResult -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -2119,7 +2119,7 @@ spec:
     kind: Service
     action: list
     options: |-
-      labelSelector: openebs/controller-service=jiva-controller-service,openebs/vsm={{ .Volume.owner }}
+      labelSelector: openebs/controller-service=jiva-controller-service,vsm={{ .Volume.owner }}
   post: |
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "deletelistsvc.names" .TaskResult | noop -}}
     {{- .TaskResult.deletelistsvc.names | notFoundErr "controller service not found" | saveIf "deletelistsvc.notFoundErr" .TaskResult | noop -}}

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1182,6 +1182,19 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
 metadata:
+  name: jiva-volume-read-default-0.6.0
+spec:
+  taskNamespace: openebs
+  run:
+    tasks:
+    - jiva-volume-read-listtargetservice-default-0.6.0
+    - jiva-volume-read-listtargetpod-default-0.6.0
+    - jiva-volume-read-listreplicapod-default-0.6.0
+  output: jiva-volume-read-output-default-0.7.0
+---
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
   name: jiva-volume-read-default-0.7.0
 spec:
   taskNamespace: openebs
@@ -1516,6 +1529,42 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
+  name: jiva-volume-read-getpv-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: readgetpv
+    apiVersion: v1
+    runNamespace: default
+    kind: PersistentVolume
+    objectName: {{ .Volume.owner }}
+    action: get
+  post: |
+    {{- $capacity := jsonpath .JsonResult "{.spec.capacity.storage}" -}}
+    {{- trim $capacity | saveAs "readgetpv.capacity" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-read-listtargetservice-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: readlistsvc
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Service
+    action: list
+    options: |-
+      labelSelector: openebs/controller-service=jiva-controller-service,vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistsvc.items" .TaskResult | noop -}}
+    {{- .TaskResult.readlistsvc.items | notFoundErr "controller service not found" | saveIf "readlistsvc.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].spec.clusterIP}" | trim | saveAs "readlistsvc.clusterIP" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
   name: jiva-volume-read-listtargetservice-default-0.7.0
   namespace: openebs
 spec:
@@ -1531,6 +1580,26 @@ spec:
     {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistsvc.items" .TaskResult | noop -}}
     {{- .TaskResult.readlistsvc.items | notFoundErr "controller service not found" | saveIf "readlistsvc.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].spec.clusterIP}" | trim | saveAs "readlistsvc.clusterIP" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-read-listtargetpod-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: readlistctrl
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs/controller=jiva-controller,vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistctrl.items" .TaskResult | noop -}}
+    {{- .TaskResult.readlistctrl.items | notFoundErr "controller pod not found" | saveIf "readlistctrl.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistctrl.podIP" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistctrl.status" .TaskResult | noop -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
@@ -1551,6 +1620,27 @@ spec:
     {{- .TaskResult.readlistctrl.items | notFoundErr "controller pod not found" | saveIf "readlistctrl.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistctrl.podIP" .TaskResult | noop -}}
     {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistctrl.status" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-read-listreplicapod-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    id: readlistrep
+    runNamespace: {{ .Volume.runNamespace }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs/replica=jiva-replica,vsm={{ .Volume.owner }}
+  post: |
+    {{- jsonpath .JsonResult "{.items[*].metadata.name}" | trim | saveAs "readlistrep.items" .TaskResult | noop -}}
+    {{- .TaskResult.readlistrep.items | notFoundErr "replica pod(s) not found" | saveIf "readlistrep.notFoundErr" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].status.podIP}" | trim | saveAs "readlistrep.podIP" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.items[*].status.containerStatuses[*].ready}" | trim | saveAs "readlistrep.status" .TaskResult | noop -}}
+    {{- "0G" | saveAs "readlistrep.capacity" .TaskResult -}}
 ---
 apiVersion: openebs.io/v1alpha1
 kind: RunTask

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -556,6 +556,7 @@ spec:
       labels:
         openebs.io/target-service: cstor-target-svc
         openebs.io/storage-engine-type: cstor
+        openebs.io/cas-type: cstor
         openebs.io/persistent-volume: {{ .Volume.owner }}
       name: {{ .Volume.owner }}
     spec:
@@ -632,6 +633,7 @@ spec:
       labels:
         app: cstor-volume-manager
         openebs.io/storage-engine-type: cstor
+        openebs.io/cas-type: cstor
         openebs.io/target: cstor-target
         openebs.io/persistent-volume: {{ .Volume.owner }}
         openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
@@ -1293,6 +1295,88 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: CASTemplate
 metadata:
+  name: jiva-volume-list-default-0.6.0
+spec:
+  taskNamespace: openebs
+  run:
+    tasks:
+    - jiva-volume-list-listtargetservice-default-0.6.0
+    - jiva-volume-list-listtargetpod-default-0.6.0
+    - jiva-volume-list-listreplicapod-default-0.6.0
+  output: jiva-volume-list-output-default-0.7.0
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-list-listtargetservice-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
+    id: listlistsvc
+    repeatWith:
+      metas:
+      {{- range $k, $ns := $nss }}
+      - runNamespace: {{ $ns }}
+      {{- end }}
+    apiVersion: v1
+    kind: Service
+    action: list
+    options: |-
+      labelSelector: openebs.io/controller-service=jiva-controller-service
+  post: |
+    {{- $servicePairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.vsm},clusterIP={@.spec.clusterIP};{end}` | trim | default "" | splitList ";" -}}
+    {{- $servicePairs | keyMap "volumeList" .ListItems | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-list-listtargetpod-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
+    id: listlistctrl
+    repeatWith:
+      metas:
+      {{- range $k, $ns := $nss }}
+      - runNamespace: {{ $ns }}
+      {{- end }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs/controller=jiva-controller
+  post: |
+    {{- $controllerPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.vsm},controllerIP={@.status.podIP},controllerStatus={@.status.containerStatuses[*].ready};{end}` | trim | default "" | splitList ";" -}}
+    {{- $controllerPairs | keyMap "volumeList" .ListItems | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
+  name: jiva-volume-list-listreplicapod-default-0.6.0
+  namespace: openebs
+spec:
+  meta: |
+    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
+    id: listlistrep
+    repeatWith:
+      metas:
+      {{- range $k, $ns := $nss }}
+      - runNamespace: {{ $ns }}
+      {{- end }}
+    apiVersion: v1
+    kind: Pod
+    action: list
+    options: |-
+      labelSelector: openebs/replica=jiva-replica
+  post: |
+    {{- $replicaPairs := jsonpath .JsonResult `{range .items[*]}pkey={@.metadata.namespace}/{@.metadata.labels.vsm},replicaIP={@.status.podIP},replicaStatus={@.status.containerStatuses[*].ready},capacity=Uknown;{end}` | trim | default "" | splitList ";" -}}
+    {{- $replicaPairs | keyMap "volumeList" .ListItems | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: CASTemplate
+metadata:
   name: jiva-volume-list-default-0.7.0
 spec:
   taskNamespace: openebs
@@ -1554,14 +1638,12 @@ spec:
     Kind: Service
     metadata:
       labels:
-        openebs/controller-service: jiva-controller-service
-        openebs/volume-provisioner: jiva
-        vsm: {{ .Volume.owner }}
-        pvc: {{ .Volume.pvc }}
         openebs.io/storage-engine-type: jiva
+        openebs.io/cas-type: jiva
         openebs.io/controller-service: jiva-controller-svc
         openebs.io/persistent-volume: {{ .Volume.owner }}
         openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+        pvc: {{ .Volume.pvc }}
       name: {{ .Volume.owner }}-ctrl-svc
     spec:
       ports:
@@ -1574,8 +1656,6 @@ spec:
         protocol: TCP
         targetPort: 9501
       selector:
-        openebs/controller: jiva-controller
-        vsm: {{ .Volume.owner }}
         openebs.io/controller: jiva-controller
         openebs.io/persistent-volume: {{ .Volume.owner }}
 ---
@@ -1710,17 +1790,15 @@ spec:
     Kind: Deployment
     metadata:
       labels:
-        openebs/volume-provisioner: jiva
-        openebs/controller: jiva-controller
-        vsm: {{ .Volume.owner }}
-        pvc: {{ .Volume.pvc }}
         {{- if eq $isMonitor "true" }}
         monitoring: "volume_exporter_prometheus"
         {{- end}}
         openebs.io/storage-engine-type: jiva
+        openebs.io/cas-type: jiva
         openebs.io/controller: jiva-controller
         openebs.io/persistent-volume: {{ .Volume.owner }}
         openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+        pvc: {{ .Volume.pvc }}
       annotations:
         {{- if eq $isMonitor "true" }}
         openebs.io/volume-monitor: "true"
@@ -1731,28 +1809,18 @@ spec:
       replicas: 1
       selector:
         matchLabels:
-          openebs/volume-provisioner: jiva
-          openebs/controller: jiva-controller
-          vsm: {{ .Volume.owner }}
-          pvc: {{ .Volume.pvc }}
-          {{- if eq $isMonitor "true" }}
-          monitoring: volume_exporter_prometheus
-          {{- end}}
           openebs.io/controller: jiva-controller
           openebs.io/persistent-volume: {{ .Volume.owner }}
       template:
         metadata:
           labels:
-            openebs/volume-provisioner: jiva
-            openebs/controller: jiva-controller
-            vsm: {{ .Volume.owner }}
-            pvc: {{ .Volume.pvc }}
             {{- if eq $isMonitor "true" }}
             monitoring: volume_exporter_prometheus
             {{- end}}
             openebs.io/controller: jiva-controller
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+            pvc: {{ .Volume.pvc }}
         spec:
           containers:
           - args:
@@ -1825,14 +1893,12 @@ spec:
     kind: Deployment
     metadata:
       labels:
-        openebs/replica: jiva-replica
-        openebs/volume-provisioner: jiva
-        vsm: {{ .Volume.owner }}
-        pvc: {{ .Volume.pvc }}
         openebs.io/storage-engine-type: jiva
+        openebs.io/cas-type: jiva
         openebs.io/replica: jiva-replica
         openebs.io/persistent-volume: {{ .Volume.owner }}
         openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+        pvc: {{ .Volume.pvc }}
       annotations:
         openebs.io/capacity: {{ .Volume.capacity }}
         openebs.io/storage-pool: {{ .Config.StoragePool.value }}
@@ -1841,22 +1907,15 @@ spec:
       replicas: {{ .Config.ReplicaCount.value }}
       selector:
         matchLabels:
-          openebs/replica: jiva-replica
-          openebs/volume-provisioner: jiva
-          vsm: {{ .Volume.owner }}
-          pvc: {{ .Volume.pvc }}
           openebs.io/replica: jiva-replica
           openebs.io/persistent-volume: {{ .Volume.owner }}
       template:
         metadata:
           labels:
-            openebs/replica: jiva-replica
-            openebs/volume-provisioner: jiva
-            vsm: {{ .Volume.owner }}
-            pvc: {{ .Volume.pvc }}
             openebs.io/replica: jiva-replica
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
+            pvc: {{ .Volume.pvc }}
           annotations:
             openebs.io/capacity: {{ .Volume.capacity }}
             openebs.io/storage-pool: {{ .Config.StoragePool.value }}
@@ -1866,9 +1925,7 @@ spec:
               requiredDuringSchedulingIgnoredDuringExecution:
               - labelSelector:
                   matchLabels:
-                    openebs/replica: jiva-replica
                     openebs.io/replica: jiva-replica
-                    vsm: {{ .Volume.owner }}
                     openebs.io/persistent-volume: {{ .Volume.owner }}
                 topologyKey: kubernetes.io/hostname
           containers:

--- a/k8s/sample-pv-yamls/pvc-cstor-sc-sparse-ns-default.yaml
+++ b/k8s/sample-pv-yamls/pvc-cstor-sc-sparse-ns-default.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: cstor-sc-sparse-ns-default
+spec:
+  storageClassName: openebs-cstor-sparse
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-standard-ns-default.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-standard-ns-default.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-sc-standard-ns-default
+spec:
+  storageClassName: openebs-standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-standard-ns-test.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-standard-ns-test.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  namespace: test
+  name: jiva-sc-standard-ns-test
+spec:
+  storageClassName: openebs-standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+---


### PR DESCRIPTION
This PR adds:
- CAS templates for list, read, delete of jiva volumes from 0.6 - that make use of the labels available in 0.6
- Updates the 0.7 created jiva volumes to not have the old style labels like - vsm
- Update the operator to add jiva-0.6 list volume cas template
- Added some sample PVC yaml files of jiva and cstor
- Minor fix to the Docs. 
- Updated e2e playbooks to use `openebs.io` in labels than `openebs`
