### PR TITLE
Update CAS templates to configure Pod Resource limits

### DIFF
--- a/k8s/demo/pvc-cstor-sparse-limit-resources.yaml
+++ b/k8s/demo/pvc-cstor-sparse-limit-resources.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-limits
+  annotations:
+    cas.openebs.io/create-volume-template: cstor-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: cstor-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: cstor-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "cstor-sparse-pool"
+      - name: TargetResourceLimits
+        value: |-
+            memory: 1Gi
+            cpu: 200m
+      - name: AuxResourceLimits
+        value: |-
+            memory: 0.5Gi
+            cpu: 50m
+provisioner: openebs.io/provisioner-iscsi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-cstor-limits-claim
+spec:
+  storageClassName: openebs-cstor-limits
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/demo/pvc-jiva-limit-resources.yaml
+++ b/k8s/demo/pvc-jiva-limit-resources.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-jiva-limits
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:ci
+      - name: ReplicaImage
+        value: openebs/jiva:ci
+      - name: VolumeMonitorImage
+        value: openebs/m-exporter:ci
+      - name: ReplicaCount
+        value: "1"
+      - name: StoragePool
+        value: default
+      - name: TargetResourceLimits
+        value: |-
+            memory: 1Gi
+            cpu: 100m
+      - name: AuxResourceLimits
+        value: |-
+            memory: 0.5Gi
+            cpu: 50m
+      - name: ReplicaResourceLimits
+        value: |-
+            memory: 2Gi
+            cpu: 200m
+provisioner: openebs.io/provisioner-iscsi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-jiva-limits-claim
+spec:
+  storageClassName: openebs-jiva-limits
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -446,6 +446,17 @@ metadata:
         value: "3"
       - name: StoragePool
         value: default
+      #- name: TargetResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 100m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 0.5Gi
+      #      cpu: 50m
+      #- name: ReplicaResourceLimits
+      #  value: |-
+      #      memory: 2Gi
 provisioner: openebs.io/provisioner-iscsi
 parameters:
   openebs.io/storage-pool: "default"

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -31,6 +31,8 @@ spec:
   #- name: PoolResourceLimits
   #  value: |-
   #      memory: 1Gi
+  - name: PoolResourceLimits
+    value: "false"
   # AuxResourceLimits allow you to set limits on side cars. Limits have to be specified
   # in the format expected by Kubernetes
   - name: AuxResourceLimits

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -25,14 +25,19 @@ spec:
   # will be placed
   - name: RunNamespace
     value: openebs
-  # ResourceLimits allow you to set the limits on memory and cpu for pool pods
+  # PoolResourceLimits allow you to set the limits on memory and cpu for pool pods
   # The resource and limit value should be in the same format as expected by
   # Kubernetes. Example:
-  #- name: ResourceLimits
+  #- name: PoolResourceLimits
   #  value: |-
   #      memory: 1Gi
+  #      cpu: 200m
   # By default, the resource limits are disabled. 
-  - name: ResourceLimits
+  - name: PoolResourceLimits
+    value: "false"
+  # AuxResourceLimits allow you to set limits on side cars. Limits have to be specified
+  # in the format expected by Kubernetes
+  - name: AuxResourceLimits
     value: "false"
   taskNamespace: openebs
   run:
@@ -185,8 +190,10 @@ spec:
     {{- $resourceNames := jsonpath .JsonResult `pkey=names,{.metadata.name}=;` | trim | default "" | splitList ";" -}}
     {{- $resourceNames | keyMap "resourceNameList" .ListItems | noop -}}
   task: |
-    {{- $setResourceLimits := .Config.ResourceLimits.value | default "false" -}}
-    {{- $resourceLimitsVal := fromYaml .Config.ResourceLimits.value -}}
+    {{- $setResourceLimits := .Config.PoolResourceLimits.value | default "false" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.PoolResourceLimits.value -}}
+    {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
+    {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -244,6 +251,13 @@ spec:
                     command: ["/bin/sh", "-c", "sleep 2"]
           - name: cstor-pool-mgmt
             image: {{ .Config.CstorPoolMgmtImage.value }}
+            {{- if ne $setAuxResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             ports:
             - containerPort: 9500
               protocol: TCP
@@ -452,6 +466,20 @@ spec:
     value: openebs/m-exporter:ci
   - name: ReplicaCount
     value: "3"
+  # TargetResourceLimits allow you to set the limits on memory and cpu for target pods
+  # The resource and limit value should be in the same format as expected by
+  # Kubernetes. Example:
+  #- name: TargetResourceLimits
+  #  value: |-
+  #      memory: 1Gi
+  #      cpu: 200m
+  # By default, the resource limits are disabled. 
+  - name: TargetResourceLimits
+    value: "false"
+  # AuxResourceLimits allow you to set limits on side cars. Limits have to be specified
+  # in the format expected by Kubernetes
+  - name: AuxResourceLimits
+    value: "false"
   taskNamespace: openebs
   run:
     tasks:
@@ -625,6 +653,10 @@ spec:
     {{- jsonpath .JsonResult `{.metadata.name}` | trim | saveAs "cvolcreateputctrl.objectName" .TaskResult | noop -}}
   task: |
     {{- $isMonitor := .Config.VolumeMonitor.enabled | default "true" | lower -}}
+    {{- $setResourceLimits := .Config.TargetResourceLimits.value | default "false" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.TargetResourceLimits.value -}}
+    {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
+    {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     apiVersion: apps/v1beta1
     Kind: Deployment
     metadata:
@@ -665,6 +697,13 @@ spec:
           - image: {{ .Config.VolumeTargetImage.value }}
             name: cstor-istgt
             imagePullPolicy: IfNotPresent
+            {{- if ne $setResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $resourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             ports:
             - containerPort: 3260
               protocol: TCP
@@ -680,6 +719,13 @@ spec:
           {{- if eq $isMonitor "true" }}
           - image: {{ .Config.VolumeMonitorImage.value }}
             name: maya-volume-exporter
+            {{- if ne $setAuxResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             args:
             - "-e=cstor"
             command: ["maya-exporter"]
@@ -692,6 +738,13 @@ spec:
           {{- end}}
           - name: cstor-volume-mgmt
             image: {{ .Config.VolumeControllerImage.value }}
+            {{- if ne $setAuxResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             imagePullPolicy: IfNotPresent
             ports:
             - containerPort: 80
@@ -1264,6 +1317,25 @@ spec:
         operator: In
         values:
         - some-node-label-value
+  # TargetResourceLimits allow you to set the limits on memory and cpu for jiva 
+  # target pods. The resource and limit value should be in the same format as 
+  # expected by Kubernetes. Example:
+  #- name: TargetResourceLimits
+  #  value: |-
+  #      memory: 1Gi
+  #      cpu: 200m
+  # By default, the resource limits are disabled. 
+  - name: TargetResourceLimits
+    value: "false"
+  # ReplicaResourceLimits allow you to set the limits on memory and cpu for jiva 
+  # replica pods. The resource and limit value should be in the same format as
+  # expected by Kubernetes. Example:
+  - name: ReplicaResourceLimits
+    value: "false"
+  # AuxResourceLimits allow you to set limits on side cars. Limits have to be specified
+  # in the format expected by Kubernetes
+  - name: AuxResourceLimits
+    value: "false"
   taskNamespace: openebs
   run:
     tasks:
@@ -1706,6 +1778,10 @@ spec:
     {{- jsonpath .JsonResult "{.metadata.name}" | trim | saveAs "createputctrl.objectName" .TaskResult | noop -}}
   task: |
     {{- $isMonitor := .Config.VolumeMonitor.enabled | default "true" | lower -}}
+    {{- $setResourceLimits := .Config.TargetResourceLimits.value | default "false" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.TargetResourceLimits.value -}}
+    {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
+    {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     apiVersion: extensions/v1beta1
     Kind: Deployment
     metadata:
@@ -1766,6 +1842,13 @@ spec:
             - launch
             image: {{ .Config.ControllerImage.value }}
             name: {{ .Volume.owner }}-ctrl-con
+            {{- if ne $setResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $resourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             env:
             - name: "REPLICATION_FACTOR"
               value: {{ .Config.ReplicaCount.value }}
@@ -1781,6 +1864,13 @@ spec:
             - maya-exporter
             image: {{ .Config.VolumeMonitorImage.value }}
             name: maya-volume-exporter
+            {{- if ne $setAuxResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $auxResourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             ports:
             - containerPort: 9500
               protocol: TCP
@@ -1821,6 +1911,10 @@ spec:
     {{- $isEvictionTolerations := .Config.EvictionTolerations.value | default "false" -}}
     {{- $evictionTolerationsVal := fromYaml .Config.EvictionTolerations.value -}}
     {{- $isCloneEnable := .Volume.isCloneEnable | default "false" -}}
+    {{- $setResourceLimits := .Config.ReplicaResourceLimits.value | default "false" -}}
+    {{- $resourceLimitsVal := fromYaml .Config.ReplicaResourceLimits.value -}}
+    {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
+    {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -1891,6 +1985,13 @@ spec:
             - launch
             image: {{ .Config.ReplicaImage.value }}
             name: {{ .Volume.owner }}-rep-con
+            {{- if ne $setResourceLimits "false" }}
+            resources:
+              limits:
+              {{- range $rKey, $rLimit := $resourceLimitsVal }}
+                {{ $rKey }}: {{ $rLimit }}
+              {{- end }}
+            {{- end }}
             ports:
             - containerPort: 9502
               protocol: TCP
@@ -2073,6 +2174,17 @@ metadata:
   annotations:
     cas.openebs.io/create-pool-template: cstor-pool-create-default-0.7.0
     cas.openebs.io/delete-pool-template: cstor-pool-delete-default-0.7.0
+    cas.openebs.io/config: |
+      - name: PoolResourceLimits
+        value: false
+      #- name: PoolResourceLimits
+      #  value: |-
+      #      memory: 2Gi
+      #      cpu: 500m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 100m
 spec:
   name: cstor-sparse-pool
   type: sparse
@@ -2093,7 +2205,13 @@ metadata:
     cas.openebs.io/config: |
       - name: StoragePoolClaim
         value: "cstor-sparse-pool"
-      - name: SparseDir
-        value: /var/openebs
+      #- name: TargetResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 200m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 0.5Gi
+      #      cpu: 50m
 provisioner: openebs.io/provisioner-iscsi
 ---

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -173,7 +173,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: extensions/v1beta1
     kind: Deployment
     action: put
@@ -552,7 +552,7 @@ metadata:
 spec:
   meta: |
     id: cvolcreatelistpool
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: openebs.io/v1alpha1
     kind: CStorPool
     action: list
@@ -582,7 +582,7 @@ spec:
     kind: Service
     action: put
     id: cvolcreateputsvc
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
   post: |
     {{- jsonpath .JsonResult `{.metadata.name}` | trim | saveAs "cvolcreateputsvc.objectName" .TaskResult | noop -}}
     {{- jsonpath .JsonResult `{.spec.clusterIP}` | trim | saveAs "cvolcreateputsvc.clusterIP" .TaskResult | noop -}}
@@ -621,7 +621,7 @@ spec:
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolume
     id: cvolcreateputvolume
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     action: put
   post: |
     {{- jsonpath .JsonResult `{.metadata.uid}` | trim | saveAs "cvolcreateputvolume.cstorid" .TaskResult | noop -}}
@@ -653,7 +653,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: apps/v1beta1
     kind: Deployment
     action: put
@@ -786,7 +786,7 @@ metadata:
 spec:
   meta: |
     apiVersion: openebs.io/v1alpha1
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     kind: CStorVolumeReplica
     action: put
     id: cstorvolumecreatereplica
@@ -871,7 +871,7 @@ spec:
     Create and save list of namespaces to $nss.
     Iterate over each namespace and perform list task
     */ -}}
-    {{- $nss := .Config.RunNamespace.value | default "" | splitList ", " -}}
+    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
     id: listlistsvc
     repeatWith:
       metas:
@@ -899,7 +899,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    {{- $nss := .Config.RunNamespace.value | default "" | splitList ", " -}}
+    {{- $nss := .Volume.runNamespace | default "" | splitList ", " -}}
     id: listlistctrl
     repeatWith:
       metas:
@@ -926,7 +926,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     id: listlistrep
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
@@ -987,7 +987,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: v1
     id: readlistsvc
     kind: Service
@@ -1008,7 +1008,7 @@ metadata:
 spec:
   meta: |
     id: readlistrep
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
     action: list
@@ -1027,7 +1027,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: v1
     kind: Pod
     action: list
@@ -1080,7 +1080,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     id: deletelistcsv
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolume
@@ -1101,7 +1101,7 @@ metadata:
 spec:
   meta: |
     id: deletelistsvc
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: v1
     kind: Service
     action: list
@@ -1125,7 +1125,7 @@ metadata:
 spec:
   meta: |
     id: deletelistctrl
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: apps/v1beta1
     kind: Deployment
     action: list
@@ -1145,7 +1145,7 @@ metadata:
 spec:
   meta: |
     id: deletelistcvr
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: openebs.io/v1alpha1
     kind: CStorVolumeReplica
     action: list
@@ -1169,7 +1169,7 @@ metadata:
 spec:
   meta: |
     id: deletedeletesvc
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: v1
     kind: Service
     action: delete
@@ -1184,7 +1184,7 @@ metadata:
 spec:
   meta: |
     id: deletedeletectrl
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     apiVersion: apps/v1beta1
     kind: Deployment
     action: delete
@@ -1198,7 +1198,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     id: deletedeletecvr
     action: delete
     kind: CStorVolumeReplica
@@ -1213,7 +1213,7 @@ metadata:
   namespace: openebs
 spec:
   meta: |
-    runNamespace: {{.Config.RunNamespace.value}}
+    runNamespace: openebs
     id: deletedeletecsv
     action: delete
     apiVersion: openebs.io/v1alpha1


### PR DESCRIPTION
    Updated the cStor Pool, cStor Target, jiva Target and Replica
    creation CAS templates with configuring CPU and Memory limits.
    The limits are disabled by default.
    
    For cStor Pool, the limits can be enabled via SPC
    For cStor Target, Jiva Target and Replica via the StorageClass
    
    SPC and StorageClass can also take AuxResourceLimits that will
    be set on the side-cars.
    
    The default jiva storage class, cstor sparse pool and storage class
    are updated with (commented) example on how to specify the CPU
    limits