### PR TITLE
Update jiva CAS Templates with node selector based scheduling

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -141,19 +141,19 @@ spec:
           value: "openebs/m-exporter:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
-        # DEFAULT_CONTROLLER_NODE_SELECTOR allows your to specify the nodes
+        # DEFAULT_CONTROLLER_NODE_SELECTOR allows you to specify the nodes
         # on which openebs controller have to be scheduled. To use this feature,
         # the nodes should already be labeled with the key=value. For example:
-        # `kubectl label nodes <node-name> nodetype=storage
+        # `kubectl label nodes <node-name> nodetype=storage`
         # Note: It is recommended that node selector for controller be
         # same as that of the stateful apps.
         # This is supported for maya api server version 0.6.0-RC2 onwards
         #- name: DEFAULT_CONTROLLER_NODE_SELECTOR
         #  value: "nodetype=storage"
-        # DEFAULT_REPLICA_NODE_SELECTOR allows your to specify the nodes
+        # DEFAULT_REPLICA_NODE_SELECTOR allows you to specify the nodes
         # on which openebs replicas have to be scheduled. To use this feature,
         # the nodes should already be labeled with the key=value. For example:
-        # `kubectl label nodes <node-name> nodetype=storage
+        # `kubectl label nodes <node-name> nodetype=storage`
         # Note: It is recommended that node selector for replica will specify
         # nodes that have disks/ssds attached to them.
         # This is supported for maya api server version 0.6.0-RC2 onwards

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1373,6 +1373,28 @@ spec:
   # in the format expected by Kubernetes
   - name: AuxResourceLimits
     value: "false"
+  # TargetNodeSelector allows you to specify the nodes where
+  # openebs targets have to be scheduled. To use this feature,
+  # the nodes should already be labeled with the key=value. For example:
+  # `kubectl label nodes <node-name> nodetype=storage`
+  # Note: It is recommended that node selector for replica specify
+  # nodes that have disks/ssds attached to them. Example:
+  #- name: TargetNodeSelector
+  #  value: |-
+  #      nodetype: storage
+  - name: TargetNodeSelector
+    value: "false"
+  # ReplicaNodeSelector allows you to specify the nodes where
+  # openebs replicas have to be scheduled. To use this feature,
+  # the nodes should already be labeled with the key=value. For example:
+  # `kubectl label nodes <node-name> nodetype=storage`
+  # Note: It is recommended that node selector for replica specify
+  # nodes that have disks/ssds attached to them. Example:
+  #- name: ReplicaNodeSelector
+  #  value: |-
+  #      nodetype: storage
+  - name: ReplicaNodeSelector
+    value: "false"
   taskNamespace: openebs
   run:
     tasks:
@@ -1990,6 +2012,8 @@ spec:
     {{- $resourceLimitsVal := fromYaml .Config.TargetResourceLimits.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
+    {{- $hasNodeSelector := .Config.TargetNodeSelector.value | default "false" -}}
+    {{- $nodeSelectorVal := fromYaml .Config.TargetNodeSelector.value -}}
     apiVersion: extensions/v1beta1
     Kind: Deployment
     metadata:
@@ -2027,6 +2051,12 @@ spec:
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
             pvc: {{ .Volume.pvc }}
         spec:
+          {{- if ne $hasNodeSelector "false" }}
+          nodeSelector:
+            {{- range $sK, $sV := $nodeSelectorVal }}
+              {{ $sK }}: {{ $sV }}
+            {{- end }}
+          {{- end}}
           containers:
           - args:
             - controller
@@ -2112,6 +2142,8 @@ spec:
     {{- $resourceLimitsVal := fromYaml .Config.ReplicaResourceLimits.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
+    {{- $hasNodeSelector := .Config.ReplicaNodeSelector.value | default "false" -}}
+    {{- $nodeSelectorVal := fromYaml .Config.ReplicaNodeSelector.value -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -2143,6 +2175,12 @@ spec:
             openebs.io/capacity: {{ .Volume.capacity }}
             openebs.io/storage-pool: {{ .Config.StoragePool.value }}
         spec:
+          {{- if ne $hasNodeSelector "false" }}
+          nodeSelector:
+            {{- range $sK, $sV := $nodeSelectorVal }}
+              {{ $sK }}: {{ $sV }}
+            {{- end }}
+          {{- end}}
           affinity:
             podAntiAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-nodeselector.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-nodeselector.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-jiva-nodeselector
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:ci
+      - name: ReplicaImage
+        value: openebs/jiva:ci
+      - name: VolumeMonitorImage
+        value: openebs/m-exporter:ci
+      - name: ReplicaCount
+        value: "1"
+      - name: StoragePool
+        value: default
+      - name: ReplicaNodeSelector
+        value: |-
+            nodetype: storage
+      - name: TargetNodeSelector
+        value: |-
+            nodetype: app
+provisioner: openebs.io/provisioner-iscsi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-jiva-replica-pinned
+spec:
+  storageClassName: openebs-jiva-nodeselector
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+


### PR DESCRIPTION
With 0.6, users were allowed to specify node selectors for jiva
replica and target pods via ENV variables. However this applied
to all the jiva/replica pods. This PR allows, users to specify
the Node selectors via StorageClass.

Signed-off-by: kmova <kiran.mova@openebs.io>

