### PR TITLE
Add hostname and cvr name to cstor CASVolume annotation for read

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1059,6 +1059,7 @@ spec:
   post: |
     {{- jsonpath .JsonResult `{.items[*].metadata.name}` | trim | saveAs "readlistrep.items" .TaskResult | noop -}}
     {{- jsonpath .JsonResult `{.items[*].metadata.annotations.cstorpool\.openebs\.io/hostname}` | trim | saveAs "readlistrep.hostname" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult `{.items[*].metadata.labels.cstorpool\.openebs\.io/name}` | trim | saveAs "readlistrep.poolname" .TaskResult | noop -}}
     {{- .TaskResult.readlistrep.items | notFoundErr "replicas not found" | saveIf "readlistrep.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult `{.items[*].spec.capacity}` | trim | saveAs "readlistrep.capacity" .TaskResult | noop -}}
 ---
@@ -1106,8 +1107,9 @@ spec:
       annotations:
         openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
-        openebs.io/cvr-name: {{ .TaskResult.readlistrep.items | default "" | splitList " " | join "," }}
-        openebs.io/host-name: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
+        openebs.io/cvr-names: {{ .TaskResult.readlistrep.items | default "" | splitList " " | join "," }}
+        openebs.io/host-names: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
+        openebs.io/pool-names: {{ .TaskResult.readlistrep.poolname | default "" | splitList " " | join "," }}
     spec:
       capacity: {{ $capacity }}
       iqn: iqn.2016-09.com.openebs.cstor:{{ .Volume.owner }}

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1108,7 +1108,7 @@ spec:
         openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
         openebs.io/cvr-names: {{ .TaskResult.readlistrep.items | default "" | splitList " " | join "," }}
-        openebs.io/host-names: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
+        openebs.io/node-names: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
         openebs.io/pool-names: {{ .TaskResult.readlistrep.poolname | default "" | splitList " " | join "," }}
     spec:
       capacity: {{ $capacity }}

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1058,6 +1058,7 @@ spec:
       labelSelector: openebs.io/persistent-volume={{ .Volume.owner }}
   post: |
     {{- jsonpath .JsonResult `{.items[*].metadata.name}` | trim | saveAs "readlistrep.items" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult `{.items[*].metadata.annotations.cstorpool\.openebs\.io/hostname}` | trim | saveAs "readlistrep.hostname" .TaskResult | noop -}}
     {{- .TaskResult.readlistrep.items | notFoundErr "replicas not found" | saveIf "readlistrep.notFoundErr" .TaskResult | noop -}}
     {{- jsonpath .JsonResult `{.items[*].spec.capacity}` | trim | saveAs "readlistrep.capacity" .TaskResult | noop -}}
 ---
@@ -1105,6 +1106,8 @@ spec:
       annotations:
         openebs.io/controller-ips: {{ .TaskResult.readlistctrl.podIP | default "" | splitList " " | first }}
         openebs.io/controller-status: {{ .TaskResult.readlistctrl.status | default "" | splitList " " | join "," | replace "true" "running" | replace "false" "notready" }}
+        openebs.io/cvr-name: {{ .TaskResult.readlistrep.items | default "" | splitList " " | join "," }}
+        openebs.io/host-name: {{ .TaskResult.readlistrep.hostname | default "" | splitList " " | join "," }}
     spec:
       capacity: {{ $capacity }}
       iqn: iqn.2016-09.com.openebs.cstor:{{ .Volume.owner }}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
-> This PR adds hostname , poolname and cvr name to cstor volume annotation.
-> These information can be consumed by tools like mayactl.

**Special notes for your reviewer**:
Proof:
```
{
  "apiVersion": "v1alpha1",
  "kind": "CASVolume",
  "metadata": {
    "annotations": {
      "openebs.io\/controller-ips": "10.32.2.11",
      "openebs.io\/controller-status": "running,running,running",
      "openebs.io\/cvr-names": "default-cstor-volume-3602380723-cstor-sparse-pool-7ey7,default-cstor-volume-3602380723-cstor-sparse-pool-j1la,default-cstor-volume-3602380723-cstor-sparse-pool-kv3n",
      "openebs.io\/host-names": "gke-ashish-dev-default-pool-1fe155b7-w75t,gke-ashish-dev-default-pool-1fe155b7-qv7v,gke-ashish-dev-default-pool-1fe155b7-rvqd",
      "openebs.io\/pool-names": "cstor-sparse-pool-7ey7,cstor-sparse-pool-j1la,cstor-sparse-pool-kv3n"
    },
    "name": "default-cstor-volume-3602380723"
  },
  "spec": {
    "capacity": "4G",
    "casType": "cstor",
    "iqn": "iqn.2016-09.com.openebs.cstor:default-cstor-volume-3602380723",
    "replicas": "3",
    "targetIP": "10.35.251.53",
    "targetPort": "3260",
    "targetPortal": "10.35.251.53:3260"
  },
  "status": {
    "Message": "",
    "Phase": "",
    "Reason": ""
  }
}

```
