### PR TITLE
Update Jiva CAS Templates for cross AZ scheduling

### DIFF
--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -1373,14 +1373,29 @@ spec:
   # in the format expected by Kubernetes
   - name: AuxResourceLimits
     value: "false"
+  # ReplicaAntiAffinityTopoKey is used to schedule replica pods 
+  # of a given volume/application, such that they are:
+  # - not co-located on the same node. (kubernetes.io/hostname)
+  # - not co-located on the same availability zone.(failure-domain.beta.kubernetes.io/zone) 
+  # The value for toplogy key can be anythign supported by Kubernetes
+  # clusters. It is possible that some cluster might support topology schemes
+  # like the rack or floor.
+  #
+  # Examples:
+  #   kubernetes.io/hostname (default)
+  #   failure-domain.beta.kubernetes.io/zone
+  #   failure-domain.beta.kubernetes.io/region
+  - name: ReplicaAntiAffinityTopoKey
+    value: kubernetes.io/hostname
   taskNamespace: openebs
   run:
     tasks:
     - jiva-volume-create-getstorageclass-default-0.7.0
+    - jiva-volume-create-getpvc-default-0.7.0
     - jiva-volume-create-puttargetservice-default-0.7.0
     - jiva-volume-create-getstoragepoolcr-default-0.7.0
-    - jiva-volume-create-puttargetdeployment-default-0.7.0
     - jiva-volume-create-putreplicadeployment-default-0.7.0
+    - jiva-volume-create-puttargetdeployment-default-0.7.0
   output: jiva-volume-create-output-default-0.7.0
 ---
 apiVersion: openebs.io/v1alpha1
@@ -1893,6 +1908,23 @@ spec:
 apiVersion: openebs.io/v1alpha1
 kind: RunTask
 metadata:
+  name: jiva-volume-create-getpvc-default-0.7.0
+  namespace: openebs
+spec:
+  meta: |
+    id: creategetpvc
+    apiVersion: v1
+    runNamespace: {{ .Volume.runNamespace }}
+    kind: PersistentVolumeClaim
+    objectName: {{ .Volume.pvc }}
+    action: get
+  post: |
+    {{- $replicaAntiAffinity := jsonpath .JsonResult "{.metadata.labels.openebs\\.io/replica-anti-affinity}" | default "none" -}}
+    {{- trim $replicaAntiAffinity | saveAs "creategetpvc.replicaAntiAffinity" .TaskResult | noop -}}
+---
+apiVersion: openebs.io/v1alpha1
+kind: RunTask
+metadata:
   name: jiva-volume-create-listreplicapod-default-0.7.0
   namespace: openebs
 spec:
@@ -2112,6 +2144,8 @@ spec:
     {{- $resourceLimitsVal := fromYaml .Config.ReplicaResourceLimits.value -}}
     {{- $setAuxResourceLimits := .Config.AuxResourceLimits.value | default "false" -}}
     {{- $auxResourceLimitsVal := fromYaml .Config.AuxResourceLimits.value -}}
+    {{- $replicaAntiAffinityVal := .TaskResult.creategetpvc.replicaAntiAffinity -}}
+    {{- $scVersion := .TaskResult.creategetsc.storageClassVersion | default "false" -}}
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
@@ -2139,6 +2173,9 @@ spec:
             openebs.io/persistent-volume: {{ .Volume.owner }}
             openebs.io/persistent-volume-claim: {{ .Volume.pvc }}
             pvc: {{ .Volume.pvc }}
+            {{- if ne $replicaAntiAffinityVal "none" }}
+            openebs.io/replica-anti-affinity: {{ $replicaAntiAffinityVal }}
+            {{- end }}
           annotations:
             openebs.io/capacity: {{ .Volume.capacity }}
             openebs.io/storage-pool: {{ .Config.StoragePool.value }}
@@ -2149,8 +2186,18 @@ spec:
               - labelSelector:
                   matchLabels:
                     openebs.io/replica: jiva-replica
+                    {{/* If PVC object has a replica anti-affinity value. Use it.
+                         This is usually the case for STS that creates PVCs from a 
+                         PVC Template. So, a STS can have multiple PVs with their
+                         unique id. To schedule/spread out replicas belonging to 
+                         different PV, a unique label assoicated with the STS should 
+                         be passed to all the PVCs tied to the STS. */}}
+                    {{- if ne $replicaAntiAffinityVal "none" }}
+                    openebs.io/replica-anti-affinity: {{ $replicaAntiAffinityVal }}
+                    {{- else }}
                     openebs.io/persistent-volume: {{ .Volume.owner }}
-                topologyKey: kubernetes.io/hostname
+                    {{- end }}
+                topologyKey: {{ .Config.ReplicaAntiAffinityTopoKey.value }}
           containers:
           - args:
             - replica

--- a/k8s/openebs-pre-release-features.yaml
+++ b/k8s/openebs-pre-release-features.yaml
@@ -2276,7 +2276,7 @@ spec:
                          This is usually the case for STS that creates PVCs from a 
                          PVC Template. So, a STS can have multiple PVs with their
                          unique id. To schedule/spread out replicas belonging to 
-                         different PV, a unique label assoicated with the STS should 
+                         different PV, a unique label associated with the STS should 
                          be passed to all the PVCs tied to the STS. */}}
                     {{- if ne $replicaAntiAffinityVal "none" }}
                     openebs.io/replica-anti-affinity: {{ $replicaAntiAffinityVal }}

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-1r-raa.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-1r-raa.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jiva-1r-raa
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:0.6.0
+      - name: ReplicaImage
+        value: openebs/jiva:0.6.0
+      - name: VolumeMonitorImage
+        value: openebs/m-exporter:ci
+      - name: ReplicaCount
+        value: "1"
+      - name: StoragePool
+        value: default
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "1"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol1-1r-raa-claim
+  labels:
+    openebs.io/replica-anti-affinity: application-name
+spec:
+  storageClassName: jiva-1r-raa
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol2-1r-raa-claim
+  labels:
+    openebs.io/replica-anti-affinity: application-name
+spec:
+  storageClassName: jiva-1r-raa
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-1r.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-1r.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jiva-1r
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ControllerImage
+        value: openebs/jiva:0.6.0
+      - name: ReplicaImage
+        value: openebs/jiva:0.6.0
+      - name: VolumeMonitorImage
+        value: openebs/m-exporter:ci
+      - name: ReplicaCount
+        value: "1"
+      - name: StoragePool
+        value: default
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "1"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol1-1r-claim
+spec:
+  storageClassName: jiva-1r
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-raa-az.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-raa-az.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jiva-raa-az
+  annotations:
+    cas.openebs.io/create-volume-template: jiva-volume-create-default-0.7.0
+    cas.openebs.io/delete-volume-template: jiva-volume-delete-default-0.7.0
+    cas.openebs.io/read-volume-template: jiva-volume-read-default-0.7.0
+    cas.openebs.io/config: |
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+      - name: ReplicaAntiAffinityTopoKey
+        value: failure-domain.beta.kubernetes.io/zone
+provisioner: openebs.io/provisioner-iscsi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol1-raa-az-claim
+spec:
+  storageClassName: jiva-raa-az
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol2-raa-az-claim
+spec:
+  storageClassName: jiva-raa-az
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G

--- a/k8s/sample-pv-yamls/pvc-jiva-sc-raa.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-sc-raa.yaml
@@ -1,0 +1,29 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol1-raa-claim
+  labels:
+    openebs.io/replica-anti-affinity: application-name
+spec:
+  storageClassName: openebs-standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-vol2-raa-claim
+  labels:
+    openebs.io/replica-anti-affinity: application-name
+spec:
+  storageClassName: openebs-standard
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+---


### PR DESCRIPTION
The jiva replica's are scheduled using anti-affinity
of node using the jiva volume id. However, there are cases
like:
- Replicas should be spread across zones
- Replias of different PVs associated with a STS should
  be spread across nodes/zones.

To support the above, the following options are supported:
- The topologyKey used for Replica scheduling can be provided
  the user via StorageClass.
- A custom anti-affinity label can be used inplace of jiva
  volume id. This custom label can be passed via PVCs by
  users.

This PR also includes some sample PVC YAMLs making use
of the different combinations of above features.

Signed-off-by: kmova <kiran.mova@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
