### PR TITLE
Env variable for default cstor sparsepool creation

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -131,6 +131,11 @@ spec:
         # to maya install
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME
           value: "maya-install-config-default-0.7.0"
+        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_POOL decides wheteher default cstor pool should be
+        # configured as a part op openebs installation.
+        # If "true" a default cstor pool will be configured, if "false" it will not be configured.
+        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+          value: "true"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -131,9 +131,9 @@ spec:
         # to maya install
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME
           value: "maya-install-config-default-0.7.0"
-        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_POOL decides wheteher default cstor pool should be
-        # configured as a part op openebs installation.
-        # If "true" a default cstor pool will be configured, if "false" it will not be configured.
+        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+        # configured as a part of openebs installation.
+        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "true"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an


### PR DESCRIPTION
Add a env variable for creation of cstor sparse pool when openebs is installed.
The env variable is : 
OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
If value of the env variable is true, installation of openebs will create a cstor sparse pool by default else it will not create.

Following PR should be merged to enable this feature.
https://github.com/openebs/maya/pull/483
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
