### PR TITLE
Added tasks specific to cstor deployment in libiscsi playbook

### DIFF
--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml
@@ -1,19 +1,37 @@
 ---
+- name: Obtaining PV name
+  shell: kubectl get pvc -n {{ namespace }} --no-headers -o custom-columns=:metadata.name
+  args:
+    executable: /bin/bash
+  register: pv
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
 - include_tasks: "{{utils_path}}/delete_deploy.yml"
   vars:
     ns: "{{ namespace }}"
     app_yml: "{{ volume_def }}"
-
-- name: Confirm the iSCSI target has been deleted
-  shell: source ~/.profile; kubectl get pvc -n {{ namespace }}
+   
+- name: Confirm whether the pods are deleted.
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }}
   args:
     executable: /bin/bash
   delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
   register: result
-  until: "'pvc' not in result.stdout"
-  delay: 120
-  retries: 6
-  changed_when: true
+  until: "pv.stdout not in result.stdout"
+  delay: 30
+  retries: 10
+  when:  storage_engine  == 'jiva'
+
+- name: Confirm if the target pod is deleted
+  shell: source ~/.profile; kubectl get pods -n {{ operator_ns }} | grep {{ namespace }}
+  args:
+    executable: /bin/bash
+  delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+  register: result
+  until: "pv.stdout not in result.stdout"
+  delay: 30
+  retries: 10
+  when: storage_engine == 'cStor'
 
 - name: Remove test artifacts
   file:

--- a/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
+++ b/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml
@@ -38,46 +38,99 @@
            status: create
            ns: "{{ namespace }}"
 
-       - name: 3a) Create a storage volume via a pvc
-         shell: source ~/.profile; kubectl apply -f "{{ volume_def }}" -n {{ namespace }}
-         args:
-           executable: /bin/bash
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+       - block:
 
-       - name: 3b) Confirm volume container is running
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{item}} | grep Running | wc -l
-         args:
-           executable: /bin/bash
-         register: result
-         until: result.stdout|int >= 1
-         delay: 30
-         retries: 10
-         with_items:
-           - ctrl
-           - rep
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+           - name:  Replace storage-class to use jiva storage engine
+             replace:
+               path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+               regexp: 'openebs-standard'
+               replace: '{{ jiva_sc }}'
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 4) Get storage ctrl pod name
-         shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep ctrl
-         args:
-           executable: /bin/bash
-         register: ctrl_name
-         delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+           - name: 3a) Create a storage volume via a pvc
+             shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ volume_def }}" -n {{ namespace }}
+             args:
+               executable: /bin/bash
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 4a) Set ctrl pod name to variable
-         set_fact:
-           ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
+           - name: 3b) Confirm volume container is running
+             shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep {{item}} | grep Running | wc -l
+             args:
+               executable: /bin/bash
+             register: result
+             until: result.stdout|int >= 1
+             delay: 30
+             retries: 10
+             with_items:
+               - ctrl
+               - rep
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 4b) Get IP address of ctrl pod
-         shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} -n {{ namespace }} | grep IP
-         args:
-           executable: /bin/bash
-         register: ctrl_IP
-         delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+           - name: 4) Get storage ctrl pod name
+             shell: source ~/.profile; kubectl get pods -n {{ namespace }} | grep ctrl
+             args:
+               executable: /bin/bash
+             register: ctrl_name
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
 
-       - name: 4c) Set IP of Pod to variable
-         set_fact:
-           ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
+           - name: 4a) Set ctrl pod name to variable
+             set_fact:
+               ctrl_pod_name: "{{ ctrl_name.stdout.split()[0] }}"
+
+           - name: 4b) Get IP address of ctrl pod
+             shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} -n {{ namespace }} | grep IP
+             args:
+               executable: /bin/bash
+             register: ctrl_IP
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: 4c) Set IP of Pod to variable
+             set_fact:
+               ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
+           
+         when: storage_engine == 'jiva'
+
+       - block:
+
+           - name: Replace the storage class in the volume definition yaml
+             replace:
+               path: "{{ result_kube_home.stdout }}/{{ volume_def }}"
+               regexp: 'openebs-standard'
+               replace: '{{ cstor_sc }}'
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+           - name: 3a) Create a storage volume via a pvc
+             shell: source ~/.profile; kubectl apply -f "{{ result_kube_home.stdout }}/{{ volume_def }}" -n {{ namespace }}
+             args:
+               executable: /bin/bash
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+           - name: Check if the cstor target has been created and running.
+             shell: source ~/.profile; kubectl get pods -n {{ operator_ns }} -l openebs.io/target=cstor-target | grep {{ namespace }}
+             args:
+               executable: /bin/bash
+             register: pods_list
+             until: "'Running' in pods_list.stdout"
+             delay: 30
+             retries: 15
+             delegate_to: "{{ groups['kubernetes-kubemasters'].0 }}"
+
+           - name: Get the target pod name
+             set_fact:
+                ctrl_pod_name: "{{ pods_list.stdout.split()[0] }}"
+
+           - name: 4b) Get IP address of ctrl pod
+             shell: source ~/.profile; kubectl describe pod {{ ctrl_pod_name }} -n {{ operator_ns }} | grep IP
+             args:
+               executable: /bin/bash
+             register: ctrl_IP
+             delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+
+           - name: 4c) Set IP of Pod to variable
+             set_fact:
+               ctrl_ip: "{{ ctrl_IP.stdout_lines[0].split()[1]}}"
+
+         when: storage_engine == 'cStor'
 
        - name: 5) Copy libiscsi test list into kube minion
          copy:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

**What this PR does / why we need it**:
- If the storage engine is jiva, use jiva specific storage class to deploy volume and use the same for libiscsi test cases.
- If the storage engine is cstor, use jiva specific storage class to deploy volume and use the same for libiscsi test cases.
- Added cleanup tasks.

```
PLAYBOOK: libiscsi.yml *************************************************************************************************************************************************************************************
1 plays in playbooks/compliance/iscsi/libiscsi.yml
PLAY [localhost] *******************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:18
ok: [localhost]
META: ran handlers
TASK [Update apt cache] ************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml:2
 [WARNING]: Consider using the apt module rather than running apt-get.  If you need to use command because apt is insufficient you can add warn=False to this command task or set command_warnings=False in
ansible.cfg to get rid of this message.

changed: [localhost -> None] => {"changed": true, "cmd": ["apt-get", "update"], "delta": "0:00:01.857202", "end": "2018-08-27 15:12:21.426639", "rc": 0, "start": "2018-08-27 15:12:19.569437", "stderr": "", "stderr_lines": [], "stdout": "Hit:1 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial InRelease\nHit:2 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial-updates InRelease\nHit:3 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial-backports InRelease\nHit:4 http://ppa.launchpad.net/cloud-images/gke-19/ubuntu xenial InRelease\nHit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease\nReading package lists...", "stdout_lines": ["Hit:1 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial InRelease", "Hit:2 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial-updates InRelease", "Hit:3 http://us-central1.gce.archive.ubuntu.com/ubuntu xenial-backports InRelease", "Hit:4 http://ppa.launchpad.net/cloud-images/gke-19/ubuntu xenial InRelease", "Hit:5 http://security.ubuntu.com/ubuntu xenial-security InRelease", "Reading package lists..."]}

TASK [Install libiscsi on K8S-minion] **********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml:10
changed: [localhost -> None] => (item=libiscsi-bin) => {"changed": true, "cmd": "apt-get install -y libiscsi-bin", "delta": "0:00:00.368145", "end": "2018-08-27 15:12:25.835918", "item": "libiscsi-bin", "rc": 0, "start": "2018-08-27 15:12:25.467773", "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nlibiscsi-bin is already the newest version (1.12.0-2).\n0 upgraded, 0 newly installed, 0 to remove and 10 not upgraded.", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "libiscsi-bin is already the newest version (1.12.0-2).", "0 upgraded, 0 newly installed, 0 to remove and 10 not upgraded."], "warnings": ["Consider using the apt module rather than running apt-get.  If you need to use command because apt is insufficient you can add warn=False to this command task or set command_warnings=False in ansible.cfg to get rid of this message."]}

TASK [Get $HOME of K8s master for kubernetes user] *********************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml:18
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; echo $HOME", "delta": "0:00:00.004210", "end": "2018-08-27 20:42:26.561202", "rc": 0, "start": "2018-08-27 20:42:26.556992", "stderr": "", "stderr_lines": [], "stdout": "/home/giridhara_prasad", "stdout_lines": ["/home/giridhara_prasad"]}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-prerequisites.yml:26
included: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; nohup stern --all-namespaces \"maya*|openebs*|pvc*\" --kubeconfig /home/giridhara_prasad/.kube/config --since 1m > /home/giridhara_prasad/setup/logs/libiscsi_test_suite.log &", "delta": "0:00:00.005066", "end": "2018-08-27 20:42:26.875297", "rc": 0, "start": "2018-08-27 20:42:26.870231", "stderr": "/bin/bash: /root/.profile: No such file or directory\nnohup: failed to run command 'stern': No such file or directory", "stderr_lines": ["/bin/bash: /root/.profile: No such file or directory", "nohup: failed to run command 'stern': No such file or directory"], "stdout": "", "stdout_lines": []}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [2) Copy the volume claim to kube master] *************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:29
changed: [localhost -> None] => {"changed": true, "checksum": "ffac0ad06ec57f90a3c7da9d5e626256c9351e0f", "dest": "/home/giridhara_prasad/test-pvc.yaml", "gid": 1000, "group": "giridhara_prasad", "md5sum": "1eb3867c9728c5567b751dd03533b459", "mode": "0644", "owner": "giridhara_prasad", "size": 188, "src": "/home/giridhara_prasad/.ansible/tmp/ansible-tmp-1535382747.06-169535534916651/source", "state": "file", "uid": 1000}

TASK [3) Create namespace.] ********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:35
included: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml for localhost

TASK [Create test specific namespace.] *********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:4
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl create ns libiscsi-test", "delta": "0:00:00.941320", "end": "2018-08-27 20:42:29.116573", "rc": 0, "start": "2018-08-27 20:42:28.175253", "stderr": "", "stderr_lines": [], "stdout": "namespace \"libiscsi-test\" created", "stdout_lines": ["namespace \"libiscsi-test\" created"]}

TASK [Checking the status  of test specific namespace.] ****************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:10
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get ns | grep libiscsi-test | awk {'print $2'}", "delta": "0:00:01.405902", "end": "2018-08-27 20:42:30.770614", "rc": 0, "start": "2018-08-27 20:42:29.364712", "stderr": "", "stderr_lines": [], "stdout": "Active", "stdout_lines": ["Active"]}

TASK [Deletion of test specific  namespace.] ***************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:24
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the namespace status.] *************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:30
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Replace storage-class to use jiva storage engine] ****************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:43
changed: [localhost -> None] => {"changed": true, "msg": "1 replacements made"}

TASK [3a) Create a storage volume via a pvc] ***************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:50
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl apply -f \"/home/giridhara_prasad/test-pvc.yaml\" -n libiscsi-test", "delta": "0:00:01.824484", "end": "2018-08-27 20:42:33.319718", "rc": 0, "start": "2018-08-27 20:42:31.495234", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"vut\" created", "stdout_lines": ["persistentvolumeclaim \"vut\" created"]}

TASK [3b) Confirm volume container is running] *************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:56
FAILED - RETRYING: 3b) Confirm volume container is running (10 retries left).
changed: [localhost -> None] => (item=ctrl) => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n libiscsi-test | grep ctrl | grep Running | wc -l", "delta": "0:00:01.638127", "end": "2018-08-27 20:43:07.044962", "item": "ctrl", "rc": 0, "start": "2018-08-27 20:43:05.406835", "stderr": "", "stderr_lines": [], "stdout": "1", "stdout_lines": ["1"]}
changed: [localhost -> None] => (item=rep) => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n libiscsi-test | grep rep | grep Running | wc -l", "delta": "0:00:01.647859", "end": "2018-08-27 20:43:08.911886", "item": "rep", "rc": 0, "start": "2018-08-27 20:43:07.264027", "stderr": "", "stderr_lines": [], "stdout": "3", "stdout_lines": ["3"]}

TASK [4) Get storage ctrl pod name] ************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:69
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl get pods -n libiscsi-test | grep ctrl", "delta": "0:00:01.622293", "end": "2018-08-27 20:43:10.806138", "rc": 0, "start": "2018-08-27 20:43:09.183845", "stderr": "", "stderr_lines": [], "stdout": "libiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq   2/2       Running   0          37s", "stdout_lines": ["libiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq   2/2       Running   0          37s"]}

TASK [4a) Set ctrl pod name to variable] *******************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:76
ok: [localhost] => {"ansible_facts": {"ctrl_pod_name": "libiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq"}, "changed": false}

TASK [4b) Get IP address of ctrl pod] **********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:80
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl describe pod libiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq -n libiscsi-test | grep IP", "delta": "0:00:01.393437", "end": "2018-08-27 20:43:12.653288", "rc": 0, "start": "2018-08-27 20:43:11.259851", "stderr": "", "stderr_lines": [], "stdout": "IP:             10.16.19.35\n      --clusterIP", "stdout_lines": ["IP:             10.16.19.35", "      --clusterIP"]}

TASK [4c) Set IP of Pod to variable] ***********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:87
ok: [localhost] => {"ansible_facts": {"ctrl_ip": "10.16.19.35"}, "changed": false}

TASK [Replace the storage class in the volume definition yaml] *********************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:95
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [3a) Create a storage volume via a pvc] ***************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:102
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if the cstor target has been created and running.] *********************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:108
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the target pod name] *****************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:118
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [4b) Get IP address of ctrl pod] **********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:122
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [4c) Set IP of Pod to variable] ***********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:129
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [5) Copy libiscsi test list into kube minion] *********************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:135
ok: [localhost -> None] => {"changed": false, "checksum": "fd822f8125341c48d72a40c9a34803f70cda9c14", "dest": "/tmp/run-tests.out", "gid": 1023, "group": "giridhara_prasad", "mode": "0664", "owner": "giridhara_prasad", "path": "/tmp/run-tests.out", "size": 1035, "state": "file", "uid": 1022}

TASK [6) Discover the iSCSI target using iscsi-ls] *********************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:141
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "iscsi-ls iscsi://10.16.19.35", "delta": "0:00:00.006351", "end": "2018-08-27 15:13:26.252559", "rc": 0, "start": "2018-08-27 15:13:26.246208", "stderr": "", "stderr_lines": [], "stdout": "Target:iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363 Portal:10.19.251.239,1", "stdout_lines": ["Target:iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363 Portal:10.19.251.239,1"]}

TASK [6a) Set target iqn to variable] **********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:151
ok: [localhost] => {"ansible_facts": {"iqn": "iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363"}, "changed": false}

TASK [6b) Create log directory for libiscsi test run] ******************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:155
ok: [localhost -> None] => {"changed": false, "gid": 1023, "group": "giridhara_prasad", "mode": "0775", "owner": "giridhara_prasad", "path": "/tmp/libiscsi_suite_logs", "size": 4096, "state": "directory", "uid": 1022}

TASK [6c) Get test list from test file] ********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:161
changed: [localhost -> None] => {"changed": true, "cmd": ["cat", "/tmp/run-tests.out"], "delta": "0:00:01.004333", "end": "2018-08-27 15:13:35.482509", "rc": 0, "start": "2018-08-27 15:13:34.478176", "stderr": "", "stderr_lines": [], "stdout": "ALL.CompareAndWrite\nALL.Inquiry \nALL.Mandatory \nALL.ModeSense6\nALL.NoMedia\nALL.OrWrite\nALL.Prefetch10\nALL.Prefetch16\nALL.PreventAllow\nALL.PrinReadKeys\nALL.PrinServiceactionRange\nALL.ProutRegister\nALL.ProutReserve\nALL.Read6\nALL.Read10\nALL.Read12\nALL.Read16\nALL.ReadCapacity10\nALL.ReadCapacity16\nALL.ReadOnly\nALL.ReadOnly.ReadOnlySBC\nALL.Reserve6\nALL.Sanitize\nALL.StartStopUnit\nALL.TestUnitReady\nALL.Unmap\nALL.Verify10\nALL.Verify12\nALL.Verify16\nALL.Write10\nALL.Write12\nALL.Write16\nALL.WriteVerify10\nALL.iSCSIcmdsn\nALL.iSCSIResiduals\nSCSI.CompareAndWrite\nSCSI.Inquiry\nSCSI.Mandatory\nSCSI.ModeSense6\nSCSI.NoMedia\nSCSI.OrWrite\nSCSI.Prefetch10\nSCSI.Prefetch16\nSCSI.PreventAllow\nSCSI.PrinReadKeys\nSCSI.PrinServiceactionRange\nSCSI.ProutRegister\nSCSI.Read6\nSCSI.ReadCapacity10\nSCSI.ReadCapacity16\nSCSI.ReadOnly\nSCSI.Reserve6\nSCSI.Sanitize\nSCSI.StartStopUnit\nSCSI.TestUnitReady\nSCSI.Unmap\nSCSI.Verify10\nSCSI.Verify12\nSCSI.Verify16\nSCSI.WriteVerify10\nSCSI.WriteVerify12\nSCSI.WriteVerify16\niSCSI.iSCSIcmdsn\niSCSI.iSCSIdatasn\niSCSI.iSCSIResiduals", "stdout_lines": ["ALL.CompareAndWrite", "ALL.Inquiry ", "ALL.Mandatory ", "ALL.ModeSense6", "ALL.NoMedia", "ALL.OrWrite", "ALL.Prefetch10", "ALL.Prefetch16", "ALL.PreventAllow", "ALL.PrinReadKeys", "ALL.PrinServiceactionRange", "ALL.ProutRegister", "ALL.ProutReserve", "ALL.Read6", "ALL.Read10", "ALL.Read12", "ALL.Read16", "ALL.ReadCapacity10", "ALL.ReadCapacity16", "ALL.ReadOnly", "ALL.ReadOnly.ReadOnlySBC", "ALL.Reserve6", "ALL.Sanitize", "ALL.StartStopUnit", "ALL.TestUnitReady", "ALL.Unmap", "ALL.Verify10", "ALL.Verify12", "ALL.Verify16", "ALL.Write10", "ALL.Write12", "ALL.Write16", "ALL.WriteVerify10", "ALL.iSCSIcmdsn", "ALL.iSCSIResiduals", "SCSI.CompareAndWrite", "SCSI.Inquiry", "SCSI.Mandatory", "SCSI.ModeSense6", "SCSI.NoMedia", "SCSI.OrWrite", "SCSI.Prefetch10", "SCSI.Prefetch16", "SCSI.PreventAllow", "SCSI.PrinReadKeys", "SCSI.PrinServiceactionRange", "SCSI.ProutRegister", "SCSI.Read6", "SCSI.ReadCapacity10", "SCSI.ReadCapacity16", "SCSI.ReadOnly", "SCSI.Reserve6", "SCSI.Sanitize", "SCSI.StartStopUnit", "SCSI.TestUnitReady", "SCSI.Unmap", "SCSI.Verify10", "SCSI.Verify12", "SCSI.Verify16", "SCSI.WriteVerify10", "SCSI.WriteVerify12", "SCSI.WriteVerify16", "iSCSI.iSCSIcmdsn", "iSCSI.iSCSIdatasn", "iSCSI.iSCSIResiduals"]}

TASK [7) Run the libiscsi test suites] *********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:166
changed: [localhost -> None] => (item=ALL.CompareAndWrite) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.CompareAndWrite iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.CompareAndWrite.log 2>&1", "delta": "0:00:00.019478", "end": "2018-08-27 15:13:39.756150", "item": "ALL.CompareAndWrite", "rc": 0, "start": "2018-08-27 15:13:39.736672", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
failed: [localhost -> None] (item=ALL.Inquiry ) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Inquiry  iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Inquiry .log 2>&1", "delta": "0:00:00.005299", "end": "2018-08-27 15:13:43.680560", "item": "ALL.Inquiry ", "msg": "non-zero return code", "rc": 1, "start": "2018-08-27 15:13:43.675261", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
failed: [localhost -> None] (item=ALL.Mandatory ) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Mandatory  iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Mandatory .log 2>&1", "delta": "0:00:00.006417", "end": "2018-08-27 15:13:47.603329", "item": "ALL.Mandatory ", "msg": "non-zero return code", "rc": 1, "start": "2018-08-27 15:13:47.596912", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ModeSense6) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ModeSense6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ModeSense6.log 2>&1", "delta": "0:00:00.013882", "end": "2018-08-27 15:13:51.622081", "item": "ALL.ModeSense6", "rc": 0, "start": "2018-08-27 15:13:51.608199", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.NoMedia) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.NoMedia iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.NoMedia.log 2>&1", "delta": "0:00:00.014375", "end": "2018-08-27 15:13:55.677437", "item": "ALL.NoMedia", "rc": 0, "start": "2018-08-27 15:13:55.663062", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.OrWrite) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.OrWrite iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.OrWrite.log 2>&1", "delta": "0:00:00.053697", "end": "2018-08-27 15:13:59.732499", "item": "ALL.OrWrite", "rc": 0, "start": "2018-08-27 15:13:59.678802", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Prefetch10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Prefetch10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Prefetch10.log 2>&1", "delta": "0:00:00.485608", "end": "2018-08-27 15:14:04.147661", "item": "ALL.Prefetch10", "rc": 0, "start": "2018-08-27 15:14:03.662053", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Prefetch16) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Prefetch16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Prefetch16.log 2>&1", "delta": "0:00:00.431600", "end": "2018-08-27 15:14:08.505782", "item": "ALL.Prefetch16", "rc": 0, "start": "2018-08-27 15:14:08.074182", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.PreventAllow) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.PreventAllow iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.PreventAllow.log 2>&1", "delta": "0:00:00.020983", "end": "2018-08-27 15:14:12.570627", "item": "ALL.PreventAllow", "rc": 0, "start": "2018-08-27 15:14:12.549644", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.PrinReadKeys) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.PrinReadKeys iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.PrinReadKeys.log 2>&1", "delta": "0:00:00.012152", "end": "2018-08-27 15:14:16.623106", "item": "ALL.PrinReadKeys", "rc": 0, "start": "2018-08-27 15:14:16.610954", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.PrinServiceactionRange) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.PrinServiceactionRange iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.PrinServiceactionRange.log 2>&1", "delta": "0:00:00.013035", "end": "2018-08-27 15:14:20.629440", "item": "ALL.PrinServiceactionRange", "rc": 0, "start": "2018-08-27 15:14:20.616405", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ProutRegister) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ProutRegister iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ProutRegister.log 2>&1", "delta": "0:00:00.013611", "end": "2018-08-27 15:14:24.583591", "item": "ALL.ProutRegister", "rc": 0, "start": "2018-08-27 15:14:24.569980", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ProutReserve) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ProutReserve iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ProutReserve.log 2>&1", "delta": "0:00:00.026319", "end": "2018-08-27 15:14:28.533613", "item": "ALL.ProutReserve", "rc": 0, "start": "2018-08-27 15:14:28.507294", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Read6) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Read6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Read6.log 2>&1", "delta": "0:00:00.626837", "end": "2018-08-27 15:14:33.198043", "item": "ALL.Read6", "rc": 0, "start": "2018-08-27 15:14:32.571206", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Read10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Read10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Read10.log 2>&1", "delta": "0:00:01.495729", "end": "2018-08-27 15:14:38.747851", "item": "ALL.Read10", "rc": 0, "start": "2018-08-27 15:14:37.252122", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Read12) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Read12 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Read12.log 2>&1", "delta": "0:00:01.566327", "end": "2018-08-27 15:14:44.363400", "item": "ALL.Read12", "rc": 0, "start": "2018-08-27 15:14:42.797073", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Read16) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Read16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Read16.log 2>&1", "delta": "0:00:01.495995", "end": "2018-08-27 15:14:49.896800", "item": "ALL.Read16", "rc": 0, "start": "2018-08-27 15:14:48.400805", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ReadCapacity10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ReadCapacity10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ReadCapacity10.log 2>&1", "delta": "0:00:00.012179", "end": "2018-08-27 15:14:53.845702", "item": "ALL.ReadCapacity10", "rc": 0, "start": "2018-08-27 15:14:53.833523", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ReadCapacity16) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ReadCapacity16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ReadCapacity16.log 2>&1", "delta": "0:00:00.020120", "end": "2018-08-27 15:14:57.789854", "item": "ALL.ReadCapacity16", "rc": 0, "start": "2018-08-27 15:14:57.769734", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ReadOnly) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ReadOnly iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ReadOnly.log 2>&1", "delta": "0:00:00.012119", "end": "2018-08-27 15:15:01.835395", "item": "ALL.ReadOnly", "rc": 0, "start": "2018-08-27 15:15:01.823276", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.ReadOnly.ReadOnlySBC) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.ReadOnly.ReadOnlySBC iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.ReadOnly.ReadOnlySBC.log 2>&1", "delta": "0:00:00.011303", "end": "2018-08-27 15:15:05.907258", "item": "ALL.ReadOnly.ReadOnlySBC", "rc": 0, "start": "2018-08-27 15:15:05.895955", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Reserve6) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Reserve6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Reserve6.log 2>&1", "delta": "0:00:12.044838", "end": "2018-08-27 15:15:22.020799", "item": "ALL.Reserve6", "rc": 0, "start": "2018-08-27 15:15:09.975961", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Sanitize) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Sanitize iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Sanitize.log 2>&1", "delta": "0:00:00.016747", "end": "2018-08-27 15:15:26.071480", "item": "ALL.Sanitize", "rc": 0, "start": "2018-08-27 15:15:26.054733", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.StartStopUnit) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.StartStopUnit iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.StartStopUnit.log 2>&1", "delta": "0:00:00.013603", "end": "2018-08-27 15:15:30.071911", "item": "ALL.StartStopUnit", "rc": 0, "start": "2018-08-27 15:15:30.058308", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.TestUnitReady) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.TestUnitReady iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.TestUnitReady.log 2>&1", "delta": "0:00:00.012072", "end": "2018-08-27 15:15:34.009227", "item": "ALL.TestUnitReady", "rc": 0, "start": "2018-08-27 15:15:33.997155", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Unmap) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Unmap iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Unmap.log 2>&1", "delta": "0:00:00.013844", "end": "2018-08-27 15:15:37.943370", "item": "ALL.Unmap", "rc": 0, "start": "2018-08-27 15:15:37.929526", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Verify10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Verify10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Verify10.log 2>&1", "delta": "0:00:06.662127", "end": "2018-08-27 15:15:48.533147", "item": "ALL.Verify10", "rc": 0, "start": "2018-08-27 15:15:41.871020", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Verify12) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Verify12 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Verify12.log 2>&1", "delta": "0:00:06.211249", "end": "2018-08-27 15:15:58.658567", "item": "ALL.Verify12", "rc": 0, "start": "2018-08-27 15:15:52.447318", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Verify16) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Verify16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Verify16.log 2>&1", "delta": "0:00:05.596308", "end": "2018-08-27 15:16:08.182981", "item": "ALL.Verify16", "rc": 0, "start": "2018-08-27 15:16:02.586673", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Write10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Write10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Write10.log 2>&1", "delta": "0:00:03.808087", "end": "2018-08-27 15:16:16.016869", "item": "ALL.Write10", "rc": 0, "start": "2018-08-27 15:16:12.208782", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Write12) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Write12 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Write12.log 2>&1", "delta": "0:00:03.823508", "end": "2018-08-27 15:16:23.869732", "item": "ALL.Write12", "rc": 0, "start": "2018-08-27 15:16:20.046224", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.Write16) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.Write16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.Write16.log 2>&1", "delta": "0:00:03.707642", "end": "2018-08-27 15:16:31.606657", "item": "ALL.Write16", "rc": 0, "start": "2018-08-27 15:16:27.899015", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.WriteVerify10) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.WriteVerify10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.WriteVerify10.log 2>&1", "delta": "0:00:05.080370", "end": "2018-08-27 15:16:40.600186", "item": "ALL.WriteVerify10", "rc": 0, "start": "2018-08-27 15:16:35.519816", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.iSCSIcmdsn) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.iSCSIcmdsn iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.iSCSIcmdsn.log 2>&1", "delta": "0:00:00.018391", "end": "2018-08-27 15:16:44.539058", "item": "ALL.iSCSIcmdsn", "rc": 0, "start": "2018-08-27 15:16:44.520667", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=ALL.iSCSIResiduals) => {"changed": true, "cmd": "iscsi-test-cu --test=ALL.iSCSIResiduals iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/ALL.iSCSIResiduals.log 2>&1", "delta": "0:00:00.291958", "end": "2018-08-27 15:16:48.742730", "item": "ALL.iSCSIResiduals", "rc": 0, "start": "2018-08-27 15:16:48.450772", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.CompareAndWrite) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.CompareAndWrite iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.CompareAndWrite.log 2>&1", "delta": "0:00:00.020048", "end": "2018-08-27 15:16:52.813561", "item": "SCSI.CompareAndWrite", "rc": 0, "start": "2018-08-27 15:16:52.793513", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Inquiry) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Inquiry iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Inquiry.log 2>&1", "delta": "0:00:00.075672", "end": "2018-08-27 15:16:56.926403", "item": "SCSI.Inquiry", "rc": 0, "start": "2018-08-27 15:16:56.850731", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Mandatory) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Mandatory iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Mandatory.log 2>&1", "delta": "0:00:00.014225", "end": "2018-08-27 15:17:00.988649", "item": "SCSI.Mandatory", "rc": 0, "start": "2018-08-27 15:17:00.974424", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.ModeSense6) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.ModeSense6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.ModeSense6.log 2>&1", "delta": "0:00:00.012492", "end": "2018-08-27 15:17:05.049866", "item": "SCSI.ModeSense6", "rc": 0, "start": "2018-08-27 15:17:05.037374", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.NoMedia) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.NoMedia iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.NoMedia.log 2>&1", "delta": "0:00:00.013514", "end": "2018-08-27 15:17:09.104812", "item": "SCSI.NoMedia", "rc": 0, "start": "2018-08-27 15:17:09.091298", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.OrWrite) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.OrWrite iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.OrWrite.log 2>&1", "delta": "0:00:00.056891", "end": "2018-08-27 15:17:13.206735", "item": "SCSI.OrWrite", "rc": 0, "start": "2018-08-27 15:17:13.149844", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Prefetch10) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Prefetch10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Prefetch10.log 2>&1", "delta": "0:00:00.510099", "end": "2018-08-27 15:17:17.747740", "item": "SCSI.Prefetch10", "rc": 0, "start": "2018-08-27 15:17:17.237641", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Prefetch16) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Prefetch16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Prefetch16.log 2>&1", "delta": "0:00:00.514140", "end": "2018-08-27 15:17:22.298403", "item": "SCSI.Prefetch16", "rc": 0, "start": "2018-08-27 15:17:21.784263", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.PreventAllow) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.PreventAllow iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.PreventAllow.log 2>&1", "delta": "0:00:00.012646", "end": "2018-08-27 15:17:26.363979", "item": "SCSI.PreventAllow", "rc": 0, "start": "2018-08-27 15:17:26.351333", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.PrinReadKeys) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.PrinReadKeys iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.PrinReadKeys.log 2>&1", "delta": "0:00:00.012416", "end": "2018-08-27 15:17:30.353704", "item": "SCSI.PrinReadKeys", "rc": 0, "start": "2018-08-27 15:17:30.341288", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.PrinServiceactionRange) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.PrinServiceactionRange iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.PrinServiceactionRange.log 2>&1", "delta": "0:00:00.012511", "end": "2018-08-27 15:17:34.284552", "item": "SCSI.PrinServiceactionRange", "rc": 0, "start": "2018-08-27 15:17:34.272041", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.ProutRegister) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.ProutRegister iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.ProutRegister.log 2>&1", "delta": "0:00:00.011606", "end": "2018-08-27 15:17:38.219982", "item": "SCSI.ProutRegister", "rc": 0, "start": "2018-08-27 15:17:38.208376", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Read6) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Read6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Read6.log 2>&1", "delta": "0:00:01.317565", "end": "2018-08-27 15:17:43.471045", "item": "SCSI.Read6", "rc": 0, "start": "2018-08-27 15:17:42.153480", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.ReadCapacity10) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.ReadCapacity10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.ReadCapacity10.log 2>&1", "delta": "0:00:00.013684", "end": "2018-08-27 15:17:47.410093", "item": "SCSI.ReadCapacity10", "rc": 0, "start": "2018-08-27 15:17:47.396409", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.ReadCapacity16) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.ReadCapacity16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.ReadCapacity16.log 2>&1", "delta": "0:00:00.015068", "end": "2018-08-27 15:17:51.340920", "item": "SCSI.ReadCapacity16", "rc": 0, "start": "2018-08-27 15:17:51.325852", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.ReadOnly) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.ReadOnly iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.ReadOnly.log 2>&1", "delta": "0:00:00.012595", "end": "2018-08-27 15:17:55.283016", "item": "SCSI.ReadOnly", "rc": 0, "start": "2018-08-27 15:17:55.270421", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Reserve6) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Reserve6 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Reserve6.log 2>&1", "delta": "0:00:12.042666", "end": "2018-08-27 15:18:11.261290", "item": "SCSI.Reserve6", "rc": 0, "start": "2018-08-27 15:17:59.218624", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Sanitize) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Sanitize iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Sanitize.log 2>&1", "delta": "0:00:00.019171", "end": "2018-08-27 15:18:15.317639", "item": "SCSI.Sanitize", "rc": 0, "start": "2018-08-27 15:18:15.298468", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.StartStopUnit) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.StartStopUnit iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.StartStopUnit.log 2>&1", "delta": "0:00:00.015582", "end": "2018-08-27 15:18:19.339201", "item": "SCSI.StartStopUnit", "rc": 0, "start": "2018-08-27 15:18:19.323619", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.TestUnitReady) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.TestUnitReady iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.TestUnitReady.log 2>&1", "delta": "0:00:00.012390", "end": "2018-08-27 15:18:23.266735", "item": "SCSI.TestUnitReady", "rc": 0, "start": "2018-08-27 15:18:23.254345", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Unmap) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Unmap iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Unmap.log 2>&1", "delta": "0:00:00.012144", "end": "2018-08-27 15:18:27.205253", "item": "SCSI.Unmap", "rc": 0, "start": "2018-08-27 15:18:27.193109", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Verify10) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Verify10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Verify10.log 2>&1", "delta": "0:00:09.793041", "end": "2018-08-27 15:18:40.910581", "item": "SCSI.Verify10", "rc": 0, "start": "2018-08-27 15:18:31.117540", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.Verify12) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Verify12 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Verify12.log 2>&1", "delta": "0:00:09.145668", "end": "2018-08-27 15:18:53.980514", "item": "SCSI.Verify12", "rc": 0, "start": "2018-08-27 15:18:44.834846", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

changed: [localhost -> None] => (item=SCSI.Verify16) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.Verify16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.Verify16.log 2>&1", "delta": "0:00:09.113061", "end": "2018-08-27 15:19:07.024550", "item": "SCSI.Verify16", "rc": 0, "start": "2018-08-27 15:18:57.911489", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.WriteVerify10) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.WriteVerify10 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.WriteVerify10.log 2>&1", "delta": "0:00:04.871892", "end": "2018-08-27 15:19:15.815605", "item": "SCSI.WriteVerify10", "rc": 0, "start": "2018-08-27 15:19:10.943713", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.WriteVerify12) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.WriteVerify12 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.WriteVerify12.log 2>&1", "delta": "0:00:05.383767", "end": "2018-08-27 15:19:25.149469", "item": "SCSI.WriteVerify12", "rc": 0, "start": "2018-08-27 15:19:19.765702", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=SCSI.WriteVerify16) => {"changed": true, "cmd": "iscsi-test-cu --test=SCSI.WriteVerify16 iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/SCSI.WriteVerify16.log 2>&1", "delta": "0:00:05.167394", "end": "2018-08-27 15:19:34.350569", "item": "SCSI.WriteVerify16", "rc": 0, "start": "2018-08-27 15:19:29.183175", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=iSCSI.iSCSIcmdsn) => {"changed": true, "cmd": "iscsi-test-cu --test=iSCSI.iSCSIcmdsn iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/iSCSI.iSCSIcmdsn.log 2>&1", "delta": "0:00:00.013593", "end": "2018-08-27 15:19:38.410259", "item": "iSCSI.iSCSIcmdsn", "rc": 0, "start": "2018-08-27 15:19:38.396666", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=iSCSI.iSCSIdatasn) => {"changed": true, "cmd": "iscsi-test-cu --test=iSCSI.iSCSIdatasn iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/iSCSI.iSCSIdatasn.log 2>&1", "delta": "0:00:00.034080", "end": "2018-08-27 15:19:42.483168", "item": "iSCSI.iSCSIdatasn", "rc": 0, "start": "2018-08-27 15:19:42.449088", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
changed: [localhost -> None] => (item=iSCSI.iSCSIResiduals) => {"changed": true, "cmd": "iscsi-test-cu --test=iSCSI.iSCSIResiduals iscsi://10.16.19.35/iqn.2016-09.com.openebs.jiva:libiscsi-test-vut-4275748363/0 --dataloss --allow-sanitize > /tmp/libiscsi_suite_logs/iSCSI.iSCSIResiduals.log 2>&1", "delta": "0:00:00.416773", "end": "2018-08-27 15:19:46.961613", "item": "iSCSI.iSCSIResiduals", "rc": 0, "start": "2018-08-27 15:19:46.544840", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
...ignoring

TASK [8) Generate test summary] ****************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:179
changed: [localhost -> None] => {"changed": true, "rc": 0, "stderr": "Shared connection to 35.226.45.162 closed.\r\n", "stdout": "No of tests passed:139  No of tests failed:28", "stdout_lines": ["No of tests passed:139  No of tests failed:28"]}

TASK [8a) Display the test status] *************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:184
ok: [localhost] => {
    "msg": "No of tests passed:139  No of tests failed:28"
}

TASK [Setting pass flag] ***********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:188
ok: [localhost] => {"ansible_facts": {"flag": "Test Passed", "status": "good", "status_id": 1}, "changed": false}

TASK [Obtaining PV name] ***********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:2
changed: [localhost -> None] => {"changed": true, "cmd": "kubectl get pvc -n libiscsi-test -o custom-columns=:metadata.name", "delta": "0:00:06.863868", "end": "2018-08-27 20:49:59.880478", "rc": 0, "start": "2018-08-27 20:49:53.016610", "stderr": "", "stderr_lines": [], "stdout": "\nvut", "stdout_lines": ["", "vut"]}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:9
included: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/delete_deploy.yml for localhost

TASK [Delete application] **********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/delete_deploy.yml:2
changed: [localhost -> None] => (item=test-pvc.yaml) => {"changed": true, "cmd": "source ~/.profile; kubectl delete -f \"/home/giridhara_prasad/test-pvc.yaml\" -n libiscsi-test", "delta": "0:00:00.913109", "end": "2018-08-27 20:50:01.094350", "item": "test-pvc.yaml", "rc": 0, "start": "2018-08-27 20:50:00.181241", "stderr": "", "stderr_lines": [], "stdout": "persistentvolumeclaim \"vut\" deleted", "stdout_lines": ["persistentvolumeclaim \"vut\" deleted"]}

TASK [Confirm whether the pods are deleted.] ***************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:14
changed: [localhost -> None] => {"attempts": 1, "changed": true, "cmd": "source ~/.profile; kubectl get pods -n libiscsi-test", "delta": "0:00:01.626421", "end": "2018-08-27 20:50:02.962536", "rc": 0, "start": "2018-08-27 20:50:01.336115", "stderr": "", "stderr_lines": [], "stdout": "NAME                                                 READY     STATUS        RESTARTS   AGE\nlibiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq   2/2       Terminating   0          7m\nlibiscsi-test-vut-4275748363-rep-6dcc4cbbb4-8hrs4    1/1       Terminating   0          7m\nlibiscsi-test-vut-4275748363-rep-6dcc4cbbb4-j62zm    1/1       Terminating   0          7m\nlibiscsi-test-vut-4275748363-rep-6dcc4cbbb4-j7rzl    0/1       Terminating   0          7m", "stdout_lines": ["NAME                                                 READY     STATUS        RESTARTS   AGE", "libiscsi-test-vut-4275748363-ctrl-7746dc5bfb-j2czq   2/2       Terminating   0          7m", "libiscsi-test-vut-4275748363-rep-6dcc4cbbb4-8hrs4    1/1       Terminating   0          7m", "libiscsi-test-vut-4275748363-rep-6dcc4cbbb4-j62zm    1/1       Terminating   0          7m", "libiscsi-test-vut-4275748363-rep-6dcc4cbbb4-j7rzl    0/1       Terminating   0          7m"]}

TASK [Confirm id the target pod is deleted] ****************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:25
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Remove test artifacts] *******************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:36
changed: [localhost -> None] => (item=test-pvc.yaml) => {"changed": true, "item": "test-pvc.yaml", "path": "/home/giridhara_prasad/test-pvc.yaml", "state": "absent"}

TASK [Remove test artifacts] *******************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi-cleanup.yml:44
changed: [localhost -> None] => (item=run-tests.out) => {"changed": true, "item": "run-tests.out", "path": "/tmp/run-tests.out", "state": "absent"}

TASK [Test Cleanup Passed] *********************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:206
ok: [localhost] => {"ansible_facts": {"cflag": "Cleanup Passed"}, "changed": false}

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:217
included: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml for localhost

TASK [Start the log aggregator to capture test pod logs] ***************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml:2
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Terminate the log aggregator] ************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/stern_task.yml:14
fatal: [localhost -> None]: FAILED! => {"changed": true, "cmd": "source ~/.profile; killall stern", "delta": "0:00:00.006636", "end": "2018-08-27 20:50:07.733513", "msg": "non-zero return code", "rc": 1, "start": "2018-08-27 20:50:07.726877", "stderr": "/bin/bash: /root/.profile: No such file or directory\nstern: no process found", "stderr_lines": ["/bin/bash: /root/.profile: No such file or directory", "stern: no process found"], "stdout": "", "stdout_lines": []}
...ignoring

TASK [include_tasks] ***************************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:221
included: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml for localhost

TASK [Create test specific namespace.] *********************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:4
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking the status  of test specific namespace.] ****************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:10
skipping: [localhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deletion of test specific  namespace.] ***************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:24
changed: [localhost -> None] => {"changed": true, "cmd": "source ~/.profile; kubectl delete ns libiscsi-test", "delta": "0:00:00.894706", "end": "2018-08-27 20:50:09.046765", "rc": 0, "start": "2018-08-27 20:50:08.152059", "stderr": "", "stderr_lines": [], "stdout": "namespace \"libiscsi-test\" deleted", "stdout_lines": ["namespace \"libiscsi-test\" deleted"]}

TASK [Check the namespace status.] *************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/utils/namespace_task.yml:30
FAILED - RETRYING: Check the namespace status. (15 retries left).
changed: [localhost -> None] => {"attempts": 2, "changed": true, "cmd": "source ~/.profile; kubectl get ns", "delta": "0:00:01.537743", "end": "2018-08-27 20:50:42.463442", "rc": 0, "start": "2018-08-27 20:50:40.925699", "stderr": "", "stderr_lines": [], "stdout": "NAME          STATUS    AGE\ndefault       Active    13d\nkube-public   Active    13d\nkube-system   Active    13d\nopenebs       Active    6h", "stdout_lines": ["NAME          STATUS    AGE", "default       Active    13d", "kube-public   Active    13d", "kube-system   Active    13d", "openebs       Active    6h"]}

TASK [Set Test Name as Fact] *******************************************************************************************************************************************************************************
task path: /home/giridhara_prasad/openebs/e2e/ansible/playbooks/compliance/iscsi/libiscsi.yml:226
ok: [localhost] => {"ansible_facts": {"testname": "libiscsi_test_suite"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************
localhost                  : ok=39   changed=24   unreachable=0    failed=0
```