### PR TITLE
Scripts for upgrading from 0.6 to 0.7

### DIFF
--- a/k8s/upgrades/0.6.0-0.7.0/README.md
+++ b/k8s/upgrades/0.6.0-0.7.0/README.md
@@ -14,8 +14,8 @@ This document describes the steps for upgrading OpenEBS from 0.6.0 to 0.7.0. The
 ## Step 1: Upgrade the OpenEBS Operator
 
 OpenEBS 0.7.0 has made the following significant changes to the OpenEBS Operator (aka OpenEBS control plane components):
-- A new provisioning and policy enforcement engine. This introduces a breaking changes as it expects the volume policies to be present as annotations in storage class as opposed to `parameters` or `environment variables`.
-- OpenEBS will install default jiva storage pool (named `default`) and storage class (named `openebs-jiva-default`). If these names conflict with your existing storage pool or storage classes, rename of re-apply your storage classes.
+- A new provisioning and policy enforcement engine. This introduces breaking changes as it expects the volume policies to be present as annotations in storage class as opposed to `parameters` or `environment variables`.
+- OpenEBS will install default jiva storage pool (named `default`) and storage class (named `openebs-jiva-default`). If these names conflict with your existing storage pool or storage classes, rename and re-apply your storage classes.
 - Integrated with OpenEBS NDM project. A new Daemonset will be launched to discover the block devices attached to the nodes.
 
 ### Download the upgrade scripts

--- a/k8s/upgrades/0.6.0-0.7.0/README.md
+++ b/k8s/upgrades/0.6.0-0.7.0/README.md
@@ -1,0 +1,116 @@
+# UPGRADE FROM OPENEBS 0.6.0 TO 0.7.0
+
+## Overview
+
+This document describes the steps for upgrading OpenEBS from 0.6.0 to 0.7.0. The upgrade of OpenEBS is a two step process. 
+- *Step 1* - Upgrade the OpenEBS Operator 
+- *Step 2* - Upgrade the OpenEBS Volumes that were created with older OpenEBS Operator (0.6.0) 
+
+### Terminology
+- *OpenEBS Operator : Refers to maya-apiserver & openebs-provisioner along w/ respective services, service a/c, roles, rolebindings*
+- *OpenEBS Volume: The Jiva controller & replica pods*
+- *All steps described in this document need to be performed on the Kubernetes master or from a machine that has access to Kubernetes master*
+
+## Step 1: Upgrade the OpenEBS Operator
+
+OpenEBS 0.7.0 has made the following significant changes to the OpenEBS Operator (aka OpenEBS control plane components):
+- A new provisioning and policy enforcement engine. This introduces a breaking changes as it expects the volume policies to be present as annotations in storage class as opposed to `parameters` or `environment variables`.
+- OpenEBS will install default jiva storage pool (named `default`) and storage class (named `openebs-jiva-default`). If these names conflict with your existing storage pool or storage classes, rename of re-apply your storage classes.
+- Integrated with OpenEBS NDM project. A new Daemonset will be launched to discover the block devices attached to the nodes.
+
+### Download the upgrade scripts
+
+Either `git clone` or download the following files to your work directory. 
+https://github.com/openebs/openebs/tree/master/k8s/upgrades/0.6.0-0.7.0
+- `patch-strategy-recreate.json`
+- `replica.patch.tpl.yml`
+- `controller.patch.tpl.yml`
+- `oebs_update.sh`
+- `pre_upgrade.sh`
+
+### Pre-requisites
+Before upgrading the OpenEBS Operator, check if you are using a storage pool named `default` which will conflict with default jiva pool installed with OpenEBS 0.7.0:
+```
+./pre_upgrade.sh <openebs-namespace>
+```
+
+### Upgrade volume policies in existing storage classes
+
+Use the following command to upgrade the storage classes volume policies. Move from parameters to annotations. This script will only update the following volume policies:
+- `openebs.io/replica-count`
+- `openebs.io/storage-pool`
+- `openebs.io/volume-monitor`
+
+The remaining policies will fallback to their default values. 
+
+```
+./upgrade_sc.sh
+```
+
+Alternatively, you can skip this step and re-apply your StorageClasses as per the 0.7.0 volume policy specification. 
+
+**Note: StorageClasses have to updated prior to provisioning any new volumes with 0.7.0.**
+
+### Upgrading OpenEBS Operator CRDs and Deployments
+
+The upgrade steps vary depending on the way OpenEBS was installed, select one of the following:
+
+#### Install/Upgrade using kubectl (using openebs-operator.yaml )
+
+**The sample steps below will work if you have installed openebs without modifying the default values in openebs-operator.yaml. If you have customized it for your cluster, you will have to download the 0.7.0 openebs-operator.yaml and cutomize it again**
+
+```
+#If Upgrading from 0.5.x, delete older operator. 
+# Starting with OpenEBS 0.6, all the components are installed in namespace `openebs`
+# as opposed to `default` namespace in earlier releases. 
+kubectl delete -f https://raw.githubusercontent.com/openebs/openebs/v0.5/k8s/openebs-operator.yaml
+#Wait for objects to be delete, you can check using `kubectl get deploy`
+
+#Upgrade to 0.7 OpenEBS Operator
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.7.0.yaml
+```
+
+#### Install/Upgrade using helm chart (using stable/openebs, openebs-charts repo, etc.,) 
+
+**The sample steps below will work if you have installed openebs with default values provided by stable/openebs helm chart.**
+
+- Run `helm ls` to get the release name of openebs. 
+- Upgrade using `helm upgrade -f https://openebs.github.io/charts/helm-values-0.7.0.yaml <release-name> stable/openebs`
+
+#### Using customized operator YAML or helm chart.
+As a first step, you must update your custom helm chart or YAML with 0.7 release tags and changes made in the values/templates. 
+
+You can use the following as references to know about the changes in 0.7: 
+- openebs-charts [PR#1878](https://github.com/openebs/openebs/pull/1878) as reference.
+
+After updating the YAML or helm chart or helm chart values, you can use the above procedures to upgrade the OpenEBS Operator
+
+## Step 2: Upgrade the OpenEBS Volumes
+
+Even after the OpenEBS Operator has been upgraded to 0.7, the volumes will continue to work with older versions. Each of the volumes should be upgraded (one at a time) to 0.7, using the steps provided below. 
+
+*Note: Upgrade functionality is still under active development. It is hightly recommended to schedule a downtime for the application using the OpenEBS PV while performing this upgrade. Also, make sure you have taken a backup of the data before starting the below upgrade procedure.*
+
+Limitations:
+- this is a preliminary script only intended for using on volumes where data has been backed-up.
+- please have the following link handy in case the volume gets into read-only during upgrade 
+  https://docs.openebs.io/docs/next/readonlyvolumes.html
+- automatic rollback option is not provided. To rollback, you need to update the controller, exporter and replica pod images to the previous version
+- in the process of running the below steps, if you run into issues, you can always reach us on slack
+
+
+```
+kubectl get pv
+```
+
+```
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM                          STORAGECLASS      REASON    AGE
+pvc-48fb36a2-947f-11e8-b1f3-42010a800004   5G         RWO            Delete           Bound     percona-test/demo-vol1-claim   openebs-percona             8m
+```
+
+### Upgrade the PV that needs to be upgraded. 
+
+```
+./oebs_update.sh pvc-48fb36a2-947f-11e8-b1f3-42010a800004 openebs-storage
+```
+

--- a/k8s/upgrades/0.6.0-0.7.0/README.md
+++ b/k8s/upgrades/0.6.0-0.7.0/README.md
@@ -1,55 +1,104 @@
-# UPGRADE FROM OPENEBS 0.6.0 TO 0.7.0
+# UPGRADE FROM OPENEBS 0.6.0 TO 0.7.x
 
 ## Overview
 
-This document describes the steps for upgrading OpenEBS from 0.6.0 to 0.7.0. The upgrade of OpenEBS is a two step process. 
+This document describes the steps for upgrading OpenEBS from 0.6.0 to 0.7.x 
+
+The upgrade of OpenEBS is a two step process: 
 - *Step 1* - Upgrade the OpenEBS Operator 
-- *Step 2* - Upgrade the OpenEBS Volumes that were created with older OpenEBS Operator (0.6.0) 
+- *Step 2* - Upgrade the OpenEBS Volumes from previous versions (0.6.0, 0.5.x) 
 
 ### Terminology
 - *OpenEBS Operator : Refers to maya-apiserver & openebs-provisioner along w/ respective services, service a/c, roles, rolebindings*
-- *OpenEBS Volume: The Jiva controller & replica pods*
-- *All steps described in this document need to be performed on the Kubernetes master or from a machine that has access to Kubernetes master*
+- *OpenEBS Volume: The Jiva controller(aka target) & replica pods*
 
-## Step 1: Upgrade the OpenEBS Operator
+## Prerequisites
 
-OpenEBS 0.7.0 has made the following significant changes to the OpenEBS Operator (aka OpenEBS control plane components):
-- A new provisioning and policy enforcement engine. This introduces breaking changes as it expects the volume policies to be present as annotations in storage class as opposed to `parameters` or `environment variables`.
-- OpenEBS will install default jiva storage pool (named `default`) and storage class (named `openebs-jiva-default`). If these names conflict with your existing storage pool or storage classes, rename and re-apply your storage classes.
-- Integrated with OpenEBS NDM project. A new Daemonset will be launched to discover the block devices attached to the nodes.
+*All steps described in this document need to be performed on the Kubernetes master or from a machine that has access to Kubernetes master*
 
 ### Download the upgrade scripts
 
-Either `git clone` or download the following files to your work directory. 
-https://github.com/openebs/openebs/tree/master/k8s/upgrades/0.6.0-0.7.0
+You can either `git clone` or download the upgrade scripts.
+
+```
+mkdir upgrade-openebs
+cd upgrade-openebs
+git clone https://github.com/openebs/openebs.git
+cd openebs/k8s/upgrade/0.6.0-0.7.0/
+```
+
+Or
+
+Download the following files to your work directory from https://github.com/openebs/openebs/tree/master/k8s/upgrades/0.6.0-0.7.0
 - `patch-strategy-recreate.json`
-- `replica.patch.tpl.yml`
-- `controller.patch.tpl.yml`
+- `jiva-replica-patch.tpl.json`
+- `jiva-target-patch.tpl.json`
+- `jiva-target-svc-patch.tpl.json`
+- `target-patch-remove-labels.json`
+- `target-svc-patch-remove-labels.json`
+- `replica-patch-remove-labels.json`
+- `sc.patch.tpl.yaml`
+- `upgrade_sc.sh`
 - `oebs_update.sh`
 - `pre_upgrade.sh`
 
-### Pre-requisites
+### Breaking Changes in 0.7.x
+
+#### Default Jiva Storage Pool
+OpenEBS 0.7.0 auto installs a default Jiva Storage Pool and a default Storage Class named `default` and `openebs-jiva-default` respectively. If you have a storage pool named `default` created in earlier version, you will have to re-apply your Storage Pool after the upgrade is completed.
+
 Before upgrading the OpenEBS Operator, check if you are using a storage pool named `default` which will conflict with default jiva pool installed with OpenEBS 0.7.0:
 ```
 ./pre_upgrade.sh <openebs-namespace>
 ```
 
-### Upgrade volume policies in existing storage classes
+#### Storage Classes
+OpenEBS supports specified Storage Policies in Storage Classes. The way storage policies are specified has changed in 0.7.x. The policies will have to be specified under metadata instead of parameters. 
 
-Use the following command to upgrade the storage classes volume policies. Move from parameters to annotations. This script will only update the following volume policies:
-- `openebs.io/replica-count`
-- `openebs.io/storage-pool`
-- `openebs.io/volume-monitor`
+For example, if your storage class looks like this in 0.6.0:
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-mongodb
+provisioner: openebs.io/provisioner-iscsi
+parameters:
+  openebs.io/storage-pool: "default"
+  openebs.io/jiva-replica-count: "3"
+  openebs.io/volume-monitor: "true"
+  openebs.io/capacity: 5G
+  openebs.io/fstype: "xfs"
+```
 
-The remaining policies will fallback to their default values. 
+There is no need to mention the volume-monitor and capacity with 0.7.0. The remaining policies like storage pool, replica count and the fstype should be specified as follows:
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: openebs-mongodb
+   annotations:
+    cas.openebs.io/config: |
+      - name: ReplicaCount
+        value: "3"
+      - name: StoragePool
+        value: default
+      - name: FSType
+        value: "xfs"
+provisioner: openebs.io/provisioner-iscsi
+```
 
+Make edits to your Storage Class YAMLs - delete them and add them back. A delete and re-apply is required since updates to Storage Class parameters are not possible. 
+
+If you are using `ext4` for FSType, you could use the following script to upgrade your StorageClasses. 
 ```
 ./upgrade_sc.sh
 ```
 
 Alternatively, you can skip this step and re-apply your StorageClasses as per the 0.7.0 volume policy specification. 
 
-**Note: StorageClasses have to updated prior to provisioning any new volumes with 0.7.0.**
+**Important Note: StorageClasses have to updated prior to provisioning any new volumes with 0.7.0.**
+
+## Step 1: Upgrade the OpenEBS Operator
 
 ### Upgrading OpenEBS Operator CRDs and Deployments
 
@@ -57,7 +106,7 @@ The upgrade steps vary depending on the way OpenEBS was installed, select one of
 
 #### Install/Upgrade using kubectl (using openebs-operator.yaml )
 
-**The sample steps below will work if you have installed openebs without modifying the default values in openebs-operator.yaml. If you have customized it for your cluster, you will have to download the 0.7.0 openebs-operator.yaml and cutomize it again**
+**The sample steps below will work if you have installed openebs without modifying the default values in openebs-operator.yaml. If you have customized it for your cluster, you will have to download the 0.7.0 openebs-operator.yaml and customize it again**
 
 ```
 #If Upgrading from 0.5.x, delete older operator. 
@@ -67,7 +116,7 @@ kubectl delete -f https://raw.githubusercontent.com/openebs/openebs/v0.5/k8s/ope
 #Wait for objects to be delete, you can check using `kubectl get deploy`
 
 #Upgrade to 0.7 OpenEBS Operator
-kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.7.0.yaml
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.7.1.yaml
 ```
 
 #### Install/Upgrade using helm chart (using stable/openebs, openebs-charts repo, etc.,) 
@@ -75,7 +124,7 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.7.0.yaml
 **The sample steps below will work if you have installed openebs with default values provided by stable/openebs helm chart.**
 
 - Run `helm ls` to get the release name of openebs. 
-- Upgrade using `helm upgrade -f https://openebs.github.io/charts/helm-values-0.7.0.yaml <release-name> stable/openebs`
+- Upgrade using `helm upgrade -f https://openebs.github.io/charts/helm-values-0.7.1.yaml <release-name> stable/openebs`
 
 #### Using customized operator YAML or helm chart.
 As a first step, you must update your custom helm chart or YAML with 0.7 release tags and changes made in the values/templates. 
@@ -89,7 +138,7 @@ After updating the YAML or helm chart or helm chart values, you can use the abov
 
 Even after the OpenEBS Operator has been upgraded to 0.7, the volumes will continue to work with older versions. Each of the volumes should be upgraded (one at a time) to 0.7, using the steps provided below. 
 
-*Note: Upgrade functionality is still under active development. It is hightly recommended to schedule a downtime for the application using the OpenEBS PV while performing this upgrade. Also, make sure you have taken a backup of the data before starting the below upgrade procedure.*
+*Note: Upgrade functionality is still under active development. It is highly recommended to schedule a downtime for the application using the OpenEBS PV while performing this upgrade. Also, make sure you have taken a backup of the data before starting the below upgrade procedure.*
 
 Limitations:
 - this is a preliminary script only intended for using on volumes where data has been backed-up.

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
@@ -34,7 +34,7 @@
            "containers":[
               {
                 "name": "@r_name",
-                "image": "openebs/jiva:0.7.0"
+                "image": "quay.io/openebs/jiva:0.7.1"
               }
            ],
           "nodeSelector": {

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
@@ -40,6 +40,21 @@
           "nodeSelector": {
               "openebs-pv-@pv-name": "@replica_node_label"
           },
+          "affinity": {
+              "podAntiAffinity": {
+                  "requiredDuringSchedulingIgnoredDuringExecution" : [
+                     {
+                         "labelSelector": {
+                             "matchLabels": {
+                                 "openebs.io/replica": "jiva-replica",
+                                 "openebs.io/persistent-volume": "@pv-name"
+                             }
+                          },
+                          "topologyKey": "kubernetes.io/hostname"
+                     }
+                  ]
+              }
+          },
           "tolerations": [
             {
               "effect": "NoExecute",

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-replica-patch.tpl.json
@@ -1,0 +1,98 @@
+{
+  "metadata": {
+     "annotations": {
+       "openebs.io/capacity": "TODO",
+       "openebs.io/storage-pool": "TODO"
+     },
+     "labels": {
+       "openebs.io/cas-type": "jiva",
+       "openebs.io/persistent-volume": "@pv-name",
+       "openebs.io/persistent-volume-claim": "@pvc-name",
+       "openebs.io/replica": "jiva-replica",
+       "openebs.io/storage-engine-type": "jiva",
+       "vsm": "deprecated"
+     }
+  },
+  "spec": {
+     "selector": {
+        "matchLabels": {
+           "openebs.io/persistent-volume": "@pv-name",
+           "openebs.io/replica": "jiva-replica",
+           "vsm": "deprecated"
+        }
+     },
+     "template": {
+        "metadata": {
+           "labels": {
+             "openebs.io/persistent-volume": "@pv-name",
+             "openebs.io/persistent-volume-claim": "@pvc-name",
+             "openebs.io/replica": "jiva-replica",
+             "vsm": "deprecated"
+           }
+        },
+        "spec": {
+           "containers":[
+              {
+                "name": "@r_name",
+                "image": "openebs/jiva:0.7.0"
+              }
+           ],
+          "nodeSelector": {
+              "openebs-pv-@pv-name": "@replica_node_label"
+          },
+          "tolerations": [
+            {
+              "effect": "NoExecute",
+              "key": "node.alpha.kubernetes.io/notReady",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.alpha.kubernetes.io/unreachable",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/out-of-disk",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/memory-pressure",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/disk-pressure",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/network-unavailable",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unschedulable",
+              "operator": "Exists"
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.cloudprovider.kubernetes.io/uninitialized",
+              "operator": "Exists"
+            }
+          ]
+        }
+     }
+  }
+} 

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-target-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-target-patch.tpl.json
@@ -36,7 +36,7 @@
            "containers":[
               {
                 "name": "@c_name",
-                "image": "openebs/jiva:0.7.0",
+                "image": "quay.io/openebs/jiva:0.7.1",
                 "env":[
                   {
                     "name": "REPLICATION_FACTOR",
@@ -49,7 +49,7 @@
                 "command": [
                    "maya-exporter"
                 ],
-                "image": "openebs/m-exporter:0.7.0"
+                "image": "quay.io/openebs/m-exporter:0.7.1"
               }
            ], 
           "tolerations": [

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-target-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-target-patch.tpl.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+     "annotations": {
+       "openebs.io/fs-type": "ext4",
+       "openebs.io/lun": "0",
+       "openebs.io/volume-monitor": "true",
+       "openebs.io/volume-type": "jiva"
+     },
+     "labels": {
+       "openebs.io/cas-type": "jiva",
+       "openebs.io/storage-engine-type": "jiva",
+       "openebs.io/controller": "jiva-controller",
+       "openebs.io/persistent-volume": "@pv-name",
+       "openebs.io/persistent-volume-claim": "@pvc-name",
+       "vsm": "deprecated"
+     }
+  },
+  "spec": {
+     "selector": {
+        "matchLabels": {
+           "openebs.io/controller": "jiva-controller",
+           "openebs.io/persistent-volume": "@pv-name",
+           "vsm": "deprecated"
+        }
+     },
+     "template": {
+        "metadata": {
+           "labels": {
+              "openebs.io/controller": "jiva-controller",
+              "openebs.io/persistent-volume": "@pv-name",
+              "openebs.io/persistent-volume-claim": "@pvc-name",
+              "vsm": "deprecated"
+           }
+        },
+        "spec": {
+           "containers":[
+              {
+                "name": "@c_name",
+                "image": "openebs/jiva:0.7.0",
+                "env":[
+                  {
+                    "name": "REPLICATION_FACTOR",
+                    "value": "@rep_count"
+                  }
+                ]
+              },
+              {
+                "name": "maya-volume-exporter",
+                "command": [
+                   "maya-exporter"
+                ],
+                "image": "openebs/m-exporter:0.7.0"
+              }
+           ], 
+          "tolerations": [
+            {
+              "effect": "NoExecute",
+              "key": "node.alpha.kubernetes.io/notReady",
+              "operator": "Exists",
+              "tolerationSeconds": 0
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.alpha.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 0
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/not-ready",
+              "operator": "Exists",
+              "tolerationSeconds": 0
+            },
+            {
+              "effect": "NoExecute",
+              "key": "node.kubernetes.io/unreachable",
+              "operator": "Exists",
+              "tolerationSeconds": 0
+            }
+          ]
+        }
+     }
+  }
+} 

--- a/k8s/upgrades/0.6.0-0.7.0/jiva-target-svc-patch.tpl.json
+++ b/k8s/upgrades/0.6.0-0.7.0/jiva-target-svc-patch.tpl.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+     "labels": {
+       "openebs.io/cas-type": "jiva",
+       "openebs.io/storage-engine-type": "jiva",
+       "openebs.io/controller-service": "jiva-controller-svc",
+       "openebs.io/persistent-volume": "@pv-name",
+       "openebs.io/persistent-volume-claim": "@pvc-name"
+     }
+  },
+  "spec": {
+     "selector": {
+       "openebs.io/controller": "jiva-controller",
+       "openebs.io/persistent-volume": "@pv-name",
+       "vsm": "deprecated"
+     }
+  }
+} 

--- a/k8s/upgrades/0.6.0-0.7.0/oebs_update.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/oebs_update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 ################################################################
 # STEP: Get Persistent Volume (PV) name as argument            #
@@ -10,12 +10,12 @@ function usage() {
     echo 
     echo "Usage:"
     echo 
-    echo "$0 <pv-name> <replica-label>"
+    echo "$0 <pv-name> <custom-label>"
     echo 
     echo "  <pv-name> Get the PV name using: kubectl get pv"
-    echo "  <node-label> Label to be applied to the nodes where replicas of"
-    echo "    this PV are present. Get the nodes by running:"
-    echo "    kubectl get pods --all-namespaces -o wide | grep <pv-name>"
+    echo "  <custom-label> Label to be applied to the nodes where replicas of"
+    echo "    this PV are present. This is done to make sure the replicas    "
+    echo "    stay on the same node after upgrade."
     exit 1
 }
 
@@ -180,6 +180,8 @@ kubectl delete rs $c_rs --namespace $ns
 rollout_status=$(kubectl rollout status --namespace $ns  deployment/$c_dep)
 rc=$?; if [[ ($rc -ne 0) || !($rollout_status =~ "successfully rolled out") ]];
 then echo "ERROR: $rc"; exit; fi
+
+kubectl annotate pv $pv openebs.io/cas-type=jiva
 
 echo "Clearing temporary files"
 rm jiva-replica-patch.tpl.json.0

--- a/k8s/upgrades/0.6.0-0.7.0/oebs_update.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/oebs_update.sh
@@ -1,0 +1,186 @@
+#!/bin/bash -x
+
+################################################################
+# STEP: Get Persistent Volume (PV) name as argument            #
+#                                                              #
+# NOTES: Obtain the pv to upgrade via "kubectl get pv"         #
+################################################################
+
+function usage() {
+    echo 
+    echo "Usage:"
+    echo 
+    echo "$0 <pv-name> <replica-label>"
+    echo 
+    echo "  <pv-name> Get the PV name using: kubectl get pv"
+    echo "  <node-label> Label to be applied to the nodes where replicas of"
+    echo "    this PV are present. Get the nodes by running:"
+    echo "    kubectl get pods --all-namespaces -o wide | grep <pv-name>"
+    exit 1
+}
+
+
+if [ "$#" -ne 2 ]; then
+    usage
+fi
+
+pv=$1
+replica_node_label=$2
+
+pvc=`kubectl get pv $pv -o jsonpath="{.spec.claimRef.name}"`
+ns=`kubectl get pv $pv -o jsonpath="{.spec.claimRef.namespace}"`
+
+################################################################ 
+# STEP: Generate deploy, replicaset and container names from PV#
+#                                                              #
+# NOTES: Ex: If PV="pvc-cec8e86d-0bcc-11e8-be1c-000c298ff5fc", #
+#                                                              #
+# ctrl-dep: pvc-cec8e86d-0bcc-11e8-be1c-000c298ff5fc-ctrl      #  
+# ctrl-cont: pvc-cec8e86d-0bcc-11e8-be1c-000c298ff5fc-ctrl-con #  
+################################################################
+
+c_dep=$(echo $pv-ctrl); c_name=$(echo $c_dep-con)
+r_dep=$(echo $pv-rep); r_name=$(echo $r_dep-con)
+c_svc=$(echo $c_dep-svc)
+
+# Get the number of replicas configured. 
+# This field is currently not used, but can add additional validations
+# based on the nodes and expected number of replicas
+rep_count=`kubectl get deploy $r_dep --namespace $ns -o jsonpath="{.spec.replicas}"`
+
+# Get the list of nodes where replica pods are running, delimited by ':'
+rep_nodenames=`kubectl get pods -n $ns $rep_labels \
+ -l "vsm=$pv" -l "openebs/replica=jiva-replica" \
+ -o jsonpath="{range .items[*]}{@.spec.nodeName}:{end}"`
+
+echo "Checking if the node with replica pod has been labeled with $replica_node_label"
+for rep_node in `echo $rep_nodenames | tr ":" " "`; do
+    nl="";nl=`kubectl get nodes $rep_node -o jsonpath="{.metadata.labels.openebs-pv-$pv}"`
+    if [  -z "$nl" ];
+    then
+       echo "Labeling $rep_node";
+       kubectl label node $rep_node "openebs-pv-${pv}=$replica_node_label"
+    fi
+done
+
+
+echo "Patching Replica Deployment upgrade strategy as recreate"
+kubectl patch deployment --namespace $ns --type json $r_dep -p "$(cat patch-strategy-recreate.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+echo "Patching Target Deployment upgrade strategy as recreate"
+kubectl patch deployment --namespace $ns --type json $c_dep -p "$(cat patch-strategy-recreate.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+# Fetch the older target and replica - ReplicaSet objects which need to be 
+# deleted before upgrading. If not deleted, the new pods will be stuck in 
+# creating state - due to affinity rules. 
+c_rs=$(kubectl get rs -o name --namespace $ns | grep $c_dep | cut -d '/' -f 2)
+r_rs=$(kubectl get rs -o name --namespace $ns | grep $r_dep | cut -d '/' -f 2)
+
+################################################################ 
+# STEP: Update patch files with appropriate container names    #
+#                                                              # 
+# NOTES: Placeholder "pvc-<deploy-hash>-ctrl/rep-con in the    #
+# patch files are replaced with container names derived from   #
+# the PV in the previous step                                  #  
+################################################################
+
+sed "s/@pvc-name[^ \"]*/$pvc/g" jiva-replica-patch.tpl.json > jiva-replica-patch.tpl.json.0
+sed "s/@replica_node_label[^ \"]*/$replica_node_label/g" jiva-replica-patch.tpl.json.0 > jiva-replica-patch.tpl.json.1
+sed "s/@pv-name[^ \"]*/$pv/g" jiva-replica-patch.tpl.json.1 > jiva-replica-patch.tpl.json.2
+sed "s/@r_name[^ \"]*/$r_name/g" jiva-replica-patch.tpl.json.2 > jiva-replica-patch.json
+
+sed "s/@pvc-name[^ \"]*/$pvc/g" jiva-target-patch.tpl.json > jiva-target-patch.tpl.json.0
+sed "s/@c_name[^ \"]*/$c_name/g" jiva-target-patch.tpl.json.0 > jiva-target-patch.tpl.json.1
+sed "s/@pv-name[^ \"]*/$pv/g" jiva-target-patch.tpl.json.1 > jiva-target-patch.tpl.json.2
+sed "s/@rep_count[^ \"]*/$rep_count/g" jiva-target-patch.tpl.json.2 > jiva-target-patch.json
+
+sed "s/@pvc-name[^ \"]*/$pvc/g" jiva-target-svc-patch.tpl.json > jiva-target-svc-patch.tpl.json.0
+sed "s/@pv-name[^ \"]*/$pv/g" jiva-target-svc-patch.tpl.json.0 > jiva-target-svc-patch.json
+
+################################################################
+# STEP: Patch OpenEBS volume deployments (jiva-target, jiva-replica) #  
+#                                                              #
+# NOTES: Strategic merge patch is used to update the volume w/ #  
+# rollout status verification                                  #  
+################################################################
+
+# PATCH JIVA REPLICA DEPLOYMENT ####
+echo "Upgrading Replica Deployment to 0.7"
+kubectl patch deployment --namespace $ns $r_dep -p "$(cat jiva-replica-patch.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+kubectl delete rs $r_rs --namespace $ns
+
+rollout_status=$(kubectl rollout status --namespace $ns deployment/$r_dep)
+rc=$?; if [[ ($rc -ne 0) || !($rollout_status =~ "successfully rolled out") ]];
+then echo "ERROR: $rc"; exit; fi
+
+#### PATCH TARGET DEPLOYMENT ####
+echo "Upgrading Target Deployment to 0.7"
+kubectl patch deployment  --namespace $ns $c_dep -p "$(cat jiva-target-patch.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+kubectl delete rs $c_rs --namespace $ns
+
+rollout_status=$(kubectl rollout status --namespace $ns  deployment/$c_dep)
+rc=$?; if [[ ($rc -ne 0) || !($rollout_status =~ "successfully rolled out") ]];
+then echo "ERROR: $rc"; exit; fi
+
+#### PATCH TARGET SERVICE ####
+echo "Upgrading Target Service to 0.7"
+kubectl patch service --namespace $ns $c_svc -p "$(cat jiva-target-svc-patch.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+### REMOVE DEPRECATED LABELS
+
+kubectl patch service --namespace $ns $c_svc --type json -p "$(cat target-svc-patch-remove-labels.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+kubectl label svc --namespace $ns $c_svc "vsm-"
+kubectl label svc --namespace $ns $c_svc "openebs/controller-service-"
+
+# Fetch the older target and replica - ReplicaSet objects which need to be 
+# deleted before upgrading. If not deleted, the new pods will be stuck in 
+# creating state - due to affinity rules. 
+c_rs=$(kubectl get rs -o name --namespace $ns | grep $c_dep | cut -d '/' -f 2)
+r_rs=$(kubectl get rs -o name --namespace $ns | grep $r_dep | cut -d '/' -f 2)
+
+
+# PATCH JIVA REPLICA DEPLOYMENT ####
+echo "Remove deprecated lables from Replica Deployment"
+kubectl patch deployment --namespace $ns $r_dep --type json -p "$(cat replica-patch-remove-labels.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+kubectl delete rs $r_rs --namespace $ns
+
+rollout_status=$(kubectl rollout status --namespace $ns deployment/$r_dep)
+rc=$?; if [[ ($rc -ne 0) || !($rollout_status =~ "successfully rolled out") ]];
+then echo "ERROR: $rc"; exit; fi
+
+#### PATCH TARGET DEPLOYMENT ####
+echo "Remove deprecated lables from Controller Deployment"
+kubectl patch deployment  --namespace $ns $c_dep --type json -p "$(cat target-patch-remove-labels.json)"
+rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+kubectl delete rs $c_rs --namespace $ns
+
+rollout_status=$(kubectl rollout status --namespace $ns  deployment/$c_dep)
+rc=$?; if [[ ($rc -ne 0) || !($rollout_status =~ "successfully rolled out") ]];
+then echo "ERROR: $rc"; exit; fi
+
+echo "Clearing temporary files"
+rm jiva-replica-patch.tpl.json.0
+rm jiva-replica-patch.tpl.json.1
+rm jiva-replica-patch.tpl.json.2
+rm jiva-replica-patch.json
+rm jiva-target-patch.tpl.json.0
+rm jiva-target-patch.tpl.json.1
+rm jiva-target-patch.tpl.json.2
+rm jiva-target-patch.json
+rm jiva-target-svc-patch.tpl.json.0
+rm jiva-target-svc-patch.json
+
+echo "Successfully upgraded $pv to 0.7. Please run your application checks."
+exit 0
+

--- a/k8s/upgrades/0.6.0-0.7.0/patch-strategy-recreate.json
+++ b/k8s/upgrades/0.6.0-0.7.0/patch-strategy-recreate.json
@@ -1,0 +1,4 @@
+[
+  { "op": "remove", "path": "/spec/strategy/rollingUpdate" },
+  { "op": "replace", "path": "/spec/strategy/type", "value": "Recreate" }
+]

--- a/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+################################################################
+# STEP: Verify if upgrade needs to be performed                #
+#   Check the version of OpenEBS installed                     #
+#   Check if default jiva storage pool or storage class can    #
+#     conflict with the installed storage pool or class        #
+#   Check if there are any PVs that need to be upgraded        #
+#                                                              #
+################################################################
+
+function print_usage() {
+    echo 
+    echo "Usage:"
+    echo 
+    echo "$0 <openebs-namespace>"
+    echo 
+    echo "  <openebs-namepsace> Namespace where openebs control"
+    echo "    plane pods like maya-apiserver are installed.    "
+    exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+    print_usage
+fi
+
+
+oens=$1
+
+
+echo
+VERSION_INSTALLED=`kubectl get deploy -n openebs -o yaml \
+ | grep m-apiserver \
+ | grep 'image: openebs' \
+ | awk -F ':' '{print $3}'`
+
+
+if [ -z $VERSION_INSTALLED ] || [ $VERSION_INSTALLED = "0*" ]; then 
+    echo "Unable to determine installed openebs version"
+    print_usage
+elif [ $VERSION_INSTALLED = "0.6.0*" ]; then
+    echo "Upgrade is supported only from 0.6.0"
+    exit 1
+fi
+
+echo "Installed Version: $VERSION_INSTALLED" 
+
+echo
+kubectl get sp default 2>/dev/null
+rc=$? 
+if [ $rc -eq 0 ]; then 
+   POOL_PATH=`kubectl get sp default -o jsonpath='{.spec.path}'`
+   if [ $POOL_PATH = "/var/openebs" ]; then
+     echo "Found Jiva StoragePool named 'default' with path as /var/openebs"
+   else
+     echo "Found Jiva StoragePool named 'default' with cutomized path"
+     echo " After upgrading to 0.7.0, you will need to re-apply your StoragePool"
+     echo " or consider renaming the pool." 
+     exit 1
+   fi
+else
+   echo "Jiva StoragePool named 'default' was not found"
+fi
+
+echo
+OLDER_PVS=`kubectl get pods --all-namespaces -l openebs/controller | wc -l`
+if [ -z $OLDER_PVS ] || [ $OLDER_PVS -lt 2 ]; then 
+    echo "There are no PVs that need to be upgraded to 0.7.0"
+else
+    echo "Found PVs that need to be upgraded to 0.7.0"
+fi
+
+echo
+exit 0
+
+

--- a/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
@@ -31,7 +31,6 @@ oens=$1
 echo
 VERSION_INSTALLED=`kubectl get deploy -n openebs -o yaml \
  | grep m-apiserver \
- | grep 'image: openebs' \
  | awk -F ':' '{print $3}'`
 
 

--- a/k8s/upgrades/0.6.0-0.7.0/replica-patch-remove-labels.json
+++ b/k8s/upgrades/0.6.0-0.7.0/replica-patch-remove-labels.json
@@ -1,0 +1,8 @@
+[
+  { "op": "remove", "path": "/metadata/labels/openebs~1replica" },
+  { "op": "remove", "path": "/metadata/labels/vsm" },
+  { "op": "remove", "path": "/spec/selector/matchLabels/openebs~1replica" },
+  { "op": "remove", "path": "/spec/selector/matchLabels/vsm" },
+  { "op": "remove", "path": "/spec/template/metadata/labels/openebs~1replica" },
+  { "op": "remove", "path": "/spec/template/metadata/labels/vsm" }
+]

--- a/k8s/upgrades/0.6.0-0.7.0/sc.patch.tpl.yaml
+++ b/k8s/upgrades/0.6.0-0.7.0/sc.patch.tpl.yaml
@@ -1,0 +1,12 @@
+metadata:
+  labels:
+    openebs.io/cas-type: jiva
+  annotations:
+    openebs.io/cas-type: jiva
+    cas.openebs.io/config: |
+      - name: VolumeMonitor
+        enabled: @volume-monitoring
+      - name: ReplicaCount
+        value: @jiva-replica-count
+      - name: StoragePool
+        value: @storage-pool

--- a/k8s/upgrades/0.6.0-0.7.0/target-patch-remove-labels.json
+++ b/k8s/upgrades/0.6.0-0.7.0/target-patch-remove-labels.json
@@ -1,0 +1,8 @@
+[
+  { "op": "remove", "path": "/metadata/labels/openebs~1controller" },
+  { "op": "remove", "path": "/metadata/labels/vsm" },
+  { "op": "remove", "path": "/spec/selector/matchLabels/openebs~1controller" },
+  { "op": "remove", "path": "/spec/selector/matchLabels/vsm" },
+  { "op": "remove", "path": "/spec/template/metadata/labels/openebs~1controller" },
+  { "op": "remove", "path": "/spec/template/metadata/labels/vsm" }
+]

--- a/k8s/upgrades/0.6.0-0.7.0/target-svc-patch-remove-labels.json
+++ b/k8s/upgrades/0.6.0-0.7.0/target-svc-patch-remove-labels.json
@@ -1,0 +1,4 @@
+[
+  { "op": "remove", "path": "/spec/selector/openebs~1controller" },
+  { "op": "remove", "path": "/spec/selector/vsm" }
+]

--- a/k8s/upgrades/0.6.0-0.7.0/tests/setup-percona-with-0.6.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/tests/setup-percona-with-0.6.sh
@@ -1,0 +1,24 @@
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.6.0.yaml
+kubectl apply -f https://openebs.github.io/charts/openebs-storageclasses-0.6.0.yaml
+
+echo "Waiting for m-apiserver to be ready"
+JSONPATH='{range .items[0]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; 
+until kubectl get pods -n openebs -l name=maya-apiserver -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True";
+do
+  echo -n "."
+  sleep 2; 
+done
+echo ""
+kubectl get pods -n openebs
+
+echo "Launching percona"
+kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/v0.6/k8s/demo/percona/percona-openebs-deployment.yaml
+
+JSONPATH='{range .items[0]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; 
+until kubectl get pods -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True";
+do
+  echo -n "."
+  sleep 2; 
+done
+echo ""
+kubectl get pods 

--- a/k8s/upgrades/0.6.0-0.7.0/tests/test-jiva-default-sp.yaml
+++ b/k8s/upgrades/0.6.0-0.7.0/tests/test-jiva-default-sp.yaml
@@ -1,0 +1,7 @@
+apiVersion: openebs.io/v1alpha1
+kind: StoragePool
+metadata:
+  name: default
+  type: hostdir
+spec:
+  path: "/mnt/openebs"

--- a/k8s/upgrades/0.6.0-0.7.0/tests/upgrade-operator-0.7.0.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/tests/upgrade-operator-0.7.0.sh
@@ -1,0 +1,12 @@
+
+kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.7.0.yaml
+
+echo "Waiting for default jiva pool to be ready"
+until kubectl get sp -l openebs.io/version 2>&1 | grep -q "default";
+do
+  echo -n "."
+  sleep 2; 
+done
+echo ""
+kubectl get pods -n openebs
+

--- a/k8s/upgrades/0.6.0-0.7.0/upgrade_sc.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/upgrade_sc.sh
@@ -56,7 +56,7 @@ for sc in `echo $sc_list | tr ":" " "`; do
        # Check if SC has other parameters and warn the user about patching them manually.
        # or contact openebs dev.
 
-       echo "Successfully upgraded $sc to 0.7."
+       echo "Successfully upgraded $sc to 0.7"
     fi
 done
 

--- a/k8s/upgrades/0.6.0-0.7.0/upgrade_sc.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/upgrade_sc.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+###############################################################################
+# STEP: Get Storage Classes                                                   #
+###############################################################################
+
+# Get the list of storageclasses, delimited by ':'
+sc_list=`kubectl get sc \
+ -o jsonpath="{range .items[*]}{@.metadata.name}:{end}"`
+rc=$?;
+if [ $rc -ne 0 ]; 
+then 
+  echo "ERROR: $rc"; 
+  echo "Please ensure `kubectl` is installed and can access your cluster."; 
+  exit; 
+fi
+
+echo "Check if openebs storage class parameters are moved to config annotation"
+for sc in `echo $sc_list | tr ":" " "`; do
+    pt="";pt=`kubectl get sc $sc -o jsonpath="{.provisioner}"`
+    if [ "openebs.io/provisioner-iscsi"  == "$pt" ];
+    then
+       uc="";uc=`kubectl get sc $sc -o jsonpath="{.metadata.labels.openebs\.io/cas-type}"`
+       if [ ! -z $uc ]; then 
+         echo "SC $sc already upgraded";
+         continue
+       fi
+
+       echo "Upgrading SC $sc";
+
+       replicas=`kubectl get sc $sc -o jsonpath="{.parameters.openebs\.io/jiva-replica-count}"`
+       pool=`kubectl get sc $sc -o jsonpath="{.parameters.openebs\.io/storage-pool}"`
+       monitoring=`kubectl get sc $sc -o jsonpath="{.parameters.openebs\.io/volume-monitor}"`
+
+       if [ -z replicas ]; then replicas="3"; fi
+       sed "s/@jiva-replica-count[^ \"]*/$replicas/g" sc.patch.tpl.yaml > sc.patch.tpl.yaml.0
+
+       if [ -z pool ]; then replicas="default"; fi
+       sed "s/@storage-pool[^ \"]*/$pool/g" sc.patch.tpl.yaml.0 > sc.patch.tpl.yaml.1
+
+       if [ -z monitoring ]; then replicas="true"; fi
+       sed "s/@volume-monitor[^ \"]*/$monitoring/g" sc.patch.tpl.yaml.1 > sc.patch.yaml
+
+       echo " openebs.io/jiva-replica-count -> ReplicaCount : $replicas"
+       echo " openebs.io/storage-pool -> StoragePool : $pool"
+       echo " openebs.io/volume-monitor -> VolumeMonitor : $monitoring"
+
+       kubectl patch sc $sc -p "$(cat sc.patch.yaml)"
+       rc=$?; if [ $rc -ne 0 ]; then echo "ERROR: $rc"; exit; fi
+
+       rm -rf sc.patch.tpl.yaml.0
+       rm -rf sc.patch.tpl.yaml.1
+       rm -rf sc.patch.yaml
+
+       #TODO
+       # Check if SC has other parameters and warn the user about patching them manually.
+       # or contact openebs dev.
+
+       echo "Successfully upgraded $sc to 0.7."
+    fi
+done
+
+


### PR DESCRIPTION
After upgrading the openebs-operator.yaml with 0.7 deployments, the following scripts will be helpful to upgrade:
- StorageClasses (upgrade_sc.sh)
- Existing PVs.     (upgrade_pv.sh)

Signed-off-by: kmova <kiran.mova@openebs.io>

