### PR TITLE
Add single sparse pool SPC and PVC yamls

### DIFF
--- a/k8s/sample-pv-yamls/pvc-sparse-claim-cstor.yaml
+++ b/k8s/sample-pv-yamls/pvc-sparse-claim-cstor.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-sparse-auto
+  annotations:
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "sparse-claim-auto"
+      #- name: TargetResourceLimits
+      #  value: |-
+      #      memory: 1Gi
+      #      cpu: 200m
+      #- name: AuxResourceLimits
+      #  value: |-
+      #      memory: 0.5Gi
+      #      cpu: 50m
+provisioner: openebs.io/provisioner-iscsi
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: percona-cstor-pvc
+spec:
+  storageClassName: openebs-cstor-sparse-auto
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/sample-pv-yamls/spc-sparse-single.yaml
+++ b/k8s/sample-pv-yamls/spc-sparse-single.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: sparse-claim-auto
+spec:
+  name: sparse-claim-auto
+  type: sparse
+  maxPools: 1
+  minPools: 1
+  poolSpec:
+    poolType: striped
+    overProvisioning: false


### PR DESCRIPTION
 These yamls will be helpful to create single pool storagepoolclaim
 and cstor volumes in a single node kubernetes clusters like
 minikube etc.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>
