### PR TITLE
Add cas-type annotations in travis test yamls

### DIFF
--- a/k8s/sample-pv-yamls/pvc-sparse-claim-cstor.yaml
+++ b/k8s/sample-pv-yamls/pvc-sparse-claim-cstor.yaml
@@ -4,6 +4,7 @@ kind: StorageClass
 metadata:
   name: openebs-cstor-sparse-auto
   annotations:
+    openebs.io/cas-type: cstor
     cas.openebs.io/config: |
       - name: StoragePoolClaim
         value: "sparse-claim-auto"
@@ -20,7 +21,7 @@ provisioner: openebs.io/provisioner-iscsi
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: percona-cstor-pvc
+  name: cstor-vol1-1r-claim
 spec:
   storageClassName: openebs-cstor-sparse-auto
   accessModes:

--- a/k8s/sample-pv-yamls/spc-sparse-single.yaml
+++ b/k8s/sample-pv-yamls/spc-sparse-single.yaml
@@ -10,4 +10,5 @@ spec:
   minPools: 1
   poolSpec:
     poolType: striped
+    cacheFile: /var/openebs/sparse/sparse-claim-auto.cache
     overProvisioning: false


### PR DESCRIPTION
We can get the cas template from env variales for volume and storagepool
related operations, if storageclass and SPC yamls doesn't have them.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

