### PR TITLE
Expose maya pod namespace/name using downward api

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -166,12 +166,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        # OPENEBS_MAYA_POD_NAMESPACE provides the namespaces of this pod as
-        # environment variable
-        - name: OPENEBS_MAYA_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
         # based on this config. This is ignored if empty.
         # This is supported for maya api server version 0.5.2 onwards

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -160,6 +160,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        # OPENEBS_MAYA_POD_NAME provides the name of this pod as
+        # environment variable
+        - name: OPENEBS_MAYA_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # OPENEBS_MAYA_POD_NAMESPACE provides the namespaces of this pod as
+        # environment variable
+        - name: OPENEBS_MAYA_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
         # based on this config. This is ignored if empty.
         # This is supported for maya api server version 0.5.2 onwards


### PR DESCRIPTION
This PR will update openebs-operator yaml to expose
maya-apiserver pod name and namespace using downward API.
This is required for following:
https://github.com/openebs/maya/pull/497
Signed-off-by: sonasingh46 <sonasingh46@gmail.com>
