### PR TITLE
chore(monitoring): Removing unused relabel_config entries in openebs-monitoring-pg.yaml.

### DIFF
--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -52,11 +52,9 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
-      - source_labels: [__meta_kubernetes_pod_label_vsm]
+      - source_labels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
         action: replace
         target_label: openebs_pv
-      - source_labels: [__meta_kubernetes_pod_label_openebs_pv]
-        action: keep
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: drop
         regex: '(.*)9501'

--- a/k8s/openebs-monitoring-pg.yaml
+++ b/k8s/openebs-monitoring-pg.yaml
@@ -52,6 +52,14 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+      # Below entry ending with vsm is deprecated and is maintained for
+      # backward compatibility purpose.
+      - source_labels: [__meta_kubernetes_pod_label_vsm]
+        action: replace
+        target_label: openebs_pv
+      # Below entry is the correct entry. Though the above and below entries
+      # are having same target_label as openebs_pv, only one of them will be
+      # valid for any release.
       - source_labels: [__meta_kubernetes_pod_label_openebs_io_persistent_volume]
         action: replace
         target_label: openebs_pv


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Removing the below unused relabel_config entry from openebs-monitoring-pg.yaml.
- Pod label: openebs_pv

Instead adding the following entry to make use of the latest label.
- Pod label: openebs.io/persistent-volume

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Refer: [openebs/openebs#507](https://github.com/openebs/maya/pull/507)
