### PR TITLE
Changed  the label to get the status of node disk manager

### DIFF
--- a/e2e/ansible/inventory/group_vars/all.yml
+++ b/e2e/ansible/inventory/group_vars/all.yml
@@ -98,6 +98,7 @@ cluster_type: managed
 
 storage_engine: jiva
 tag: ci
+ndm_tag: ci
 #Custom storage class names
 
 cstor_sc: openebs-cstor-disk

--- a/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
+++ b/e2e/ansible/playbooks/resiliency/test-ctrl-failure/test-ctrl-failure.yml
@@ -158,7 +158,7 @@
        - name: 4) Get the name of the controller/target deployment
          shell: >
            source ~/.profile; kubectl get deployments -n {{ ns }}
-           -l {{ pod_label }} --no-headers
+           -l {{ pod_label }} --no-headers | grep {{ namespace }}
          args:
            executable: /bin/bash
          delegate_to: "{{groups['kubernetes-kubemasters'].0}}"

--- a/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/defaults/main.yml
@@ -7,8 +7,4 @@ openebs_storageclasses_link: https://raw.githubusercontent.com/openebs/openebs/m
 
 openebs_storageclasses_alias: openebs-storageclasses.yaml
 
-# Image tag for openebs containers
-# Accepted entries (ci, latest): Default: latest
-test_tag: ci
-
 namespace: openebs

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -89,7 +89,7 @@
   register: node_count
 
 - name: Confirm if node-disk-manager is running in all the nodes
-  shell: source ~/.profile; kubectl get pods -n {{ namespace }} --selector=app=node-disk-manager | grep Running | wc -l
+  shell: source ~/.profile; kubectl get pods -n {{ namespace }} --selector=name=openebs-ndm | grep Running | wc -l
   args:
     executable: /bin/bash
   register: ndm_count

--- a/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
+++ b/e2e/ansible/roles/k8s-openebs-operator/tasks/main.yml
@@ -19,13 +19,20 @@
   replace:
     path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
     regexp: "{{item}}:[\\w.-]+"
-    replace: "{{item}}:{{ test_tag }}"
+    replace: "{{item}}:{{ tag }}"
   with_items:
     - m-apiserver
     - jiva
     - openebs-k8s-provisioner
     - snapshot-controller
     - snapshot-provisioner
+
+- name: Change the images of ndm resources to desired tag in operator YAML
+  replace:
+    path: "{{ ansible_env.HOME }}/{{ openebs_operator_alias }}"
+    regexp: "{{item}}:[\\w.-]+"
+    replace: "{{item}}:{{ ndm_tag }}"
+  with_items:
     - node-disk-manager-amd64
 
 - block:


### PR DESCRIPTION
Signed-off-by: sathyaseelan <sathyaseelan.n@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Changed the label to get the status of NDM operator
- Using namespaces to get the target pod in ctrl failure test case
@dargasudarshan can you please review this PR
- Included a task to change the test tag for node disk manager in openebs operator role