### PR TITLE
refactor(yaml): rename the storage class in the sample PVC specs to default SC

### DIFF
--- a/k8s/demo/pvc-standard-cstor-default.yaml
+++ b/k8s/demo/pvc-standard-cstor-default.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: demo-cstor-vol1-claim
 spec:
-  storageClassName: openebs-cstor-default-0.7.0
+  storageClassName: openebs-cstor-sparse 
   accessModes:
     - ReadWriteOnce
   resources:

--- a/k8s/demo/pvc-standard-jiva-default.yaml
+++ b/k8s/demo/pvc-standard-jiva-default.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: demo-vol1-claim
 spec:
-  storageClassName: openebs-standard
+  storageClassName: openebs-jiva-default
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Signed-off-by: ksatchit <karthik.s@openebs.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- The sample (storage-engine) specific PVC specs at k8s/demo (`pvc-standard*`) should use the default storage classes installed as part of the operator install (w/o depending on those installed via additional artifacts like openebs-storageclasses.yaml) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
