### PR TITLE
Add temporary workaround to cleanup stale disk entries for nodes.

### DIFF
--- a/e2e/ansible/ci_config.yaml
+++ b/e2e/ansible/ci_config.yaml
@@ -4,6 +4,7 @@ include_before:
  - setup-kubernetes.yml
  - setup-stern.yml
  - setup-openebs.yml
+ - cleanup-disks.yml
  - setup-disks.yml
  - create-cStorPool.yml
 include_after:

--- a/e2e/ansible/cleanup-disks.yml
+++ b/e2e/ansible/cleanup-disks.yml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+
+  tasks:
+
+    - name: Get list of disks attached
+      shell: source ~/.profile; kubectl get disks -l ndm.io/disk-type=disk --no-headers -o custom-columns=:metadata.name
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      register: diskList
+
+    - name: Delete stale disk entries
+      shell: source ~/.profile; kubectl delete disks {{ item }}
+      args:
+        executable: /bin/bash
+      delegate_to: "{{groups['kubernetes-kubemasters'].0}}"
+      with_items: "{{ diskList.stdout_lines }}"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- Add temporary workaround to cleanup stale disk entries for nodes which were scaled down and scaled up.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>