### PR TITLE
Changing the storage class in percona deployment spec

### DIFF
--- a/k8s/demo/percona/percona-openebs-deployment.yaml
+++ b/k8s/demo/percona/percona-openebs-deployment.yaml
@@ -48,7 +48,7 @@ apiVersion: v1
 metadata:
   name: demo-vol1-claim
 spec:
-  storageClassName: openebs-jiva-default
+  storageClassName: openebs-standard
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@cloudbyte.com>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
Changing the storage class in percona-deployment spec to openebs-standard. We are replacing this class with storage engine specific storage classes in all the playbooks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
