### PR TITLE
fix(CI): Use CI tagged image instead of release tag

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -99,7 +99,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: openebs/m-apiserver:0.7.0
+        image: openebs/m-apiserver:ci
         ports:
         - containerPort: 5656
         env:
@@ -113,8 +113,8 @@ spec:
         # This is supported for maya api server version 0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
-        # OPENEBS_IO_INSTALL_CONFIG_NAME specifies the config map containing the install configuration. 
-        # Currently, the configuration can be used to specifiy the default version for the CAS Templates 
+        # OPENEBS_IO_INSTALL_CONFIG_NAME specifies the config map containing the install configuration.
+        # Currently, the configuration can be used to specifiy the default version for the CAS Templates
         - name: OPENEBS_IO_INSTALL_CONFIG_NAME
           value: "maya-install-config"
         # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
@@ -141,21 +141,21 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.7.0"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.7.0"
+          value: "openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:0.7.0"
+          value: "openebs/cstor-istgt:ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:0.7.0"
+          value: "openebs/cstor-pool:ci"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "openebs/cstor-pool-mgmt:0.7.0"
+          value: "openebs/cstor-pool-mgmt:ci"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-mgmt:0.7.0"
+          value: "openebs/cstor-volume-mgmt:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.7.0"
+          value: "openebs/m-exporter:ci"
 ---
 apiVersion: v1
 kind: Service
@@ -188,7 +188,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:0.7.0
+        image: openebs/openebs-k8s-provisioner:ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -232,7 +232,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:0.7.0
+          image: openebs/snapshot-controller:ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -246,7 +246,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:0.7.0
+          image: openebs/snapshot-provisioner:ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -260,7 +260,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
 ---
-# This is the node-disk-manager related config. 
+# This is the node-disk-manager related config.
 # It can be used to customize the disks probes and filters
 apiVersion: v1
 kind: ConfigMap
@@ -335,7 +335,7 @@ spec:
         command:
         - /usr/sbin/ndm
         - start
-        image: openebs/node-disk-manager-amd64:v0.1.0
+        image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Use ci tagged image instead of release tag image (0.7) for all components in travis and other CI/CD runs.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>


