### PR TITLE
chore(maya): Add snapshot cast as environment variables m-apiserver.

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -156,6 +156,14 @@ spec:
           value: "openebs/cstor-volume-mgmt:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "openebs/m-exporter:ci"
+        - name: OPENEBS_IO_JIVA_CAS_TEMPLATE_TO_CREATE_SNAPSHOT
+          value: "jiva-snapshot-create-default-0.7.0"
+        - name: OPENEBS_IO_JIVA_CAS_TEMPLATE_TO_DELETE_SNAPSHOT
+          value: "jiva-snapshot-delete-default-0.7.0"
+        - name: OPENEBS_IO_CSTOR_CAS_TEMPLATE_TO_DELETE_SNAPSHOT
+          value: "cstor-snapshot-delete-default-0.7.0"
+        - name: OPENEBS_IO_CSTOR_CAS_TEMPLATE_TO_CREATE_SNAPSHOT
+          value: "cstor-snapshot-create-default-0.7.0"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
This is to support changes in maya as the snapshotting technique has changed and now uses cas templates.

Signed-off-by: princerachit <prince.rachit@mayadata.io>