### PR TITLE
Fixed a broken link

### DIFF
--- a/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
+++ b/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
@@ -22,7 +22,7 @@ At a very high level, the process to contributing and improving the code is pret
 - Submit your Pull Request
 
 The following sections describe some guidelines that can come in handy with the above process.
-*Followed by the guidelines, is a [cheatsheet](./contribute/git-cheatsheet.md) with frequently used git commands.*
+*Followed by the guidelines, is a [cheatsheet](https://github.com/openebs/openebs/blob/master/contribute/git-cheatsheet.md) with frequently used git commands.*
 
 ## Submit an issue describing your proposed change
 

--- a/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
+++ b/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
@@ -55,3 +55,4 @@ You can also help with some existing issues under this category available at [de
 - After the PR is merged the development branch in the forked repository can be deleted.
 
 If you need any help with git, refer to this [git cheat sheet](./git-cheatsheet.md) and go back to the [**contributing to OpenEBS Documentation**](../CONTRIBUTING.md) guide to proceed.
+

--- a/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
+++ b/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
@@ -55,4 +55,3 @@ You can also help with some existing issues under this category available at [de
 - After the PR is merged the development branch in the forked repository can be deleted.
 
 If you need any help with git, refer to this [git cheat sheet](./git-cheatsheet.md) and go back to the [**contributing to OpenEBS Documentation**](../CONTRIBUTING.md) guide to proceed.
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**: This will fix an broken link in the contribute section.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # 

**Special notes for your reviewer**:
The cheetsheet link on line 25 under Contribute\CONTRIBUTING-TO-DEVELOPER-DOC.md is broken, fixed the same.

Error
https://github.com/openebs/openebs/blob/master/contribute/contribute/git-cheatsheet.md

Working
https://github.com/openebs/openebs/blob/master/contribute/git-cheatsheet.md