### PR TITLE
refactor(install): use quay images as default

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -99,7 +99,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: openebs/m-apiserver:v0.7.x-ci
+        image: quay.io/openebs/m-apiserver:v0.7.x-ci
         ports:
         - containerPort: 5656
         env:
@@ -141,21 +141,21 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:v0.7.x-ci"
+          value: "quay.io/openebs/jiva:v0.7.x-ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:v0.7.x-ci"
+          value: "quay.io/openebs/jiva:v0.7.x-ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:v0.7.x-ci"
+          value: "quay.io/openebs/cstor-istgt:v0.7.x-ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:v0.7.x-ci"
+          value: "quay.io/openebs/cstor-pool:v0.7.x-ci"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "openebs/cstor-pool-mgmt:v0.7.x-ci"
+          value: "quay.io/openebs/cstor-pool-mgmt:v0.7.x-ci"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-mgmt:v0.7.x-ci"
+          value: "quay.io/openebs/cstor-volume-mgmt:v0.7.x-ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:v0.7.x-ci"
+          value: "quay.io/openebs/m-exporter:v0.7.x-ci"
 ---
 apiVersion: v1
 kind: Service
@@ -188,7 +188,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:v0.7.x-ci
+        image: quay.io/openebs/openebs-k8s-provisioner:v0.7.x-ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -232,7 +232,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:v0.7.x-ci
+          image: quay.io/openebs/snapshot-controller:v0.7.x-ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -246,7 +246,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:v0.7.x-ci
+          image: quay.io/openebs/snapshot-provisioner:v0.7.x-ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -272,41 +272,28 @@ data:
   # filterconfigs contails configs of filters - in ther form fo include
   # and exclude comma separated strings
   node-disk-manager.config: |
-    {
-      "probeconfigs": [
-        {
-          "key": "udev-probe",
-          "name": "udev probe",
-          "state": "true"
-        },
-        {
-          "key": "smart-probe",
-          "name": "smart probe",
-          "state": "true"
-        }
-      ],
-      "filterconfigs": [
-        {
-          "key": "os-disk-exclude-filter",
-          "name": "os disk exclude filter",
-          "state": "true"
-        },
-        {
-          "key": "vendor-filter",
-          "name": "vendor filter",
-          "state": "true",
-          "include":"",
-          "exclude":"CLOUDBYT,OpenEBS"
-        },
-        {
-          "key": "path-filter",
-          "name": "path filter",
-          "state": "true",
-          "include":"",
-          "exclude":"loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-"
-        }
-      ]
-    }
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "CLOUDBYT,OpenEBS"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: ""
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-"
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -335,7 +322,7 @@ spec:
         command:
         - /usr/sbin/ndm
         - start
-        image: openebs/node-disk-manager-amd64:v0.1.0
+        image: quay.io/openebs/node-disk-manager-amd64:ci
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
Update the openebs-operator.yaml to use quay images.
Also updated the NDM config to use the latest format and filters.

Signed-off-by: kmova <kiran.mova@mayadata.io>