### PR TITLE
fix(install): rename provisioner liveness probe

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -232,7 +232,7 @@ spec:
           exec:
             command:
             - pgrep
-            - ".*provisioner"
+            - ".*openebs"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename the provisioner liveness probe to check for `openebs` instead of `openebs-provisioner`, b/c process name getting truncated to `openebs-pro` in container once it starts which causes provisioner restarts

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>
