### PR TITLE
Add env to enable/disable data sharing

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -156,6 +156,10 @@ spec:
           value: "quay.io/openebs/cstor-volume-mgmt:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "quay.io/openebs/m-exporter:ci"
+        # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
+        # events to Google Analytics
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "true"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
If the value is truthy as per `strconv.ParseBool`, m-apiserver will send
usage data to OpenEBS core-developers.

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>

issue: https://github.com/openebs/openebs/issues/2257