### PR TITLE
Update es-data-svc.yaml

### DIFF
--- a/k8s/demo/efk/es/es-data-svc.yaml
+++ b/k8s/demo/efk/es/es-data-svc.yaml
@@ -6,7 +6,7 @@ metadata:
     component: elasticsearch
     role: data
 spec:
-  clusterIP: none
+  clusterIP: None
   selector:
     component: elasticsearch
     role: data


### PR DESCRIPTION
Fix demo error `The Service "elasticsearch-data" is invalid: spec.clusterIP: Invalid value: "none": must be empty, 'None', or a valid IP address`

Signed-off-by: Alex Slubsky <aslubsky@gmail.com>