### PR TITLE
fix(install): grant access to Jobs api object (#2267)

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -24,7 +24,7 @@ rules:
   resources: ["nodes", "nodes/proxy"]
   verbs: ["*"]
 - apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints", "configmaps"]
+  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints", "configmaps", "jobs"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]


### PR DESCRIPTION
After jiva volume is deleted, a job is scheduled to
perform the clean-up. For api-server to schedule the
jobs, the service account needs to have permission
to create jobs.

Refer: https://github.com/openebs/maya/pull/786

Signed-off-by: kmova <kiran.mova@openebs.io>
(cherry picked from commit 35d3344b6701974983de911cb7b4462ab223d930)

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
