### PR TITLE
Disk pattern /dev/md needs to be filtered out

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -332,7 +332,7 @@ data:
         name: path filter
         state: true
         include: ""
-        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-"
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md-"
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet


### PR DESCRIPTION
Following is the kubectl describe output for the unfiltered disk
kubectl describe disk disk-60f8ab1b1f6eedab231431c8de62183a
Name:         disk-60f8ab1b1f6eedab231431c8de62183a
Namespace:
Labels:       kubernetes.io/hostname=gke-gke-ssd-3zones-default-pool-da1e81a2-b0jn
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Creation Timestamp:  2018-11-22T14:27:36Z
  Generation:          1
  Resource Version:    26768
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-60f8ab1b1f6eedab231431c8de62183a
  UID:                 c25c4f7f-ee62-11e8-92ff-42010a80018c
Spec:
  Capacity:
    Logical Sector Size:  512
    Storage:              0
  Details:
    Compliance:
    Firmware Revision:
    Model:
    Serial:
    Vendor:
  Path:                 /dev/md0
Status:
  State:  Active
Events:   <none>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
