### PR TITLE
Unfix the ns and use the variable instead

### DIFF
--- a/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
+++ b/k8s/upgrades/0.6.0-0.7.0/pre_upgrade.sh
@@ -29,7 +29,7 @@ oens=$1
 
 
 echo
-VERSION_INSTALLED=`kubectl get deploy -n openebs -o yaml \
+VERSION_INSTALLED=`kubectl get deploy -n $oens -o yaml \
  | grep m-apiserver | grep image: \
  | awk -F ':' '{print $3}'`
 


### PR DESCRIPTION
Correct a little bug on the script as we fill the ns but its not used.

```
bash -x pre_upgrade.sh svc-openebs
+ '[' 1 -ne 1 ']'
+ oens=svc-openebs
+ echo

++ kubectl get deploy -n openebs -o yaml
++ grep m-apiserver
++ grep image:
++ awk -F : '{print $3}'
+ VERSION_INSTALLED=
+ echo 'Installed Version: '
Installed Version:
+ '[' -z ']'
+ echo 'Unable to determine installed openebs version'
Unable to determine installed openebs version
+ print_usage
+ echo

+ echo Usage:
Usage:
+ echo

+ echo 'pre_upgrade.sh <openebs-namespace>'
pre_upgrade.sh <openebs-namespace>
+ echo

+ echo '  <openebs-namepsace> Namespace where openebs control'
  <openebs-namepsace> Namespace where openebs control
+ echo '    plane pods like maya-apiserver are installed.    '
    plane pods like maya-apiserver are installed.
+ exit 1
```