### PR TITLE
ref(label, operator.yaml, charts) Add `openebs.io/component-name` label

### DIFF
--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm
+    openebs.io/component-name: ndm
 spec:
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: apiserver
+    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   selector:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: provisioner
+    openebs.io/component-name: openebs-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:

--- a/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: snapshot-operator
+    openebs.io/component-name: openebs-snapshot-operator
 spec:
   replicas: {{ .Values.snapshotOperator.replicas }}
   selector:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -79,6 +79,7 @@ spec:
     metadata:
       labels:
         name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -188,6 +189,7 @@ spec:
     metadata:
       labels:
         name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -240,6 +242,7 @@ spec:
     metadata:
       labels:
         name: openebs-snapshot-operator
+        openebs.io/component-name: openebs-snapshot-operator
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -336,6 +339,7 @@ spec:
     metadata:
       labels:
         name: openebs-ndm
+        openebs.io/component-name: ndm
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes


### PR DESCRIPTION
The `component` label is defined for all openebs-control
plane objects if openebs is installed through `helm`, this change adds
the same labels for `openebs-operator.yaml` so that there exist
predefined labels irrespective of the installation method.

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>


<br/>
<br/>
<br/>
<br/>

**Notes for reviewer**:
1. If openebs is installed through the `openebs-operator.yaml` and the `helm charts` as specified in the docs, the labels are different, this PR tries to bring them to a single set of labels which would be there in any case.

2. Adds `openebs.io/component-name=<cmp-name>` to OpenEBS components

3. Keeps the helm specific `component` as is.

(Q) Which issue this PR addresses ? 
(A) fixes: https://github.com/openebs/openebs/issues/2338

(Q) Tl; dr benefits for the end-user/scripts?
(A) The OpenEBS components can be found in a cluster easily, aggregated logs for all type=`X` OpenEBS components can be collected easily. Chaos on some of `Y` can be done, by touching `A` and not `B` but some of `C`.

[update]
1. [14th February, 2019] The diff with respect to master shows that only `openebs.io/component-name=X` labels have been added.