### PR TITLE
Removing configmap as they are now read only, 

### DIFF
--- a/k8s/demo/efk/fluentd/fluentd-ds.yaml
+++ b/k8s/demo/efk/fluentd/fluentd-ds.yaml
@@ -137,9 +137,6 @@ spec:
               mountPath: /var/lib/docker/containers
             - name: posloc
               mountPath: /tmp
-            - name: config
-              mountPath: /fluentd/etc/fluent.conf
-              subPath: fluent.conf
       volumes:
         - name: varlog
           hostPath:
@@ -147,9 +144,6 @@ spec:
         - name: varlibdockercontainers
           hostPath:
             path: /var/lib/docker/containers
-        - name: config
-          configMap:
-            name: fluentd
         - name: posloc
           hostPath:
-            path: /tmp            
+            path: /tmp


### PR DESCRIPTION
mirroring upstream fluentd daemon set.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
