### PR TITLE
refactor(operator): changes tags to v0.8.x-ci

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -85,7 +85,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/m-apiserver:ci
+        image: quay.io/openebs/m-apiserver:v0.8.x-ci
         ports:
         - containerPort: 5656
         env:
@@ -123,21 +123,21 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "quay.io/openebs/jiva:ci"
+          value: "quay.io/openebs/jiva:v0.8.x-ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "quay.io/openebs/jiva:ci"
+          value: "quay.io/openebs/jiva:v0.8.x-ci"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "quay.io/openebs/cstor-istgt:ci"
+          value: "quay.io/openebs/cstor-istgt:v0.8.x-ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "quay.io/openebs/cstor-pool:ci"
+          value: "quay.io/openebs/cstor-pool:v0.8.x-ci"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-pool-mgmt:ci"
+          value: "quay.io/openebs/cstor-pool-mgmt:v0.8.x-ci"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "quay.io/openebs/cstor-volume-mgmt:ci"
+          value: "quay.io/openebs/cstor-volume-mgmt:v0.8.x-ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "quay.io/openebs/m-exporter:ci"
+          value: "quay.io/openebs/m-exporter:v0.8.x-ci"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -194,7 +194,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/openebs-k8s-provisioner:ci
+        image: quay.io/openebs/openebs-k8s-provisioner:v0.8.x-ci
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -245,7 +245,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: quay.io/openebs/snapshot-controller:ci
+          image: quay.io/openebs/snapshot-controller:v0.8.x-ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -266,7 +266,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: quay.io/openebs/snapshot-provisioner:ci
+          image: quay.io/openebs/snapshot-provisioner:v0.8.x-ci
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This PR changes operator image tags to v0.8.x-ci so that travis can test
with the corresponding images of cstor pool and istgt