### PR TITLE
enhance(operator): Adds env var for jiva scrub image

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -138,6 +138,8 @@ spec:
           value: "quay.io/openebs/cstor-volume-mgmt:ci"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
           value: "quay.io/openebs/m-exporter:ci"
+        - name: OPENEBS_IO_SCRUB_IMAGE
+          value: "quay.io/openebs/openebs-tools:3.8"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit adds env variable for jiva volume delete the scrub job. Earlier this variable was hardcoded in runtask but after PR [openebs/maya#934](https://github.com/openebs/maya/pull/934) gets merged the image name can be taken from OPENEBS_IO_SCRUB_IMAGE env variable of m-apiserver.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->

Fixes : 
https://github.com/openebs/openebs/issues/2344