### PR TITLE
fix (yaml): changes for NDM configs in openebs operator and charts (cherry-pick #2383)

### DIFF
--- a/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
+++ b/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
@@ -19,6 +19,9 @@ data:
       - key: udev-probe
         name: udev probe
         state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: true
       - key: smart-probe
         name: smart probe
         state: true

--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -14,6 +14,8 @@ spec:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
       component: ndm
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -27,9 +29,6 @@ spec:
       - name: {{ template "openebs.name" . }}-ndm
         image: "{{ .Values.ndm.image }}:{{ .Values.ndm.imageTag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-        - /usr/sbin/ndm
-        - start
         securityContext:
           privileged: true
         env:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -303,6 +303,9 @@ data:
       - key: udev-probe
         name: udev probe
         state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: true
       - key: smart-probe
         name: smart probe
         state: true
@@ -328,6 +331,8 @@ metadata:
   name: openebs-ndm
   namespace: openebs
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -346,9 +351,6 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        command:
-        - /usr/sbin/ndm
-        - start
         image: quay.io/openebs/node-disk-manager-amd64:v0.2.0
         imagePullPolicy: IfNotPresent
         securityContext:


### PR DESCRIPTION
`seachest-probe` is included in the list of probes.
Update strategy changed to `RollingUpdate` for NDM DaemonSet.
Entrypoint of ndm image is changed to script instead of directly
executing the binary.
The changes have been made in both `openebs-operator.yaml` and charts

Cherry-pick #2383 
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
