### PR TITLE
refactor(operator): removes namespace from cluster role binding

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -56,7 +56,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-maya-operator
-  namespace: openebs
 subjects:
 - kind: ServiceAccount
   name: openebs-maya-operator


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit removes namespace field from `ClusterRoleBinding` as ClusterRoleBinding is a cluster scoped resource and doesnot need any namespace declaration in yaml.

*Notes for Reviewers*:
Output of `kubectl api-resources to confirm this` :
```
ashishranjan738@Ashish-PC:~/Project/go/src/github.com/openebs$ kubectl api-resources 
NAME                              SHORTNAMES   APIGROUP                       NAMESPACED   KIND
clusterrolebindings                            rbac.authorization.k8s.io      false        ClusterRoleBinding
clusterroles                                   rbac.authorization.k8s.io      false        ClusterRole
rolebindings                                   rbac.authorization.k8s.io      true         RoleBinding

```
