### PR TITLE
refactor(operator): removes namespace from cluster role binding

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -56,7 +56,6 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-maya-operator
-  namespace: openebs
 subjects:
 - kind: ServiceAccount
   name: openebs-maya-operator


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit removes namespace field from `ClusterRoleBinding` as ClusterRoleBinding is a cluster scoped resource and doesnot need any namespace declaration in yaml.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
