### PR TITLE
ref(label) Use `openebs.io/component-name=X` label for YAML & charts

### DIFF
--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm
+    openebs.io/component-name: ndm
 spec:
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: apiserver
+    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   selector:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: provisioner
+    openebs.io/component-name: openebs-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:

--- a/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: snapshot-operator
+    openebs.io/component-name: openebs-snapshot-operator
 spec:
   replicas: {{ .Values.snapshotOperator.replicas }}
   selector:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -79,6 +79,7 @@ spec:
     metadata:
       labels:
         name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -188,6 +189,7 @@ spec:
     metadata:
       labels:
         name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -240,6 +242,7 @@ spec:
     metadata:
       labels:
         name: openebs-snapshot-operator
+        openebs.io/component-name: openebs-snapshot-operator
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -336,6 +339,7 @@ spec:
     metadata:
       labels:
         name: openebs-ndm
+        openebs.io/component-name: ndm
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes


### PR DESCRIPTION
- Labels which are used by helm internally haven't been changed
- Just a new set of labels are added, which can be used by third-party
  clients, scripts for a variety of use cases such as log-aggregation,
  monitoring, etc

fixes: https://github.com/openebs/openebs/issues/2338

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>