### PR TITLE
fix(doc): fixes Update mount path of minio deployment

### DIFF
--- a/k8s/demo/minio/minio.yaml
+++ b/k8s/demo/minio/minio.yaml
@@ -41,7 +41,7 @@ spec:
         # Mount the volume into the pod
         volumeMounts:
         - name: storage # must match the volume name, above
-          mountPath: "/home/username"
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
       - This PR update mount path of minio from `/home/username` to `/storage`
    
       - sample deployment yaml of minio can be generated from https://minio.io/kubernetes.html
    
       - This commit fixes the mount path of minio
    
       Signed-off-by: inyee786 <intakhab.ali@mayadata.io>
