### PR TITLE
fix(readme): update install instructions to use helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ OpenEBS can be set up in a few easy steps. You can get going on your choice of K
 kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
 ```
 
-**Apply OpenEBS StorageClasses**
+**Start the OpenEBS Services using helm**
 ```bash
-# apply this yaml
-kubectl apply -f https://openebs.github.io/charts/openebs-storageclasses.yaml
+helm repo update
+helm install --namespace openebs --name openebs stable/openebs
 ```
 
 You could also follow our [QuickStart Guide](https://docs.openebs.io/docs/overview.html).

--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -42,10 +42,10 @@ OpenEBS kann in wenigen einfachen Schritten eingerichtet werden. Sie können Ihr
 kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
 ```
 
-**Anwenden von OpenEBS StorageClasses**
+**Starten Sie die OpenEBS Services mit dem helm**
 ```bash
-# dieses yaml anwenden
-kubectl gelten -f https://openebs.github.io/charts/openebs-storageclasses.yaml
+helm repo update
+helm install --namespace openebs --name openebs stable/openebs
 ```
 
 Sie können auch unserem [QuickStart Guide](https://docs.openebs.io/docs/overview.html) folgen.

--- a/translations/README.ru.md
+++ b/translations/README.ru.md
@@ -43,10 +43,11 @@ OpenEBS можно настроить с помощью нескольких п�
 kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
 ```
 
-1. Примените OpenEBS StorageClasses, используя `openebs-storageclasses.yaml`:
+1. Запустите службы OpenEBS с `helm`:
 
    ```bash
-   kubectl apply -f https://openebs.github.io/charts/openebs-storageclasses.yaml
+   helm repo update
+   helm install --namespace openebs --name openebs stable/openebs
    ```
 
    Вы также можете ознакомиться с нашим [Руководством по быстрому запуску](https://docs.openebs.io/docs/overview.html).

--- a/translations/README.tr.md
+++ b/translations/README.tr.md
@@ -43,11 +43,11 @@ OpenEBS birkaç kolay adımda kurulabilir. Kubernetes kümenizde (cluster) open-
 kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
 ```
 
-**OpenEBS Depolama Sınıflarını Uygula**
+**OpenEBS servislerini Helm ile başlatın**
 
 ```bash
-# bu yamayı uygula
-kubectl apply -f https://openebs.github.io/charts/openebs-storageclasses.yaml
+helm repo update
+helm install --namespace openebs --name openebs stable/openebs
 ```
 
 Ayrıca [Hızlı Başlangıç ​​Kılavuzu](https://docs.openebs.io/docs/overview.html)'nu da takip edebilirsiniz.


### PR DESCRIPTION
Add instructions to install openebs with helm. Also
removed the steps to install storage classes, as they
are no longer required. Storage Classes are installed
by maya-apiserver

Signed-off-by: kmova <kiran.mova@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
