### PR TITLE
feat(upgrade snapshotdata)patch volumesnapshotdata crs as a part of volume upgrades

### DIFF
--- a/k8s/upgrades/0.8.1-0.8.2/cstor_volume_upgrade.sh
+++ b/k8s/upgrades/0.8.1-0.8.2/cstor_volume_upgrade.sh
@@ -40,6 +40,7 @@ fi
 pv=$1
 ns=$2
 
+source snapshotdata_upgrade.sh
 # Check if pv exists
 kubectl get pv $pv &>/dev/null;check_pv=$?
 if [ $check_pv -ne 0 ]; then
@@ -58,7 +59,6 @@ cas_type=`kubectl get pv $pv -o jsonpath="{.metadata.labels.openebs\.io/cas-type
 if [ $cas_type != "cstor" ]; then
     echo "Cstor volume not found";exit 1;
 fi
-
 
 ### 1. Get the cstorvolume name related to the given PV ###
 ### get the cloned volume cstorvolume name if exists
@@ -176,6 +176,12 @@ version=$(verify_volume_version "deploy" $cv_deploy)
     ## 5. Remove the temporary patch file
     rm cstor-target-patch.json
 
+##Patch cstor snapshotdata crs related to pv
+run_snapshotdata_upgrades $pv
+rc=$?
+if [ $rc -ne 0 ]; then
+   exit 1
+fi
 
 echo "Successfully upgraded $pv to $target_upgrade_version Please run your application checks."
 exit 0

--- a/k8s/upgrades/0.8.1-0.8.2/jiva_volume_upgrade.sh
+++ b/k8s/upgrades/0.8.1-0.8.2/jiva_volume_upgrade.sh
@@ -40,6 +40,8 @@ fi
 pv=$1
 replica_node_label="openebs-jiva"
 
+source snapshotdata_upgrade.sh
+
 # Check if pv exists
 kubectl get pv $pv &>/dev/null;check_pv=$?
 if [ $check_pv -ne 0 ]; then
@@ -206,6 +208,13 @@ if [[ "$controller_svc_version" != "$target_upgrade_version" ]]; then
     rc=$?; if [ $rc -ne 0 ]; then echo "Failed to patch the service $svc | Exit code: $rc"; exit; fi
 else
     echo "Controller service $c_svc is already at $target_upgrade_version"
+fi
+
+##Patch jiva snapshotdata crs related to pv
+run_snapshotdata_upgrades $pv
+rc=$?
+if [ $rc -ne 0 ]; then
+   exit 1
 fi
 
 echo "Clearing temporary files"

--- a/k8s/upgrades/0.8.1-0.8.2/snapshotdata_upgrade.sh
+++ b/k8s/upgrades/0.8.1-0.8.2/snapshotdata_upgrade.sh
@@ -1,0 +1,38 @@
+run_snapshotdata_upgrades()
+{
+    if [ $# -eq 1 ]; then
+        pv=$1
+    else
+        echo "please pass persistentVolume name got pv: $pv"
+        exit 1
+    fi
+    # Get the list of volumesnapshotdata related to given PV
+    volumesnapshotdata_list=$(kubectl get volumesnapshotdata\
+                               -o jsonpath="{range .items[?(@.spec.persistentVolumeRef.name=='$pv')]}{@.metadata.name}:{end}")
+    rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "failed to get snapshotdata name list"
+        exit 1
+    fi
+
+    if [ ! -z $volumesnapshotdata_list ]; then
+
+        pv_size=""
+        pv_size=$(kubectl get pv $pv -o jsonpath='{.spec.capacity.storage}')
+        rc=$?
+        if [ $rc -ne 0 ]; then
+            echo "failed to get pv: $pv size"
+            exit 1
+        fi
+
+        ## update volumesnapshotdata-patch.tpl.json with pv size
+        sed "s|@size@|$pv_size|g" volumesnapshotdata-patch.tpl.json > volumesnapshotdata-patch.json
+        for snapdata_name in `echo $volumesnapshotdata_list | tr ":" " "`; do
+            ## patch volumesnapshotdata cr ###
+            kubectl patch volumesnapshotdata $snapdata_name -p "$(cat volumesnapshotdata-patch.json)" --type=merge
+            rc=$?; if [ $rc -ne 0 ]; then echo "Error occured while upgrading volumesnapshotdata name: $snapdata_name Exit Code: $rc"; exit; fi
+        done
+        ## Removes temporary file
+        rm volumesnapshotdata-patch.json
+    fi
+}

--- a/k8s/upgrades/0.8.1-0.8.2/volumesnapshotdata-patch.tpl.json
+++ b/k8s/upgrades/0.8.1-0.8.2/volumesnapshotdata-patch.tpl.json
@@ -1,0 +1,7 @@
+{
+  "spec": {
+     "openebsVolume": {
+        "capacity": "@size@"
+     }
+  }
+}


### PR DESCRIPTION
This PR patches capacity field with pv size in volume snapshot data cr. 

After volume patch is successful snapshotdata cr will have the capacity field
Ex:
```
Name:         k8s-volume-snapshot-c09cb83f-4fe8-11e9-9628-0242ac110005
Namespace:    
Labels:       <none>
Annotations:  <none>
API Version:  volumesnapshot.external-storage.k8s.io/v1
Kind:         VolumeSnapshotData
Metadata:
  Creation Timestamp:  2019-03-26T17:01:09Z
  Generation:          2
  Resource Version:    3864
  Self Link:           /apis/volumesnapshot.external-storage.k8s.io/v1/volumesnapshotdatas/k8s-volume-snapshot-c09cb83f-4fe8-11e9-9628-0242ac110005
  UID:                 c09d0b07-4fe8-11e9-88c2-28d2440cdb59
Spec:
  Openebs Volume:
    Capacity:     5G
    Snapshot Id:  pvc-3e2db393-4fe8-11e9-88c2-28d2440cdb59_snapshot-demo-cstor2_1553619668275212085
  Persistent Volume Ref:
    Kind:  PersistentVolume
    Name:  pvc-3e2db393-4fe8-11e9-88c2-28d2440cdb59
  Volume Snapshot Ref:
    Kind:  VolumeSnapshot
    Name:  default/snapshot-demo-cstor2-bfe03940-4fe8-11e9-88c2-28d2440cdb59
Status:
  Conditions:
    Last Transition Time:  2019-03-26T17:01:09Z
    Message:               Snapshot created successfully
    Reason:                
    Status:                True
    Type:                  Ready
  Creation Timestamp:      <nil>
Events:                    <none>
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
