### PR TITLE
chore(operator yaml): set default sparse pool creation to false

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -103,7 +103,7 @@ spec:
         # configured as a part of openebs installation.
         # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
-          value: "true"
+          value: "false"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE


### PR DESCRIPTION
Set default pool creation flag to false.

NOTE:
- As part of this commit, we intend to use sparse pool for testing purposes only
- Sparse pool should be used by end users

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>