### PR TITLE
feat(demo-app): Include demo mongodb statefulset(1r) yaml with target affinity

### DIFF
--- a/k8s/demo/mongodb/demo-mongo-cstor-taa.yaml
+++ b/k8s/demo/mongodb/demo-mongo-cstor-taa.yaml
@@ -1,0 +1,66 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+ name: mongo
+ labels:
+   app: mongo
+spec:
+ ports:
+ - port: 27017
+   targetPort: 27017
+ clusterIP: None
+ selector:
+   role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+ name: mongo
+ labels: 
+   app: mongo
+   openebs.io/target-affinity: mongo 
+spec:
+ serviceName: "mongo"
+ replicas: 1
+ template:
+   metadata:
+     labels:
+       app: mongo
+       role: mongo
+       openebs.io/target-affinity: mongo
+       environment: test
+   spec:
+     terminationGracePeriodSeconds: 10
+     containers:
+       - name: mongo
+         image: mongo
+         command:
+                 #    - mongod
+                 #    - "--replSet"
+                 #    - rs0
+                 #    - "--smallfiles"
+                 #    - "--noprealloc"
+                 #    - "--bind_ip_all"
+         ports:
+           - containerPort: 27017
+         volumeMounts:
+           - name: mongo-pvc
+             mountPath: /data/db
+       - name: mongo-sidecar
+         image: cvallance/mongo-k8s-sidecar
+         env:
+           - name: MONGO_SIDECAR_POD_LABELS
+             value: "role=mongo,environment=test"
+ volumeClaimTemplates:
+ - metadata:
+     name: mongo-pvc
+     labels: 
+       openebs.io/target-affinity: mongo
+   spec:
+     storageClassName: openebs-cstor-sparse 
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 5G


### PR DESCRIPTION
Signed-off-by: Sudarshan <sudarshan.darga@cloudbyte.com>

- Include demo mongodb statefulset deployed with single replica with target affinity.
- Currently target affinity is supported for single replica statefulset.

