### PR TITLE
chore(ci script): update ci script to replace storagepool object operations with that of cstorpool

### DIFF
--- a/k8s/ci/test-script.sh
+++ b/k8s/ci/test-script.sh
@@ -55,8 +55,8 @@ dumpMayaAPIServerLogs 200
 kubectl get pods --all-namespaces
 
 
-#Print the default StoragePools Created
-kubectl get sp
+#Print the default cstor pools Created
+kubectl get csp
 
 #Print the default StoragePoolClaim Created
 kubectl get spc
@@ -129,7 +129,7 @@ export MAPIPOD=$(kubectl get pods -o jsonpath='{.items[?(@.spec.containers[0].na
 export CSTORVOL=$(kubectl get pv -o jsonpath='{.items[?(@.spec.claimRef.name=="cstor-vol1-1r-claim")].metadata.name}')
 export CSTORVOLNS=$(kubectl get pv -o jsonpath='{.items[?(@.spec.claimRef.name=="openebs-pvc-in-custom-ns")].metadata.name}')
 export JIVAVOL=$(kubectl get pv -o jsonpath='{.items[?(@.metadata.annotations.openebs\.io/cas-type=="jiva")].metadata.name}')
-export POOLNAME=$(kubectl get storagepools -o jsonpath='{.items[?(@.metadata.labels.openebs\.io/cas-type=="cstor")].metadata.name}')
+export POOLNAME=$(kubectl get csp -o jsonpath='{.items[?(@.metadata.labels.openebs\.io/cas-type=="cstor")].metadata.name}')
 
 echo "------------------Extracted Pod names---------------------"
 echo MAPIPOD: $MAPIPOD


### PR DESCRIPTION
This PR will replace storagepool object operations with cstorpool
operations.
storagepool objects are being deprecated as part of upcoming openebs releases.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
