### PR TITLE
chore(upgrade): ndm version update to v0.3.5

### DIFF
--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -64,7 +64,8 @@ spec:
         - name: udev
           mountPath: /run/udev
         - name: procmount
-          mountPath: /host/mounts
+          mountPath: /host/proc
+          readOnly: true
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
         - name: sparsepath
@@ -79,11 +80,12 @@ spec:
         hostPath:
           path: /run/udev
           type: Directory
-      # mount /proc/1/mounts (mount file of process 1 of host) inside container
-      # to read which partition is mounted on / path
+      # mount /proc (to access mount file of process 1 of host) inside container
+      # to read mount-point of disks and partitions
       - name: procmount
         hostPath:
-          path: /proc/1/mounts
+          path: /proc
+          type: Directory
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
       - name: sparsepath

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -47,7 +47,7 @@ snapshotOperator:
 
 ndm:
   image: "quay.io/openebs/node-disk-manager-amd64"
-  imageTag: "v0.2.0"
+  imageTag: "v0.3.5"
   sparse:
     enabled: "true"
     path: "/var/openebs/sparse"

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -354,7 +354,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:v0.3.4
+        image: quay.io/openebs/node-disk-manager-amd64:v0.3.5
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
@@ -366,7 +366,8 @@ spec:
         - name: udev
           mountPath: /run/udev
         - name: procmount
-          mountPath: /host/mounts
+          mountPath: /host/proc
+          readOnly: true
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -400,11 +401,12 @@ spec:
         hostPath:
           path: /run/udev
           type: Directory
-      # mount /proc/1/mounts (mount file of process 1 of host) inside container
-      # to read which partition is mounted on / path
+      # mount /proc (to access mount file of process 1 of host) inside container
+      # to read mount-point of disks and partitions
       - name: procmount
         hostPath:
-          path: /proc/1/mounts
+          path: /proc
+          type: Directory
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse


### PR DESCRIPTION
ndm version updated to v0.3.5. Also instead of mounting `/proc/1/mounts`, `/proc` will be mounted as ReadOnly inside the container and from there the mounts file of PID 1 will be accessed.

Cherry-Pick : #2538 
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
