### PR TITLE
cherry-pick(operator): cherrypick of PR's 2528

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -39,7 +39,7 @@ rules:
   resources: [ "disks"]
   verbs: ["*" ]
 - apiGroups: ["*"]
-  resources: [ "storagepoolclaims", "storagepools"]
+  resources: [ "storagepoolclaims", "storagepoolclaims/finalizers", "storagepools"]
   verbs: ["*" ]
 - apiGroups: ["*"]
   resources: [ "castemplates", "runtasks"]


### PR DESCRIPTION
This PR contains the cherry pick of following PR's
Cherry-pick:
- https://github.com/openebs/openebs/pull/2528 [Adds clusterRole permission for storagepoolclaim subresources to add owner refereneces, due to constraints in openshift clusters ]