### PR TITLE
feat(operator): adds the openebs.io/version label to the localpv provisioner

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -519,6 +519,7 @@ spec:
       labels:
         name: openebs-localpv-provisioner
         openebs.io/component-name: openebs-localpv-provisioner
+        openebs.io/version: 0.9.0
     spec:
       serviceAccountName: openebs-maya-operator
       containers:


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

This PR adds the openebs.io/version label to the openebs localpv provisioner (pod).

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
