### PR TITLE
docs(examples): update demo yamls localpv hostpath

### DIFF
--- a/k8s/demo/dbench/README.md
+++ b/k8s/demo/dbench/README.md
@@ -122,7 +122,7 @@ policies similar to the replica count in 0.9. These values are translated
 into a configuration file (istgt.conf) that resides within the target pod. 
 To modify them, 
  `kubectl exec -it -n openebs <cstor-target-pod> -c cstor-istgt /bin/bash`
-  - cd /usr/local/istgt
+  - cd /usr/local/etc/istgt
   - sed -i '/Luworkers 6/c\  Luworkers 1' istgt.conf
   - check for the istgt process `ps -aux`
   - kill -9 pid <istgt-pid>

--- a/k8s/demo/dbench/dbench-cstor-r1-seq.yaml
+++ b/k8s/demo/dbench/dbench-cstor-r1-seq.yaml
@@ -1,0 +1,43 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: dbench-cpvr1s-claim
+spec:
+  storageClassName: openebs-cstor-r1-seq
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dbench-cpvr1s
+spec:
+  template:
+    spec:
+      containers:
+      - name: dbench-cpvr1s
+        image: logdna/dbench:latest
+        imagePullPolicy: Always
+        env:
+          - name: DBENCH_MOUNTPOINT
+            value: /data
+          # - name: DBENCH_QUICK
+          #   value: "yes"
+          - name: FIO_SIZE
+            value: 1G
+          - name: FIO_OFFSET_INCREMENT
+            value: 256M
+          # - name: FIO_DIRECT
+          #   value: "0"
+        volumeMounts:
+        - name: dbench-pv
+          mountPath: /data
+      restartPolicy: Never
+      volumes:
+      - name: dbench-pv
+        persistentVolumeClaim:
+          claimName: dbench-cpvr1s-claim
+  backoffLimit: 4

--- a/k8s/demo/dbench/dbench-cstor-r1.yaml
+++ b/k8s/demo/dbench/dbench-cstor-r1.yaml
@@ -1,0 +1,43 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: dbench-cpvr1-claim
+spec:
+  storageClassName: openebs-cstor-r1
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dbench-cpvr1
+spec:
+  template:
+    spec:
+      containers:
+      - name: dbench-cpvr1
+        image: logdna/dbench:latest
+        imagePullPolicy: Always
+        env:
+          - name: DBENCH_MOUNTPOINT
+            value: /data
+          # - name: DBENCH_QUICK
+          #   value: "yes"
+          - name: FIO_SIZE
+            value: 1G
+          - name: FIO_OFFSET_INCREMENT
+            value: 256M
+          # - name: FIO_DIRECT
+          #   value: "0"
+        volumeMounts:
+        - name: dbench-pv
+          mountPath: /data
+      restartPolicy: Never
+      volumes:
+      - name: dbench-pv
+        persistentVolumeClaim:
+          claimName: dbench-cpvr1-claim
+  backoffLimit: 4

--- a/k8s/demo/dbench/dbench-localpvhostpath.yaml
+++ b/k8s/demo/dbench/dbench-localpvhostpath.yaml
@@ -1,0 +1,43 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: dbench-lpvhp-claim
+spec:
+  storageClassName: openebs-hostpath
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dbench-lpvhp
+spec:
+  template:
+    spec:
+      containers:
+      - name: dbench-lpvhp
+        image: logdna/dbench:latest
+        imagePullPolicy: Always
+        env:
+          - name: DBENCH_MOUNTPOINT
+            value: /data
+          # - name: DBENCH_QUICK
+          #   value: "yes"
+          - name: FIO_SIZE
+            value: 1G
+          - name: FIO_OFFSET_INCREMENT
+            value: 256M
+          # - name: FIO_DIRECT
+          #   value: "0"
+        volumeMounts:
+        - name: dbench-pv
+          mountPath: /data
+      restartPolicy: Never
+      volumes:
+      - name: dbench-pv
+        persistentVolumeClaim:
+          claimName: dbench-lpvhp-claim
+  backoffLimit: 4

--- a/k8s/demo/dbench/sc-cstor-single-replica-seq.yaml
+++ b/k8s/demo/dbench/sc-cstor-single-replica-seq.yaml
@@ -1,0 +1,20 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-r1-seq
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "sparse-claim-auto"
+      - name: ReplicaCount
+        value: "1"
+      #- name: TargetNodeSelector
+      #  value: |-
+      #      "kubernetes.io/hostname": "gke-kmova-helm-default-pool-a169cf59-kxfm"
+      - name: Luworkers
+        value: "12"
+      - name: QueueDepth
+        value: "32"
+provisioner: openebs.io/provisioner-iscsi
+---

--- a/k8s/demo/dbench/sc-cstor-single-replica.yaml
+++ b/k8s/demo/dbench/sc-cstor-single-replica.yaml
@@ -1,0 +1,16 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-r1
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "sparse-claim-auto"
+      - name: ReplicaCount
+        value: "1"
+      - name: TargetNodeSelector
+        value: |-
+            "kubernetes.io/hostname": "gke-kmova-helm-default-pool-a169cf59-kxfm"
+provisioner: openebs.io/provisioner-iscsi
+---

--- a/k8s/demo/mongodb/demo-mongo-localpvhostpath.yaml
+++ b/k8s/demo/mongodb/demo-mongo-localpvhostpath.yaml
@@ -1,0 +1,62 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+ name: mongo
+ labels:
+   app: mongo
+spec:
+ ports:
+ - port: 27017
+   targetPort: 27017
+ clusterIP: None
+ selector:
+   role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+ name: mongo
+ labels: 
+   app: mongo
+spec:
+ serviceName: "mongo"
+ replicas: 3
+ template:
+   metadata:
+     labels:
+       app: mongo
+       role: mongo
+       environment: test
+   spec:
+     terminationGracePeriodSeconds: 10
+     containers:
+       - name: mongo
+         image: mongo
+         command:
+                 #    - mongod
+                 #    - "--replSet"
+                 #    - rs0
+                 #    - "--smallfiles"
+                 #    - "--noprealloc"
+                 #    - "--bind_ip_all"
+         ports:
+           - containerPort: 27017
+         volumeMounts:
+           - name: mongo-pvc
+             mountPath: /data/db
+       - name: mongo-sidecar
+         image: cvallance/mongo-k8s-sidecar
+         env:
+           - name: MONGO_SIDECAR_POD_LABELS
+             value: "role=mongo,environment=test"
+ volumeClaimTemplates:
+ - metadata:
+     name: mongo-pvc
+   spec:
+     storageClassName: openebs-hostpath
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 5G


### PR DESCRIPTION
This PR updates the examples of mongo and dbench
with option of using Local PV (hostpath)

Also updated the bench YAMLs with example on using
configurable Luworkers and QueueDepth parameters.

Signed-off-by: kmova <kiran.mova@openebs.io>

