### PR TITLE
docs(examples): provide sample YAMLs for jiva pods in OpenEBS ns

### DIFF
--- a/k8s/demo/dbench/sc-cstor-single-replica-seq.yaml
+++ b/k8s/demo/dbench/sc-cstor-single-replica-seq.yaml
@@ -9,6 +9,7 @@ metadata:
         value: "sparse-claim-auto"
       - name: ReplicaCount
         value: "1"
+      #Use below to pin the target pod to the host where cstor pool is running.
       #- name: TargetNodeSelector
       #  value: |-
       #      "kubernetes.io/hostname": "gke-kmova-helm-default-pool-a169cf59-kxfm"

--- a/k8s/demo/dbench/sc-cstor-single-replica.yaml
+++ b/k8s/demo/dbench/sc-cstor-single-replica.yaml
@@ -9,8 +9,10 @@ metadata:
         value: "sparse-claim-auto"
       - name: ReplicaCount
         value: "1"
-      - name: TargetNodeSelector
-        value: |-
-            "kubernetes.io/hostname": "gke-kmova-helm-default-pool-a169cf59-kxfm"
+      #To pin the target to the node where pool is provisioned, 
+      #provide the hostname label as follows.
+      #- name: TargetNodeSelector
+      #  value: |-
+      #      "kubernetes.io/hostname": "gke-kmova-helm-default-pool-a169cf59-kxfm"
 provisioner: openebs.io/provisioner-iscsi
 ---

--- a/k8s/sample-pv-yamls/pvc-jiva-pods-in-openebs-ns.yaml
+++ b/k8s/sample-pv-yamls/pvc-jiva-pods-in-openebs-ns.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-jpo-ns
+spec:
+  storageClassName: jiva-pods-in-openebs-ns
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4G
+

--- a/k8s/sample-pv-yamls/sc-jiva-pods-in-openebs-ns.yaml
+++ b/k8s/sample-pv-yamls/sc-jiva-pods-in-openebs-ns.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: jiva-pods-in-openebs-ns
+  annotations:
+    openebs.io/cas-type: jiva
+    cas.openebs.io/config: |
+      - name: DeployInOpenEBSNamespace
+        enabled: "true"
+provisioner: openebs.io/provisioner-iscsi
+---
+


### PR DESCRIPTION
Add the StorageClass and PVC Sample YAML for deploying
the jiva pods in OpenEBS namespace.

Note: Also resolves the comments received in a previous PR: https://github.com/openebs/openebs/pull/2559#pullrequestreview-236363609

Signed-off-by: kmova <kiran.mova@openebs.io>
