### PR TITLE
fix(upgrade,cstorvolume): use cas-type labels instead of annotation

### DIFF
--- a/k8s/upgrades/0.8.2-0.9.0/cstor/cstor-pool-update-082-090.yaml
+++ b/k8s/upgrades/0.8.2-0.9.0/cstor/cstor-pool-update-082-090.yaml
@@ -9,7 +9,7 @@ spec:
   - name: baseVersion
     value: "0.8.2"
   - name: targetVersion
-    value: "v0.9.0-RC1"
+    value: "0.9.0-RC3"
   - name: cstorPoolImageTag
     value: "v0.9.x-ci"
   - name: cstorPoolMgmtImageTag

--- a/k8s/upgrades/0.8.2-0.9.0/cstor/cstor-volume-update-082-090.yaml
+++ b/k8s/upgrades/0.8.2-0.9.0/cstor/cstor-volume-update-082-090.yaml
@@ -174,7 +174,7 @@ spec:
     objectName: {{ .UpgradeItem.name }}
     runNamespace: {{ .UpgradeItem.namespace }}
   post: |
-    {{- jsonpath .JsonResult "{.metadata.annotations.openebs\\.io/cas-type}" | trim | saveAs "getPVDetails.volCASType" .TaskResult | noop -}}
+    {{- jsonpath .JsonResult "{.metadata.labels.openebs\\.io/cas-type}" | trim | saveAs "getPVDetails.volCASType" .TaskResult | noop -}}
     {{- .TaskResult.getPVDetails.volCASType | notFoundErr "volume CAS type not found" | saveIf "getPVDetails.notFoundErr" .TaskResult | noop -}}
 
     {{- jsonpath .JsonResult "{.spec.storageClassName}" | trim | saveAs "getPVDetails.storageClassName" .TaskResult | noop -}}


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

Use labels `cast-type` label instead  `cast-type` annotation , as Clone PV object doesn't have the `cas-type` as annotation . And its better idea to use labels instead of annotations.

1. Clone PV:

```yaml
 kubectl get pv pvc-f00c2ad8-9760-4ec6-8420-c9a55aae48d3 -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    pv.kubernetes.io/provisioned-by: volumesnapshot.external-storage.k8s.io/snapshot-promoter
    snapshotProvisionerIdentity: volumesnapshot.external-storage.k8s.io/snapshot-promoter
  creationTimestamp: "2019-05-20T13:09:24Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    openebs.io/cas-type: cstor
    openebs.io/storageclass: openebs-cstor-sparse-auto
  name: pvc-f00c2ad8-9760-4ec6-8420-c9a55aae48d3
  resourceVersion: "1643"
  selfLink: /api/v1/persistentvolumes/pvc-f00c2ad8-9760-4ec6-8420-c9a55aae48d3
  uid: ba8fdcc5-4f53-488c-a2fe-177d099b9414

```
2. Simple PV:

```yaml

kubectl get pv pvc-b146d13b-b2e7-4540-bcba-b47e0e4edda2 -oyaml
apiVersion: v1
kind: PersistentVolume
metadata:
  annotations:
    openEBSProvisionerIdentity: 127.0.0.1
    openebs.io/cas-type: cstor
    pv.kubernetes.io/provisioned-by: openebs.io/provisioner-iscsi
  creationTimestamp: "2019-05-20T13:05:00Z"
  finalizers:
  - kubernetes.io/pv-protection
  labels:
    openebs.io/cas-type: cstor
    openebs.io/storageclass: openebs-cstor-sparse-auto
  name: pvc-b146d13b-b2e7-4540-bcba-b47e0e4edda2
  resourceVersion: "1206"
  selfLink: /api/v1/persistentvolumes/pvc-b146d13b-b2e7-4540-bcba-b47e0e4edda2
  uid: 90aa4f16-b3bb-41b7-931e-8331b447e142

```
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
