### PR TITLE
fix(yaml): revert ndm version to 0.3.5

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -363,7 +363,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:ci
+        image: quay.io/openebs/node-disk-manager-amd64:v0.3.5
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
revert ndm version to `v0.3.5`. `ci` image has many breaking changes. Therefore, reverting till new changes are updated in maya.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
