### PR TITLE
fix(travis): revert support of creating cStor pools on block device

### DIFF
--- a/k8s/ci/test-script.sh
+++ b/k8s/ci/test-script.sh
@@ -69,19 +69,19 @@ sleep 10
 #echo "------------------ Deploy Pre-release features ---------------------------"
 #kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-pre-release-features.yaml
 
-echo "------------------------ Create block device claim --------------- "
-##TODO: Remove below snippet once manual BDC is supported to create cStor pools
-#### Get name of blockdevice to claim the blockdevice ####
-block_device_name=$(kubectl get blockdevice -n ${NS} -o jsonpath='{.items[*].metadata.name}')
-wget https://raw.githubusercontent.com/openebs/openebs/master/k8s/sample-pv-yamls/blockdeviceclaim.yaml -O temp_bdc.yaml
-sed "s|sparse-1234|$block_device_name|g" temp_bdc.yaml > bdc.yaml
-kubectl apply -f bdc.yaml
-sleep 15
-block_device_status=$(kubectl get blockdevice -n ${NS} -o jsonpath='{.items[*].status.claimState}')
-echo "BlockDevice: ${block_device_name} Claimstate: ${block_device_status}"
-rm temp_bdc.yaml
+#echo "------------------------ Create block device claim --------------- "
+###TODO: Remove below snippet once manual BDC is supported to create cStor pools
+##### Get name of blockdevice to claim the blockdevice ####
+#block_device_name=$(kubectl get blockdevice -n ${NS} -o jsonpath='{.items[*].metadata.name}')
+#wget https://raw.githubusercontent.com/openebs/openebs/master/k8s/sample-pv-yamls/blockdeviceclaim.yaml -O temp_bdc.yaml
+#sed "s|sparse-1234|$block_device_name|g" temp_bdc.yaml > bdc.yaml
+#kubectl apply -f bdc.yaml
+#sleep 15
+#block_device_status=$(kubectl get blockdevice -n ${NS} -o jsonpath='{.items[*].status.claimState}')
+#echo "BlockDevice: ${block_device_name} Claimstate: ${block_device_status}"
+#rm temp_bdc.yaml
 
-echo "------------------------ Create block device storagepoolclaim --------------- "
+echo "------------------------ Create disk storagepoolclaim --------------- "
 # delete the storagepoolclaim created earlier and create new spc with min/max pool
 # count 1
 kubectl delete spc --all

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -363,7 +363,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:ci
+        image: quay.io/openebs/node-disk-manager-amd64:v0.3.5
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR is to fix travis failure in `openebs/maya` by reverting support of creating cStor pools on block device

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
