### PR TITLE
feat(autoprovisioning, blockdevice): add support to create cStor pools on sparse block device

### DIFF
--- a/k8s/sample-pv-yamls/spc-sparse-single.yaml
+++ b/k8s/sample-pv-yamls/spc-sparse-single.yaml
@@ -5,7 +5,7 @@ metadata:
   name: sparse-claim-auto
 spec:
   name: sparse-claim-auto
-  type: blockdevice
+  type: sparse
   maxPools: 1
   minPools: 1
   poolSpec:


### PR DESCRIPTION
Add support to create sparse based or disk based cstor pools.
User needs to set _`spec.type`_ type as **`sparse`** or **`disk`**.

### Auto Provisioning:
1. If cstor pools need to be created on _top of sparse disks_.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-sparse
spec:
  name: cstor-sparse
  type: sparse
  maxPools: 3
  poolSpec:
    poolType: striped
    overProvisioning: false
```

2. If cstor pools need to be created _on top of disks attached to the node_.
```yaml
apiVersion: openebs.io/v1alpha1
kind: StoragePoolClaim
metadata:
  name: cstor-disk
spec:
  name: cstor-disk
  type: disk
  maxPools: 3
  poolSpec:
    poolType: mirrored
    overProvisioning: false
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
