### PR TITLE
fix(upgrade,ndm): component ndm label on 0.9-1.0 pre-upgrade script

### DIFF
--- a/k8s/upgrades/0.9.0-1.0.0/pre-upgrade.sh
+++ b/k8s/upgrades/0.9.0-1.0.0/pre-upgrade.sh
@@ -295,7 +295,7 @@ for spc_name in `echo $spc_list | tr ":" " "`; do
     fi
 done
 
-ds_name=$(kubectl get pod -n $ns -l openebs.io/component-name=ndm \
+ds_name=$(kubectl get pod -n $ns -l component=ndm \
          -o jsonpath='{.items[0].metadata.ownerReferences[?(@.kind=="DaemonSet")].name}')
 rc=$?; if [ $rc -ne 0 ]; then echo "Failed to get ndm daemonset name in namespace: $ns | Exit Code: $rc"; error_msg; exit 1; fi
 


### PR DESCRIPTION
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->

Fix this error message when executing `pre-upgrade.sh` from 0.9 to 1.0 
```
Failed to get ndm daemonset name in namespace: openebs
```

The label used `openebs.io/component-name=ndm` is for deployment, for the pods is `component=ndm`.