### PR TITLE
Chore(jiva, snapshot): Script for snapshot cleanup

### DIFF
--- a/k8s/jiva/patch.json
+++ b/k8s/jiva/patch.json
@@ -3,9 +3,9 @@
            "ports": [
                 {
                     "name": "iscsi",
-                    "port": 3260,
+                    "port": 50000,
                     "protocol": "TCP",
-                    "targetPort": 3260
+                    "targetPort": 50000
                 },
                 {
                     "name": "api",

--- a/k8s/jiva/patch.json
+++ b/k8s/jiva/patch.json
@@ -1,0 +1,24 @@
+{
+    "spec": {
+           "ports": [
+                {
+                    "name": "iscsi",
+                    "port": 3260,
+                    "protocol": "TCP",
+                    "targetPort": 3260
+                },
+                {
+                    "name": "api",
+                    "port": 9501,
+                    "protocol": "TCP",
+                    "targetPort": 9501
+                },
+                {
+                    "name": "exporter",
+                    "port": 9500,
+                    "protocol": "TCP",
+                    "targetPort": 9500
+                }
+           ]
+        }
+    }

--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -1,67 +1,138 @@
 #!/bin/bash
-
 usage()
 {
-    echo "Usage: bash script.sh <controller_pod_name> <pvc_namespace> <numbber_of_snapshots_to_delete>"
+    echo "Usage: ./ snapshot-cleanup.sh <pv-name> <number_of_snapshots_to_delete>"
     exit 1
 }
 
-delete_jiva_snapshot()
+warning()
 {
-ctrl_pod_name=$1
-ctrl_namespace=$2
-number_of_snapshot=$3
-count=0
-snapshot_list_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep -v ID | wc -l'
-snapshot_name_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep -v ID | awk 'NR==2''
-
-if [ $(eval $snapshot_list_cmd) -le $((number_of_snapshot-1)) ]; then
- echo "Provided number of snapshots are not present"
-else
- block_service
- while [ $count -lt $((number_of_snapshot-1)) ]
- do 
-   snapshot_name=$(eval $snapshot_name_cmd | tr -d '\r')
-   del_cmd="kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot rm $snapshot_name"
-   eval $del_cmd
-   count=$((count+1))
-   validate_snap_delete $snapshot_name
- done
- unblock_service
-fi
+    echo "WARNING: Snapshot cleanup involves disconnecting the application from the storage. Also, while the snapshot cleanup is in progress - you will need to ensure that the connectivity to the Kubernetes Clusters is active. In case of unexpected disconnect, you will have to run the following command to restore the volume service. snapshot-cleanup.sh <pv-name> restore_service."
+    echo "Do you want to continue (Y/N)"
+    read access
+    if [ $access == "N" ]; then
+    exit 1;
+    fi
 }
 
-#This fuction is changeing the selector field the of controller service to block connection requests.
+# spin prints ('|','/','-','\','|') in cyclic order while snapshot deletion is in progres.
+spin()
+{
+    while true
+    do
+      stat /proc/$pid > /dev/null
+      if [ $? -ne 0 ]
+      then
+          break
+      fi
+      printf "\b${sp:i++%${#sp}:1}"
+      sleep 1
+    done
+}
+
+# delete_jiva_snapshot deletes jiva-snapshots(based on the arguments passed for number of snapshots to be deleted) using jivactl 
+delete_jiva_snapshot()
+{   
+    warning
+    min_required_snapshot=4
+    count=0
+    
+    snapshot_list_cmd=$(kubectl exec -it $ctrl_pod_name -n $pvc_namespace -- jivactl snapshot ls)
+    if [ "$?" != "0" ]; then
+       exit 1;
+    fi
+
+    snapshot_number_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep -v ID | wc -l'
+    snapshot_name_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep -v ID | tail -1'
+
+    if [ $(eval $snapshot_number_cmd) -le $((number_of_snapshot-1)) ]; then
+        echo "Error: You have requested to delete. $number_of_snapshot. There are only $(($(eval $snapshot_number_cmd) - $min_required_snapshot)). snapshot that can be deleted snapshots available on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less."
+        exit 1 ;
+    else
+            if [ $(eval $snapshot_number_cmd) -gt $(($min_required_snapshot + $number_of_snapshot)) ]; then
+                block_service
+                echo "Deleting snapshots"
+                delete_snap > /dev/null 2&>1 &
+                pid=$!
+                spin
+                cat log.txt
+                unblock_service
+                rm -rf log.txt
+            else
+                echo "Error: You have requested to delete. $number_of_snapshot. There are only $(($(eval $snapshot_number_cmd) - $min_required_snapshot)). snapshot that can be deleted snapshots available on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less." ;
+            fi
+        fi
+}
+
+# block_service changes target port value with different value
+# To restrict io's to happen
 block_service()
 {
-ctrl_service_name=$(kubectl get service -n $ctrl_namespace -l openebs.io/controller-service=jiva-controller-svc -o jsonpath='{.items[0].metadata.name}')
-kubectl patch svc $ctrl_service_name -n $ctrl_namespace --type merge -p "$(cat patch.json)" 
+    kubectl patch svc $ctrl_service_name -n $pvc_namespace --type merge -p "$(cat tmp.json)"  
 }
 
-#This fuction is restoring the selector field of the controller service.
+
+# unblock_service restores the actual target port value to allow io's
 unblock_service()
 {
-kubectl patch svc $ctrl_service_name -n $ctrl_namespace -p "{\"spec\":{\"selector\":{\"openebs.io/persistent-volume\": \"$pv_name\"}}}"
-kubectl patch svc $ctrl_service_name -n $ctrl_namespace --type merge -p "$(cat patch.json)" 
-sed -i 's/3260/3261/g' patch.json
+    restart_ctrl
+    sed -i 's/50000/3260/g' tmp.json
+    kubectl patch svc $ctrl_service_name -n $pvc_namespace --type merge -p "$(cat tmp.json)"
+    rm tmp.json
 }
 
-#This function validates for snapshot deletetion using jivactl
+# restart_ctrl restart the contoller pod
+restart_ctrl()
+{
+    kubectl delete pod $ctrl_pod_name -n $pvc_namespace
+}
+
 validate_snap_delete()
 {
-del_snapshot_name=$1
-validate_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep $del_snapshot_name'
-eval $validate_cmd
-if [ $? == "0" ]; then
- echo "Unable to delete $del_snapshot_name"
- unblock_service ;
- exit 1;
-fi
+    del_snapshot_name=$1
+    validate_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep $del_snapshot_name'
+    eval $validate_cmd
+    if [ $? != "0" ]; then
+        echo "Unable to delete $del_snapshot_name" ;
+        unblock_service ;
+        exit 1;
+    fi
 }
 
+delete_snap()
+{
+    while [ $count -lt $number_of_snapshot ]
+    do
+       snapshot_name=$(eval $snapshot_name_cmd | tr -d '\r')
+       del_cmd="kubectl exec -it $ctrl_pod_name -n $pvc_namespace -- jivactl snapshot rm $snapshot_name"
+       eval $($del_cmd >> log.txt) 
+       count=$((count+1))
+       validate_snap_delete $snapshot_name 
+    done 
+}
+ 
+i=1
+sp="/-\|"
+echo -n ' '
+touch log.txt
+rm -rf tmp.json 
+cat patch.json > tmp.json 
+pv_name=$1
+number_of_snapshot=$2
+pvc_namespace=$(kubectl get pv $pv_name -o jsonpath='{.spec.claimRef.namespace}')
+ctrl_pod_name=$(kubectl get pod -n $pvc_namespace -l openebs.io/persistent-volume=$pv_name,openebs.io/controller=jiva-controller -o jsonpath='{.items[0].metadata.name}')
+ctrl_service_name=$(kubectl get service -n $pvc_namespace -l openebs.io/controller-service=jiva-controller-svc,openebs.io/persistent-volume=$pv_name -o jsonpath='{.items[0].metadata.name}')
 
-if [ $# -ne 3 ]; then
+    
+if [ $# -ne 2 ]; then
     usage
-fi 
-
-delete_jiva_snapshot $1 $2 $3
+elif [ $# -eq 2 ] && [ $2 == "restore_service" ]; then
+    unblock_service ;
+    exit 1
+elif [ $# -eq 2 ] && [ $2 != "restore_service" ]; then
+    if [ $2 -ge 0 2>/dev/null ]; then
+       delete_jiva_snapshot $1 $2 ;
+    else
+       usage
+    fi
+fi

--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -2,27 +2,27 @@
 
 usage()
 {
-    echo "Usage: bash script.sh <controller_pod_name> <application_namespace> <numbber_of_snapshots_to_delete>"
+    echo "Usage: bash script.sh <controller_pod_name> <pvc_namespace> <numbber_of_snapshots_to_delete>"
     exit 1
 }
 
 delete_jiva_snapshot()
 {
 ctrl_pod_name=$1
-application_namespace=$2
+ctrl_namespace=$2
 number_of_snapshot=$3
 count=0
-snapshot_list_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep -v ID | wc -l'
-snapshot_name_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep -v ID | awk 'NR==2''
+snapshot_list_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep -v ID | wc -l'
+snapshot_name_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep -v ID | awk 'NR==2''
 
-if [ $(eval $snapshot_list_cmd) -le $((number_of_snapshot)) ]; then
+if [ $(eval $snapshot_list_cmd) -le $((number_of_snapshot-1)) ]; then
  echo "Provided number of snapshots are not present"
 else
  block_service
- while [ $count -lt $number_of_snapshot ]
+ while [ $count -lt $((number_of_snapshot-1)) ]
  do 
    snapshot_name=$(eval $snapshot_name_cmd | tr -d '\r')
-   del_cmd="kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot rm $snapshot_name"
+   del_cmd="kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot rm $snapshot_name"
    eval $del_cmd
    count=$((count+1))
    validate_snap_delete $snapshot_name
@@ -34,15 +34,15 @@ fi
 #This fuction is changeing the selector field the of controller service to block connection requests.
 block_service()
 {
-ctrl_service_name=$(kubectl get service -n $application_namespace -l openebs.io/controller-service=jiva-controller-svc -o jsonpath='{.items[0].metadata.name}')
-kubectl patch svc $ctrl_service_name -n $application_namespace --type merge -p "$(cat patch.json)" 
+ctrl_service_name=$(kubectl get service -n $ctrl_namespace -l openebs.io/controller-service=jiva-controller-svc -o jsonpath='{.items[0].metadata.name}')
+kubectl patch svc $ctrl_service_name -n $ctrl_namespace --type merge -p "$(cat patch.json)" 
 }
 
 #This fuction is restoring the selector field of the controller service.
 unblock_service()
 {
-kubectl patch svc $ctrl_service_name -n $application_namespace -p "{\"spec\":{\"selector\":{\"openebs.io/persistent-volume\": \"$pv_name\"}}}"
-kubectl patch svc $ctrl_service_name -n $application_namespace --type merge -p "$(cat patch.json)" 
+kubectl patch svc $ctrl_service_name -n $ctrl_namespace -p "{\"spec\":{\"selector\":{\"openebs.io/persistent-volume\": \"$pv_name\"}}}"
+kubectl patch svc $ctrl_service_name -n $ctrl_namespace --type merge -p "$(cat patch.json)" 
 sed -i 's/3260/3261/g' patch.json
 }
 
@@ -50,7 +50,7 @@ sed -i 's/3260/3261/g' patch.json
 validate_snap_delete()
 {
 del_snapshot_name=$1
-validate_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep $del_snapshot_name'
+validate_cmd='kubectl exec -it $ctrl_pod_name -n $ctrl_namespace -- jivactl snapshot ls | grep $del_snapshot_name'
 eval $validate_cmd
 if [ $? == "0" ]; then
  echo "Unable to delete $del_snapshot_name"

--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -35,18 +35,15 @@ fi
 block_service()
 {
 ctrl_service_name=$(kubectl get service -n $application_namespace -l openebs.io/controller-service=jiva-controller-svc -o jsonpath='{.items[0].metadata.name}')
-ctrl_val=$(kubectl get svc $ctrl_service_name -n $application_namespace -o jsonpath='{.spec.selector.openebs\.io/controller}')
-pv_name=$(kubectl get svc $ctrl_service_name -n $application_namespace -o jsonpath='{.spec.selector.openebs\.io/persistent-volume}')
-  
-kubectl patch svc $ctrl_service_name -n $application_namespace -p '{"spec":{"selector":{"openebs.io/persistent-volume": "snap-del"}}}'
-kubectl patch svc $ctrl_service_name -n $application_namespace -p '{"spec":{"selector":{"openebs.io/controller": "snap-del"}}}'
+kubectl patch svc $ctrl_service_name -n $application_namespace --type merge -p "$(cat patch.json)" 
 }
 
 #This fuction is restoring the selector field of the controller service.
 unblock_service()
 {
 kubectl patch svc $ctrl_service_name -n $application_namespace -p "{\"spec\":{\"selector\":{\"openebs.io/persistent-volume\": \"$pv_name\"}}}"
-kubectl patch svc $ctrl_service_name -n $application_namespace -p "{\"spec\":{\"selector\":{\"openebs.io/controller\": \"$ctrl_val\"}}}"
+kubectl patch svc $ctrl_service_name -n $application_namespace --type merge -p "$(cat patch.json)" 
+sed -i 's/3260/3261/g' patch.json
 }
 
 #This function validates for snapshot deletetion using jivactl

--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+usage()
+{
+    echo "Usage: bash script.sh <controller_pod_name> <application_namespace> <numbber_of_snapshots_to_delete>"
+    exit 1
+}
+
+delete_jiva_snapshot()
+{
+ctrl_pod_name=$1
+application_namespace=$2
+number_of_snapshot=$3
+count=0
+snapshot_list_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep -v ID | wc -l'
+snapshot_name_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep -v ID | awk 'NR==2''
+
+if [ $(eval $snapshot_list_cmd) -le $((number_of_snapshot)) ]; then
+ echo "Provided number of snapshots are not present"
+else
+ while [ $count -lt $number_of_snapshot ]
+ do 
+   snapshot_name=$(eval $snapshot_name_cmd | tr -d '\r')
+   del_cmd="kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot rm $snapshot_name"
+   eval $del_cmd
+   count=$((count+1))
+ done
+fi
+}
+
+if [ $# -ne 3 ]; then
+    usage
+fi 
+
+delete_jiva_snapshot $1 $2 $3

--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -24,9 +24,22 @@ else
    del_cmd="kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot rm $snapshot_name"
    eval $del_cmd
    count=$((count+1))
+   validate_snap_delete $snapshot_name
  done
 fi
 }
+
+validate_snap_delete()
+{
+del_snapshot_name=$1
+validate_cmd='kubectl exec -it $ctrl_pod_name -n $application_namespace -- jivactl snapshot ls | grep $del_snapshot_name'
+eval $validate_cmd
+if [ $? == "0" ]; then
+ echo "Unable to delete $del_snapshot_name"
+ exit 1;
+fi
+}
+
 
 if [ $# -ne 3 ]; then
     usage


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>
**This PR includes:**
- A bash script `snapshot-cleanup.sh` for jiva snapshot cleanup
- This script takes three agruments <contoller_pod_name>, <namespace_of_application> & <number_of_snapshots_to_delete>.
- Command to execute this script: **bash snapshot-cleanup.sh <contoller_pod_name> <namespace_of_application> <number_of_snapshot_to_delete>**


**Following is the log of script:**
```
 kubectl exec -it pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns -- jivactl snapshot ls
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
ID
5c9a0f79-53e0-4673-8b74-5a482fcb73dd
52ac94c3-8bb9-4d35-9a54-f06200a2c54f
afcf244d-10f3-4907-b4af-d861d0402a50
60e76335-b0f4-46d9-a7b7-fde8c5ede961
[root@master-1558702621 ~]# vi script.sh 
[root@master-1558702621 ~]# bash script.sh pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl app-percona-ns 3
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
INFO[0000] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.4.11:9502 
INFO[0002] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.4.11:9502 
INFO[0002] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.6.13:9502 
INFO[0005] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.6.13:9502 
INFO[0005] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.2.14:9502 
INFO[0008] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-52ac94c3-8bb9-4d35-9a54-f06200a2c54f.img on tcp://172.23.2.14:9502 
deleted snapshot: 52ac94c3-8bb9-4d35-9a54-f06200a2c54f
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
INFO[0000] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.4.11:9502 
INFO[0001] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.4.11:9502 
INFO[0001] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.6.13:9502 
INFO[0003] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.6.13:9502 
INFO[0003] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.2.14:9502 
INFO[0004] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-afcf244d-10f3-4907-b4af-d861d0402a50.img on tcp://172.23.2.14:9502 
deleted snapshot: afcf244d-10f3-4907-b4af-d861d0402a50
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
Defaulting container name to pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-con.
Use 'kubectl describe pod/pvc-e8450d7a-970d-11e9-8b36-0050569846e3-ctrl-b4bbf575c-hbcjl -n app-percona-ns' to see all of the containers in this pod.
INFO[0000] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.4.11:9502 
INFO[0002] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.4.11:9502 
INFO[0002] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.6.13:9502 
INFO[0004] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.6.13:9502 
INFO[0004] Coalescing volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img to volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.2.14:9502 
INFO[0007] Replace volume-snap-5c9a0f79-53e0-4673-8b74-5a482fcb73dd.img with volume-snap-60e76335-b0f4-46d9-a7b7-fde8c5ede961.img on tcp://172.23.2.14:9502 
deleted snapshot: 60e76335-b0f4-46d9-a7b7-fde8c5ede961
```