### PR TITLE
refact(upgrade): helm upgrade to specific version instead of latest

### DIFF
--- a/k8s/upgrades/0.7.0-0.8.0/README.md
+++ b/k8s/upgrades/0.7.0-0.8.0/README.md
@@ -54,9 +54,14 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.8.0.yaml
 
 Before upgrading using helm, please review the default values available with latest stable/openebs chart. (https://raw.githubusercontent.com/helm/charts/master/stable/openebs/values.yaml).
 
-- If the default values seem appropriate, you can use the `helm upgrade --reset-values <release name> stable/openebs`.
+- If the default values seem appropriate, you can use the below commands to update OpenEBS. [More](https://hub.helm.sh/charts/stable/openebs) details about the specific chart version.
+  ```sh
+  $ helm upgrade --reset-values <release name> stable/openebs --version 0.8.1
+  ```
 - If not, customize the values into your copy (say custom-values.yaml), by copying the content from above default yamls and edit the values to suite your environment. You can upgrade using your custom values using:
-`helm upgrade <release name> stable/openebs -f custom-values.yaml`
+  ```sh
+  $ helm upgrade <release name> stable/openebs --version 0.8.1 -f custom-values.yaml`
+  ```
 
 ##### Note: 0.8.1 is the helm chart version that corresponds to OpenEBS 0.8.0 version. All available openebs helm charts can be found here https://hub.kubeapps.com/charts/stable/openebs.
 

--- a/k8s/upgrades/0.8.0-0.8.1/README.md
+++ b/k8s/upgrades/0.8.0-0.8.1/README.md
@@ -62,9 +62,14 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.8.1.yaml
 
 Before upgrading using helm, please review the default values available with latest stable/openebs chart. (https://raw.githubusercontent.com/helm/charts/master/stable/openebs/values.yaml).
 
-- If the default values seem appropriate, you can use the `helm upgrade --reset-values <release name> stable/openebs`.
+- If the default values seem appropriate, you can use the below commands to update OpenEBS. [More](https://hub.helm.sh/charts/stable/openebs) details about the specific chart version.
+  ```sh
+  $ helm upgrade --reset-values <release name> stable/openebs --version 0.8.3
+  ```
 - If not, customize the values into your copy (say custom-values.yaml), by copying the content from above default yamls and edit the values to suite your environment. You can upgrade using your custom values using:
-`helm upgrade <release name> stable/openebs -f custom-values.yaml`
+  ```sh
+  $ helm upgrade <release name> stable/openebs --version 0.8.3 -f custom-values.yaml`
+  ```
 
 #### Using customized operator YAML or helm chart.
 As a first step, you must update your custom helm chart or YAML with 0.8.1 release tags and changes made in the values/templates.

--- a/k8s/upgrades/0.8.1-0.8.2/README.md
+++ b/k8s/upgrades/0.8.1-0.8.2/README.md
@@ -56,9 +56,14 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.8.2.yaml
 
 Before upgrading using helm, please review the default values available with latest stable/openebs chart. (https://raw.githubusercontent.com/helm/charts/master/stable/openebs/values.yaml).
 
-- If the default values seem appropriate, you can use the `helm upgrade --reset-values <release name> stable/openebs`.
+- If the default values seem appropriate, you can use the below commands to update OpenEBS. [More](https://hub.helm.sh/charts/stable/openebs) details about the specific chart version.
+  ```sh
+  $ helm upgrade --reset-values <release name> stable/openebs --version 0.8.6
+  ```
 - If not, customize the values into your copy (say custom-values.yaml), by copying the content from above default yamls and edit the values to suite your environment. You can upgrade using your custom values using:
-`helm upgrade <release name> stable/openebs -f custom-values.yaml`
+  ```sh
+  $ helm upgrade <release name> stable/openebs --version 0.8.6 -f custom-values.yaml`
+  ```
 
 #### Using customized operator YAML or helm chart.
 As a first step, you must update your custom helm chart or YAML with 0.8.2 release tags and changes made in the values/templates.

--- a/k8s/upgrades/0.8.2-0.9.0/README.md
+++ b/k8s/upgrades/0.8.2-0.9.0/README.md
@@ -54,9 +54,14 @@ kubectl apply -f https://openebs.github.io/charts/openebs-operator-0.9.0.yaml
 
 Before upgrading using helm, please review the default values available with latest stable/openebs chart. (https://raw.githubusercontent.com/helm/charts/master/stable/openebs/values.yaml).
 
-- If the default values seem appropriate, you can use the `helm upgrade --reset-values <release name> stable/openebs`.
+- If the default values seem appropriate, you can use the below commands to update OpenEBS. [More](https://hub.helm.sh/charts/stable/openebs) details about the specific chart version.
+   ```sh
+  $ helm upgrade --reset-values <release name> stable/openebs --version 0.9.2
+  ```
 - If not, customize the values into your copy (say custom-values.yaml), by copying the content from above default yamls and edit the values to suite your environment. You can upgrade using your custom values using:
-`helm upgrade <release name> stable/openebs -f custom-values.yaml`
+  ```sh
+  $ helm upgrade <release name> stable/openebs --version 0.9.2 -f custom-values.yaml`
+  ```
 
 #### Using customized operator YAML or helm chart.
 As a first step, you must update your custom helm chart or YAML with 0.9.0 release tags and changes made in the values/templates.

--- a/k8s/upgrades/0.9.0-1.0.0/README.md
+++ b/k8s/upgrades/0.9.0-1.0.0/README.md
@@ -97,10 +97,14 @@ $ kubectl apply -f https://openebs.github.io/charts/openebs-operator-1.0.0.yaml
 
 Before upgrading using helm, please review the default values available with latest stable/openebs chart. (https://raw.githubusercontent.com/helm/charts/master/stable/openebs/values.yaml).
 
-
-- If the default values seem appropriate, you can use the `helm upgrade --reset-values <release name> stable/openebs`.
+- If the default values seem appropriate, you can use the below commands to update OpenEBS. [More](https://hub.helm.sh/charts/stable/openebs) details about the specific chart version.
+  ```sh
+  $ helm upgrade --reset-values <release name> stable/openebs --version 1.0.0
+  ```
 - If not, customize the values into your copy (say custom-values.yaml), by copying the content from above default yamls and edit the values to suite your environment. You can upgrade using your custom values using:
-`helm upgrade <release name> stable/openebs -f custom-values.yaml`
+  ```sh
+  $ helm upgrade <release name> stable/openebs --version 1.0.0 -f custom-values.yaml`
+  ```
 
 #### Using customized operator YAML or helm chart.
 As a first step, you must update your custom helm chart or YAML with 1.0.0 release tags and changes made in the values/templates.


### PR DESCRIPTION
 Changes update the `helm upgrde` steps to use --version tag to
 upgrade to specific release version.

 for example if you are in 0.9.2 helm chart version and wants to upgrade
 to latest 1.0.0 openebs version using chart(1.0.0), then command will be:
 ```
 helm upgrade openebs stable/openebs --version 1.0.0
 ```

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
