### PR TITLE
fix(examples): add local pv samples and fix incorrect images. 

### DIFF
--- a/k8s/demo/dbench/README.md
+++ b/k8s/demo/dbench/README.md
@@ -1,5 +1,5 @@
 This folder contains sample YAMLs for running bench marking tests
-using fio scripts present at [logdna/dbench](https://github.com/logdna/dbench/). 
+using fio scripts present at [openebs/fbench](https://github.com/openebs/fbench/). 
 
 To get optimal performance, it is essential to tune the storage settings for the
 type of workload and as well as customize the storage to run along side 

--- a/k8s/demo/dbench/dbench-jdefault-r1.yaml
+++ b/k8s/demo/dbench/dbench-jdefault-r1.yaml
@@ -31,7 +31,7 @@ spec:
         kubernetes.io/hostname: gke-kmova-perf-default-pool-8691dea0-512r
       containers:
       - name: dbench-jd
-        image: logdna/dbench:latest
+        image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
           - name: DBENCH_MOUNTPOINT

--- a/k8s/demo/dbench/dbench-jdefault.yaml
+++ b/k8s/demo/dbench/dbench-jdefault.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: dbench-jd
-        image: logdna/dbench:latest
+        image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
           - name: DBENCH_MOUNTPOINT

--- a/k8s/demo/dbench/dbench-localpv-hostdevice.yaml
+++ b/k8s/demo/dbench/dbench-localpv-hostdevice.yaml
@@ -1,13 +1,27 @@
 ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: dbench-lpv-hd-claim
+spec:
+  storageClassName: openebs-device
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: dbench-hp
+  name: dbench-hd
 spec:
   template:
     spec:
+      #nodeSelector:
+      #  kubernetes.io/hostname: gke-kmova-helm-default-pool-2fc7a594-gtbb
       containers:
-      - name: dbench-hp
+      - name: dbench-hd
         image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
@@ -27,6 +41,6 @@ spec:
       restartPolicy: Never
       volumes:
       - name: dbench-pv
-        hostPath:
-          path: /var/openebs/dbench-data
+        persistentVolumeClaim:
+          claimName: dbench-lpv-hd-claim
   backoffLimit: 4

--- a/k8s/demo/dbench/dbench-localssd.yaml
+++ b/k8s/demo/dbench/dbench-localssd.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: dbench-localssd
-        image: logdna/dbench:latest
+        image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
           - name: DBENCH_MOUNTPOINT

--- a/k8s/demo/dbench/dbench-ns.yaml
+++ b/k8s/demo/dbench/dbench-ns.yaml
@@ -9,7 +9,7 @@ spec:
         kubernetes.io/hostname: gke-kmova-perf-default-pool-8691dea0-512r
       containers:
       - name: dbench
-        image: logdna/dbench:latest
+        image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
           - name: DBENCH_MOUNTPOINT

--- a/k8s/demo/dbench/dbench.yaml
+++ b/k8s/demo/dbench/dbench.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
       - name: dbench
-        image: logdna/dbench:latest
+        image: openebs/fbench:latest
         imagePullPolicy: Always
         env:
           - name: DBENCH_MOUNTPOINT

--- a/k8s/demo/mongodb/demo-mongo-localpvhostdevice.yaml
+++ b/k8s/demo/mongodb/demo-mongo-localpvhostdevice.yaml
@@ -1,0 +1,62 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+ name: mongo
+ labels:
+   app: mongo
+spec:
+ ports:
+ - port: 27017
+   targetPort: 27017
+ clusterIP: None
+ selector:
+   role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+ name: mongo
+ labels: 
+   app: mongo
+spec:
+ serviceName: "mongo"
+ replicas: 3
+ template:
+   metadata:
+     labels:
+       app: mongo
+       role: mongo
+       environment: test
+   spec:
+     terminationGracePeriodSeconds: 10
+     containers:
+       - name: mongo
+         image: mongo
+         command:
+                 #    - mongod
+                 #    - "--replSet"
+                 #    - rs0
+                 #    - "--smallfiles"
+                 #    - "--noprealloc"
+                 #    - "--bind_ip_all"
+         ports:
+           - containerPort: 27017
+         volumeMounts:
+           - name: mongo-pvc
+             mountPath: /data/db
+       - name: mongo-sidecar
+         image: cvallance/mongo-k8s-sidecar
+         env:
+           - name: MONGO_SIDECAR_POD_LABELS
+             value: "role=mongo,environment=test"
+ volumeClaimTemplates:
+ - metadata:
+     name: mongo-pvc
+   spec:
+     storageClassName: openebs-device
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 5G

--- a/k8s/demo/mongodb/demo-mongo-localpvhostpath.yaml
+++ b/k8s/demo/mongodb/demo-mongo-localpvhostpath.yaml
@@ -1,0 +1,62 @@
+# Headless service for stable DNS entries of StatefulSet members.
+apiVersion: v1
+kind: Service
+metadata:
+ name: mongo
+ labels:
+   app: mongo
+spec:
+ ports:
+ - port: 27017
+   targetPort: 27017
+ clusterIP: None
+ selector:
+   role: mongo
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+ name: mongo
+ labels: 
+   app: mongo
+spec:
+ serviceName: "mongo"
+ replicas: 3
+ template:
+   metadata:
+     labels:
+       app: mongo
+       role: mongo
+       environment: test
+   spec:
+     terminationGracePeriodSeconds: 10
+     containers:
+       - name: mongo
+         image: mongo
+         command:
+                 #    - mongod
+                 #    - "--replSet"
+                 #    - rs0
+                 #    - "--smallfiles"
+                 #    - "--noprealloc"
+                 #    - "--bind_ip_all"
+         ports:
+           - containerPort: 27017
+         volumeMounts:
+           - name: mongo-pvc
+             mountPath: /data/db
+       - name: mongo-sidecar
+         image: cvallance/mongo-k8s-sidecar
+         env:
+           - name: MONGO_SIDECAR_POD_LABELS
+             value: "role=mongo,environment=test"
+ volumeClaimTemplates:
+ - metadata:
+     name: mongo-pvc
+   spec:
+     storageClassName: openebs-hostpath
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 5G

--- a/k8s/sample-pv-yamls/sc-localpv-custom-hostpath.yaml
+++ b/k8s/sample-pv-yamls/sc-localpv-custom-hostpath.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-custom-hostpath
+  annotations:
+    #Define a new CAS Type called `local`
+    #which indicates that Data is stored 
+    #directly onto hostpath. The hostpath can be:
+    #- device (as block or mounted path)
+    #- hostpath (sub directory on OS or mounted path)
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      #- name: StorageType
+      #  value: "storage-device"
+      - name: StorageType
+        value: "hostpath"
+      - name: BasePath
+        value: "/var/openebs-hp"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---

--- a/k8s/sample-pv-yamls/spc-cstor-sparse.yaml
+++ b/k8s/sample-pv-yamls/spc-cstor-sparse.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: openebs.io/v1alpha1
+kind: StoragePoolClaim
+metadata:
+  name: sparse-claim-auto
+  annotations:
+    cas.openebs.io/config: |
+      - name: PoolResourceRequests
+        value: |-
+            memory: 1Gi
+            cpu: 100m
+      - name: PoolResourceLimits
+        value: |-
+            memory: 2Gi
+      - name: AuxResourceLimits
+        value: |-
+            memory: 0.5Gi 
+            cpu: 50m
+spec:
+  name: sparse-claim-auto
+  type: sparse
+  maxPools: 3
+  poolSpec:
+    poolType: striped
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-cstor-sparse
+  annotations:
+    openebs.io/cas-type: cstor
+    cas.openebs.io/config: |
+      - name: StoragePoolClaim
+        value: "sparse-claim-auto"
+provisioner: openebs.io/provisioner-iscsi
+---


### PR DESCRIPTION
This PR helps with:
- Adding cstor-sparse pool sample YAML, as it is not auto-generated by openebs anymore (since 0.9)
- Adds examples of using local pv for mongo statefulset
- dbench image used from external repo has been taken down, a new openebs dbench image has been pushed. The yamls using the dbench are updated with the new image. 