### PR TITLE
oep(csi): Update cstorVolumeConfigClass and missing parameters

### DIFF
--- a/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
+++ b/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
@@ -285,25 +285,23 @@ metadata:
   name: <some name -- can be same as storage class name>
   namespace: <namespace of openebs i.e. openebs system namespace>
 spec:
-  # IOQueueDepth is the IO queue depth at the target pod
-  IOQueueDepth:
-  # FrontendIOWorkerThreads indicates the number of IO worker threads at target
-  FrontendIOWorkerThreads:
-  # FrontendIOWorkerThreads indicates the number of IO worker threads at replica
-  BackendIOWorkersThreads:
-  monitoring: true/false
-  characteristics:
-    targetPodAffinity: ""/preferred/required
-    replicaAffinity: ""/preferred
-    desiredReplicationFactor:
-  targetIP:
-  resources:
-    requests:
-      memory:
-      cpu:
-    limits:
-      memory:
-      cpu:
+  target:
+    ioQueueDepth:
+    luWorkers:
+    monitor:  # true/false
+    affinity: # preferred/required
+    replicationFactor:
+    ipAddress:
+    resources:
+      requests:
+        memory:
+        cpu:
+      limits:
+        memory:
+        cpu:
+  replica:
+    zvolWorkers:
+    affinity:
 ```
 
 ##### NOTES

--- a/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
+++ b/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
@@ -506,3 +506,11 @@ NA
 
 - Availability of github.com/openebs/csi repo 
 - Enable integration with Travis as the minimum CI tool
+
+## Missing parameters for feature parity with older implementations:
+
+ - Resource limits for target pods
+ - Target pod affinity
+ - Target pod tolerations
+ - Replica anti-affinity
+ - Preferred replica anti-affinity

--- a/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
+++ b/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
@@ -312,6 +312,7 @@ metadata:
 spec:
   targetDeployment:
     spec:
+      monitoring: true
       containers:
       - name: cstor-istgt
         env:
@@ -331,6 +332,7 @@ spec:
     spec:
       labels:
       annotations:
+      zvolWorkers:
 ```
 
 ##### NOTES
@@ -371,11 +373,12 @@ metadata:
   namespace: <openebs system namespace>
   labels:
   annotations:
-    openebs.io/config-class: 
+    openebs.io/cstor-volume-config-class: 
     openebs.io/volume-id:
 spec:
   capacity:
   claimRef:
+  replicationFactor:
 publish:
   nodeId:
 status:

--- a/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
+++ b/contribute/design/1.x/csi/20190606-csi-volume-provisioning.md
@@ -272,67 +272,38 @@ smooth volume create & delete operations.
 
 #### CStorVolumeConfigClass -- new custom resource
 This is a new Kubernetes custom resource that holds config information to be
-used by cstor volume claim controller while provisioning cstor volumes.
+used by cstor volume claim controller while provisioning cstor volumes. For each 
+volume corresponding CstorVolumeConfig is created.
 
 NOTE: This resource kind does not have a controller i.e. watcher logic. It holds
 the config information to be utilized by cstor volume claim controller.
 
 Following is the proposed schema for `CStorVolumeConfigClass`:
-
 ```yaml
 kind: CStorVolumeConfigClass
 metadata:
   name: <some name -- can be same as storage class name>
   namespace: <namespace of openebs i.e. openebs system namespace>
 spec:
-  targetDeployment:
-    # this gets applied to cstor volume target
-    # deployment via ConfigInjector
-    spec:
-  targetService:
-    # this gets applied to cstor volume target
-    # service via ConfigInjector 
-    spec:
-  cv:
-    # this gets applied to CStorVolume via 
-    # ConfigInjector
-    spec:
-  cvr:
-    # this gets applied to all CStorVolumeReplicas
-    # via ConfigInjector
-    spec:
-```
-
-Detailed specifications:
-```yaml
-kind: CStorVolumeConfigClass
-metadata:
-  name: <some name -- can be same as storage class name>
-  namespace: <namespace of openebs i.e. openebs system namespace>
-spec:
-  targetDeployment:
-    spec:
-      monitoring: true
-      containers:
-      - name: cstor-istgt
-        env:
-        - name: QueueDepth
-          value: 6
-        - name: Luworkers
-          value: 3
-  targetService:
-    spec:
-      labels:
-      annotations:
-  cv:
-    spec:
-      labels:
-      annotations:
-  cvr:
-    spec:
-      labels:
-      annotations:
-      zvolWorkers:
+  # IOQueueDepth is the IO queue depth at the target pod
+  IOQueueDepth:
+  # FrontendIOWorkerThreads indicates the number of IO worker threads at target
+  FrontendIOWorkerThreads:
+  # FrontendIOWorkerThreads indicates the number of IO worker threads at replica
+  BackendIOWorkersThreads:
+  monitoring: true/false
+  characteristics:
+    targetPodAffinity: ""/preferred/required
+    replicaAffinity: ""/preferred
+    desiredReplicationFactor:
+  targetIP:
+  resources:
+    requests:
+      memory:
+      cpu:
+    limits:
+      memory:
+      cpu:
 ```
 
 ##### NOTES


### PR DESCRIPTION
This PR accomplishes the following purposes:
1) Add zvol workers count to csorVolumeConfigClass
2) Add Replication factor to the CstorVolumeClaim object
3) Add monitoring parameter for target deployment in CstorVolumeConfigClass
4) Pass CstorVolumeConfigClass as annotations in CstorVolumeClaim. This should be provided in storage class as parameter.
5) Add missing parameters for feature parity  with older implementations