### PR TITLE
fix(yaml): add patch opearation into RBAC for CRD

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -34,7 +34,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: [ "get", "list", "create", "update", "delete"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
 - apiGroups: ["*"]
   resources: [ "disks", "blockdevices", "blockdeviceclaims"]
   verbs: ["*" ]


### PR DESCRIPTION
NDM operator is performing a patch operation on the CRD, if CRD already exists. Earlier maya service account didn't have permission for patch operation on CRD. Now patch is also added into the list of
allowed operations/verbs

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
