### PR TITLE
refact(charts, operator): added labels to make helm and operator uniform

### DIFF
--- a/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
+++ b/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
@@ -10,6 +10,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm-config
+    openebs.io/component-name: ndm-config
 data:
   # udev-probe is default or primary probe which should be enabled to run ndm
   # filterconfigs contains configs of filters - in the form of include

--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     component: ndm
     openebs.io/component-name: ndm
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   updateStrategy:
     type: "RollingUpdate"
@@ -23,6 +24,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: ndm
+        openebs.io/component-name: ndm
+        name: openebs-ndm
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/k8s/charts/openebs/templates/deployment-admission-server.yaml
+++ b/k8s/charts/openebs/templates/deployment-admission-server.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app: admission-webhook
         name: admission-webhook
+        release: {{ .Release.Name }}
         openebs.io/version: {{ .Values.release.version }}
         openebs.io/component-name: admission-webhook
     spec:

--- a/k8s/charts/openebs/templates/deployment-admission-server.yaml
+++ b/k8s/charts/openebs/templates/deployment-admission-server.yaml
@@ -8,8 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: admission-webhook
-    name: admission-webhook
-    openebs.io/component-name: maya-apiserver
+    openebs.io/component-name: admission-server
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
@@ -19,7 +19,9 @@ spec:
     metadata:
       labels:
         app: admission-webhook
+        name: admission-webhook
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: admission-webhook
     spec:
 {{- if .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/k8s/charts/openebs/templates/deployment-admission-server.yaml
+++ b/k8s/charts/openebs/templates/deployment-admission-server.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: admission-webhook
-    openebs.io/component-name: admission-server
+    openebs.io/component-name: admission-webhook
     openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.webhook.replicas }}

--- a/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     component: localpv-provisioner
     openebs.io/component-name: openebs-localpv-provisioner
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,6 +22,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: localpv-provisioner
+        name: openebs-localpv-provisioner
+        openebs.io/component-name: openebs-localpv-provisioner
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
@@ -54,7 +57,7 @@ spec:
         - name: OPENEBS_IO_BASE_PATH
           value: "{{ .Values.localprovisioner.basePath }}"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "{{ .Values.localprovisioner.helperImage }}"
+          value: "{{ .Values.localprovisioner.helperImage }}:{{ .Values.localprovisioner.helperImageTag }}"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "charts-helm"
         livenessProbe:

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -10,6 +10,7 @@ metadata:
     component: apiserver
     name: maya-apiserver
     openebs.io/component-name: maya-apiserver
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   selector:
@@ -23,6 +24,7 @@ spec:
         release: {{ .Release.Name }}
         component: apiserver
         name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
@@ -48,6 +50,8 @@ spec:
         # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "{{ .Values.apiserver.sparse.enabled }}"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -8,7 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: provisioner
+    name: openebs-provisioner
     openebs.io/component-name: openebs-provisioner
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,6 +23,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: provisioner
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     component: snapshot-operator
     openebs.io/component-name: openebs-snapshot-operator
+    openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.snapshotOperator.replicas }}
   selector:
@@ -23,7 +24,9 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: snapshot-operator
+        name: openebs-snapshot-operator
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-snapshot-operator
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:

--- a/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
@@ -9,6 +9,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm-operator
+    openebs.io/component-name: ndm-operator
+    openebs.io/version: {{ .Values.release.version }}
     name: ndm-operator
 spec:
   replicas: {{ .Values.ndmOperator.replicas }}

--- a/k8s/charts/openebs/templates/service-admission-server.yaml
+++ b/k8s/charts/openebs/templates/service-admission-server.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    openebs.io/component-name: admission-server-svc
 spec:
   ports:
   - port: 443

--- a/k8s/charts/openebs/templates/service-admission-server.yaml
+++ b/k8s/charts/openebs/templates/service-admission-server.yaml
@@ -7,7 +7,7 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    openebs.io/component-name: admission-server-svc
+    openebs.io/component-name: admission-webhook-svc
 spec:
   ports:
   - port: 443

--- a/k8s/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/service-maya-apiserver.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    openebs.io/component-name: maya-apiserver-svc
 spec:
   ports:
   - name: api

--- a/k8s/charts/openebs/templates/validationwebhook.yaml
+++ b/k8s/charts/openebs/templates/validationwebhook.yaml
@@ -42,13 +42,6 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  # Helm hook annotations in order to ensure that the certs
-  # will only be generated on chart install. This will
-  # prevent overriding the certs anytime we upgrade the chart’s
-  # released instance.
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
 {{- if .Values.webhook.generateTLS }}

--- a/k8s/charts/openebs/templates/validationwebhook.yaml
+++ b/k8s/charts/openebs/templates/validationwebhook.yaml
@@ -14,6 +14,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: admission-webhook
+    openebs.io/component-name: admission-webhook
 webhooks:
   - name: admission-webhook.openebs.io
     clientConfig:
@@ -42,6 +43,7 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    openebs.io/component-name: admission-webhook
 type: Opaque
 data:
 {{- if .Values.webhook.generateTLS }}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -47,7 +47,8 @@ provisioner:
 localprovisioner:
   image: "quay.io/openebs/provisioner-localpv"
   imageTag: "1.0.0"
-  helperImage: "quay.io/openebs/openebs-tools:3.8"
+  helperImage: "quay.io/openebs/openebs-tools"
+  helperImageTag: "3.8"
   replicas: 1
   basePath: "/var/openebs/local"
   nodeSelector: {}

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -184,6 +184,8 @@ kind: Service
 metadata:
   name: maya-apiserver-service
   namespace: openebs
+  labels:
+    openebs.io/component-name: maya-apiserver-svc
 spec:
   ports:
   - name: api
@@ -330,6 +332,8 @@ kind: ConfigMap
 metadata:
   name: openebs-ndm-config
   namespace: openebs
+  labels:
+    openebs.io/component-name: ndm-config
 data:
   # udev-probe is default or primary probe which should be enabled to run ndm
   # filterconfigs contails configs of filters - in their form fo include
@@ -518,7 +522,7 @@ metadata:
   namespace: openebs
   labels:
     app: admission-webhook
-    openebs.io/component: admission-server
+    openebs.io/component-name: admission-webhook
 type: Opaque
 data:
   cert.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQ3VENDQXRXZ0F3SUJBZ0lVYk84NS9JR0ZXYTA2Vm11WVdTWjdxaTUybmRRd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1hERUxNQWtHQTFVRUJoTUNlSGd4Q2pBSUJnTlZCQWdNQVhneENqQUlCZ05WQkFjTUFYZ3hDakFJQmdOVgpCQW9NQVhneENqQUlCZ05WQkFzTUFYZ3hDekFKQmdOVkJBTU1BbU5oTVJBd0RnWUpLb1pJaHZjTkFRa0JGZ0Y0Ck1CNFhEVEU1TURNd01qQTNNek13TUZvWERUSXdNRE13TVRBM01qYzFNbG93S3pFcE1DY0dBMVVFQXhNZ1lXUnQKYVhOemFXOXVMWE5sY25abGNpMXpkbU11YjNCbGJtVmljeTV6ZG1Nd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQQpBNElCRHdBd2dnRUtBb0lCQVFERk5MRE1xKzd6eFZidDNPcnFhaVUyOFB6K25ZeFRCblA0NVhFWGFjSUpPWG1aClM1c2ZjMjM3WVNWS0I5Tlp4cXNYT08wcXpWb0xtNlZ0UDJjREpWZGZIVUQ0QXBZSC94UVBVTktrcFg3K0NVTFEKZ3VBNWowOXozdkFaeDJidXBTaXFFdE1mVldqNkh5V0Jyd2FuZW9IaVVXVVdpbmtnUXpCQzR1SWtiRkE2djYrZwp4ZzAwS09TY2NFRWY3eU5McjBvejBKVHRpRm1aS1pVVVBwK3N3WTRpRTZ3RER5bVVnTmY4SW8wUEExVkQ1TE9vCkFwQ0l2WDJyb1RNd3VkR1VrZUc1VTA2OWIrMWtQMEJsUWdDZk9TQTBmZEN3Snp0aWE1aHpaUlVIWGxFOVArN0kKekgyR0xXeHh1aHJPTlFmT25HcVRiUE13UmowekZIdmcycUo1azJ2VkFnTUJBQUdqZ2Rjd2dkUXdEZ1lEVlIwUApBUUgvQkFRREFnV2dNQk1HQTFVZEpRUU1NQW9HQ0NzR0FRVUZCd01CTUF3R0ExVWRFd0VCL3dRQ01BQXdIUVlEClZSME9CQllFRklnOVFSOSsyVW12THQwQXY4MlYwZml0bU81WE1COEdBMVVkSXdRWU1CYUFGTU5HNkZ4aUxhYWYKMWV3bDVEN3VJcmIrRStIT01GOEdBMVVkRVFSWU1GYUNGR0ZrYldsemMybHZiaTF6WlhKMlpYSXRjM1pqZ2h4aApaRzFwYzNOcGIyNHRjMlZ5ZG1WeUxYTjJZeTV2Y0dWdVpXSnpnaUJoWkcxcGMzTnBiMjR0YzJWeWRtVnlMWE4yCll5NXZjR1Z1WldKekxuTjJZekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBSlpJRzd2d0RYaWxhWUFCS1Brc0oKZVJtdml4ZnYybTRVTVdzdlBKVVVJTXhHbzhtc1J6aWhBRjVuTExzaURKRDl4MjhraXZXaGUwbWE4aWVHYjY5Sgp1U1N4bys0OStaV3NVaTB3UlRDMi9ZWGlkWS9xNDU2c1g4ck9qQURDZlFUcFpYc2ZyekVWa2Q4NE0zdU5GTmhnCnMyWmxJMnNDTWljYXExNWxIWEh3akFkY2FqZit1VklwOXNHUElsMUhmZFcxWVFLc0NoU3dhdi80NUZJcFlMSVYKM3hiS2ZIbmh2czhJck5ZbTVIenAvVVdvcFN1Tm5tS1IwWGo3cXpGcllUYzV3eHZ3VVZrKzVpZFFreWMwZ0RDcApGbkFVdEdmaUVUQnBhU3pISjQ4STZqUFpneVE0NzlZMmRxRUtXcWtyc0RkZ2tVcXlnNGlQQ0YwWC9YVU9YU3VGClNnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
@@ -531,7 +535,7 @@ metadata:
   namespace: openebs
   labels:
     app: admission-webhook
-    openebs.io/component: admission-server
+    openebs.io/component-name: admission-webhook-svc
 spec:
   ports:
   - port: 443
@@ -546,7 +550,7 @@ metadata:
   namespace: openebs
   labels:
     app: admission-webhook
-    openebs.io/component-name: admission-server
+    openebs.io/component-name: admission-webhook
     openebs.io/version: dev
 spec:
   replicas: 1
@@ -557,7 +561,7 @@ spec:
     metadata:
       labels:
         app: admission-webhook
-        openebs.io/component-name: admission-server
+        openebs.io/component-name: admission-webhook
         openebs.io/version: dev
     spec:
       serviceAccountName: openebs-maya-operator
@@ -586,7 +590,7 @@ metadata:
   name: validation-webhook-cfg
   labels:
     app: admission-webhook
-    openebs.io/component-name: admission-server
+    openebs.io/component-name: admission-webhook
 webhooks:
   - name: admission-webhook.openebs.io
     clientConfig:
@@ -663,3 +667,4 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
+


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does / why we need it:**
This PR adds deployment labels which are present in operator but not in  helm charts.

**helm upgrade result:**
```
user:openebs$ helm install --namespace openebs --name openebs stable/openebs --version 1.0.0
NAME:   openebs
LAST DEPLOYED: Mon Jul 15 10:56:13 2019
NAMESPACE: openebs
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME     AGE
openebs  4s

==> v1/ClusterRoleBinding
NAME     AGE
openebs  4s

==> v1/ConfigMap
NAME                DATA  AGE
openebs-ndm-config  1     4s

==> v1/Deployment
NAME                         READY  UP-TO-DATE  AVAILABLE  AGE
openebs-admission-server     0/1    1           0          3s
openebs-apiserver            0/1    1           0          3s
openebs-localpv-provisioner  0/1    1           0          3s
openebs-ndm-operator         0/1    1           0          3s
openebs-provisioner          0/1    1           0          3s
openebs-snapshot-operator    0/1    1           0          3s

==> v1/Pod(related)
NAME                                          READY  STATUS             RESTARTS  AGE
openebs-admission-server-74c7f77cff-n6llb     0/1    ContainerCreating  0         3s
openebs-apiserver-7fc86cc574-lj5b9            0/1    ContainerCreating  0         3s
openebs-localpv-provisioner-7879ccd58b-zjmnz  0/1    ContainerCreating  0         3s
openebs-ndm-bf7ld                             0/1    ContainerCreating  0         3s
openebs-ndm-operator-74bcd75cfd-vd4js         0/1    Pending            0         3s
openebs-provisioner-84f98747f-l4qld           0/1    ContainerCreating  0         3s
openebs-snapshot-operator-67c9b4c4bf-xhbpt    0/2    ContainerCreating  0         3s

==> v1/Secret
NAME                    TYPE    DATA  AGE
admission-server-certs  Opaque  2     4s

==> v1/Service
NAME                  TYPE       CLUSTER-IP   EXTERNAL-IP  PORT(S)   AGE
admission-server-svc  ClusterIP  10.0.12.147  <none>       443/TCP   4s
openebs-apiservice    ClusterIP  10.0.9.54    <none>       5656/TCP  3s

==> v1/ServiceAccount
NAME     SECRETS  AGE
openebs  1        4s

==> v1beta1/DaemonSet
NAME         DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE
openebs-ndm  1        1        0      1           0          <none>         3s

==> v1beta1/ValidatingWebhookConfiguration
NAME                            AGE
openebs-validation-webhook-cfg  3s


NOTES:
The OpenEBS has been installed. Check its status by running:
$ kubectl get pods -n openebs

For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or
use one of the default storage classes provided by OpenEBS.

Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample
PVC spec using `openebs-jiva-default` StorageClass is given below:"

---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: demo-vol-claim
spec:
  storageClassName: openebs-jiva-default
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5G
---

For more information, please visit http://docs.openebs.io/.

Please note that, OpenEBS uses iSCSI for connecting applications with the
OpenEBS Volumes and your nodes should have the iSCSI initiator installed.


user:openebs$ kubectl get pods -n openebs
NAME                                           READY   STATUS    RESTARTS   AGE
openebs-admission-server-74c7f77cff-n6llb      1/1     Running   0          35s
openebs-apiserver-7fc86cc574-lj5b9             1/1     Running   0          35s
openebs-localpv-provisioner-7879ccd58b-zjmnz   1/1     Running   0          35s
openebs-ndm-bf7ld                              1/1     Running   0          35s
openebs-ndm-operator-74bcd75cfd-vd4js          1/1     Running   0          35s
openebs-provisioner-84f98747f-l4qld            1/1     Running   0          35s
openebs-snapshot-operator-67c9b4c4bf-xhbpt     2/2     Running   0          35s
user:openebs$ pwd
/home/user/work/src/github.com/openebs/openebs/k8s/charts/openebs
user:openebs$ helm upgrade openebs .
Release "openebs" has been upgraded.
LAST DEPLOYED: Mon Jul 15 10:58:24 2019
NAMESPACE: openebs
STATUS: DEPLOYED

RESOURCES:
==> v1/ClusterRole
NAME     AGE
openebs  2m14s

==> v1/ClusterRoleBinding
NAME     AGE
openebs  2m14s

==> v1/ConfigMap
NAME                DATA  AGE
openebs-ndm-config  1     2m14s

==> v1/Deployment
NAME                         READY  UP-TO-DATE  AVAILABLE  AGE
openebs-admission-server     1/1    1           1          2m13s
openebs-apiserver            1/1    1           1          2m13s
openebs-localpv-provisioner  1/1    1           1          2m13s
openebs-ndm-operator         1/1    1           1          2m13s
openebs-provisioner          1/1    1           1          2m13s
openebs-snapshot-operator    1/1    1           1          2m13s

==> v1/Pod(related)
NAME                                          READY  STATUS       RESTARTS  AGE
openebs-admission-server-74c7f77cff-n6llb     1/1    Running      0         2m13s
openebs-apiserver-7fc86cc574-lj5b9            1/1    Running      0         2m13s
openebs-localpv-provisioner-7879ccd58b-zjmnz  1/1    Terminating  0         2m13s
openebs-localpv-provisioner-7d7b4cc56d-6rh2h  1/1    Running      0         2s
openebs-ndm-bf7ld                             1/1    Running      0         2m13s
openebs-ndm-operator-74bcd75cfd-vd4js         1/1    Running      0         2m13s
openebs-provisioner-84f98747f-l4qld           1/1    Running      0         2m13s
openebs-snapshot-operator-67c9b4c4bf-xhbpt    2/2    Running      0         2m13s

==> v1/Secret
NAME                    TYPE    DATA  AGE
admission-server-certs  Opaque  2     2m14s

==> v1/Service
NAME                  TYPE       CLUSTER-IP   EXTERNAL-IP  PORT(S)   AGE
admission-server-svc  ClusterIP  10.0.12.147  <none>       443/TCP   2m14s
openebs-apiservice    ClusterIP  10.0.9.54    <none>       5656/TCP  2m13s

==> v1/ServiceAccount
NAME     SECRETS  AGE
openebs  1        2m14s

==> v1beta1/DaemonSet
NAME         DESIRED  CURRENT  READY  UP-TO-DATE  AVAILABLE  NODE SELECTOR  AGE
openebs-ndm  1        1        1      1           1          <none>         2m13s

==> v1beta1/ValidatingWebhookConfiguration
NAME                            AGE
openebs-validation-webhook-cfg  2m13s


NOTES:
The OpenEBS has been installed. Check its status by running:
$ kubectl get pods -n openebs

For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or
use one of the default storage classes provided by OpenEBS.

Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample
PVC spec using `openebs-jiva-default` StorageClass is given below:"

---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: demo-vol-claim
spec:
  storageClassName: openebs-jiva-default
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 5G
---

For more information, please visit http://docs.openebs.io/.

Please note that, OpenEBS uses iSCSI for connecting applications with the
OpenEBS Volumes and your nodes should have the iSCSI initiator installed.


user:openebs$ kubectl get pods -n openebs --show-labels 
NAME                                           READY   STATUS    RESTARTS   AGE     LABELS
openebs-admission-server-74c7f77cff-n6llb      1/1     Running   0          3m59s   app=admission-webhook,name=admission-webhook,openebs.io/component-name=admission-webhook,openebs.io/version=1.0.0,pod-template-hash=74c7f77cff
openebs-apiserver-7fc86cc574-lj5b9             1/1     Running   0          3m59s   app=openebs,component=apiserver,name=maya-apiserver,openebs.io/component-name=maya-apiserver,openebs.io/version=1.0.0,pod-template-hash=7fc86cc574,release=openebs
openebs-localpv-provisioner-7d7b4cc56d-6rh2h   1/1     Running   0          108s    app=openebs,component=localpv-provisioner,name=openebs-localpv-provisioner,openebs.io/component-name=openebs-localpv-provisioner,openebs.io/version=1.0.0,pod-template-hash=7d7b4cc56d,release=openebs
openebs-ndm-bf7ld                              1/1     Running   0          3m59s   app=openebs,component=ndm,controller-revision-hash=5cc78dd4b4,name=openebs-ndm,openebs.io/component-name=ndm,openebs.io/version=1.0.0,pod-template-generation=1,release=openebs
openebs-ndm-operator-74bcd75cfd-vd4js          1/1     Running   0          3m59s   app=openebs,component=ndm-operator,name=ndm-operator,openebs.io/component-name=ndm-operator,openebs.io/version=1.0.0,pod-template-hash=74bcd75cfd,release=openebs
openebs-provisioner-84f98747f-l4qld            1/1     Running   0          3m59s   app=openebs,component=provisioner,name=openebs-provisioner,openebs.io/component-name=openebs-provisioner,openebs.io/version=1.0.0,pod-template-hash=84f98747f,release=openebs
openebs-snapshot-operator-67c9b4c4bf-xhbpt     2/2     Running   0          3m59s   app=openebs,component=snapshot-operator,name=openebs-snapshot-operator,openebs.io/component-name=openebs-snapshot-operator,openebs.io/version=1.0.0,pod-template-hash=67c9b4c4bf,release=openebs

```
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
