### PR TITLE
fix(jiva snap cleanup): get snap list cmd on every iteration

### DIFF
--- a/k8s/jiva/snapshot-cleanup.sh
+++ b/k8s/jiva/snapshot-cleanup.sh
@@ -42,11 +42,11 @@ delete_jiva_snapshot()
        exit 1;
     fi
 
-    snapshot_number_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep -v ID | wc -l'
-    snapshot_name_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep -v ID | tail -1'
+    snapshot_number_cmd='kubectl exec -it $ctrl_pod_name -n $pvc_namespace -- jivactl snapshot ls | grep -v ID | wc -l'
+    snapshot_name_cmd='kubectl exec -it $ctrl_pod_name -n $pvc_namespace -- jivactl snapshot ls | grep -v ID | tail -1'
 
     if [ $(eval $snapshot_number_cmd) -le $((number_of_snapshot-1)) ]; then
-        echo "Error: You have requested to delete. $number_of_snapshot. There are only $(($(eval $snapshot_number_cmd) - $min_required_snapshot)). snapshot that can be deleted snapshots available on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less."
+        echo "Error: You have requested to delete $number_of_snapshot. There are only $((($(eval $snapshot_number_cmd))-1 - $min_required_snapshot)) snapshot available that can be deleted on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less."
         exit 1 ;
     else
             if [ $(eval $snapshot_number_cmd) -gt $(($min_required_snapshot + $number_of_snapshot)) ]; then
@@ -59,7 +59,7 @@ delete_jiva_snapshot()
                 unblock_service
                 rm -rf log.txt
             else
-                echo "Error: You have requested to delete. $number_of_snapshot. There are only $(($(eval $snapshot_number_cmd) - $min_required_snapshot)). snapshot that can be deleted snapshots available on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less." ;
+                echo "Error: You have requested to delete $number_of_snapshot. There are only $((($(eval $snapshot_number_cmd))-1 - $min_required_snapshot)) snapshot available that can be deleted on this volume. Please re-run this command with by specifying the number of snapshots to be deleted as $(($(eval $snapshot_number_cmd) - $min_required_snapshot)) or less." ;
             fi
         fi
 }
@@ -90,7 +90,7 @@ restart_ctrl()
 validate_snap_delete()
 {
     del_snapshot_name=$1
-    validate_cmd='echo $snapshot_list_cmd | tr " " "\n" | grep $del_snapshot_name'
+    validate_cmd='kubectl exec -it $ctrl_pod_name -n $pvc_namespace -- jivactl snapshot ls | grep $del_snapshot_name'
     eval $validate_cmd
     if [ $? != "0" ]; then
         echo "Unable to delete $del_snapshot_name" ;


### PR DESCRIPTION
Signed-off-by: shashank855 <shashank.ranjan@mayadata.io>
This commit fix the bug where only one snapshot was being deleted since `snap_list_cmd` was not getting updated on every iteration. 
