### PR TITLE
fix(chart): make seachest probe configurable

### DIFF
--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -93,15 +93,16 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `1.0.0`                                   |
 | `snapshotOperator.replicas`             | Number of Snapshot Operator Replicas          | `1`                                       |
 | `ndm.image`                             | Image for Node Disk Manager                   | `quay.io/openebs/node-disk-manager-amd64` |
-| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `v0.4.0`                              |
+| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `v0.4.0`                                  |
 | `ndm.sparse.path`                       | Directory where Sparse files are created      | `/var/openebs/sparse`                     |
 | `ndm.sparse.size`                       | Size of the sparse file in bytes              | `10737418240`                             |
 | `ndm.sparse.count`                      | Number of sparse files to be created          | `1`                                       |
 | `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
 | `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
 | `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md`  |
+| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
 | `ndmOperator.image`                     | Image for NDM Operator                        | `quay.io/openebs/node-disk-operator-amd64`|
-| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `v0.4.0`                              |
+| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `v0.4.0`                                  |
 | `jiva.image`                            | Image for Jiva                                | `quay.io/openebs/jiva`                    |
 | `jiva.imageTag`                         | Image Tag for Jiva                            | `1.0.0`                                   |
 | `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |

--- a/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
+++ b/k8s/charts/openebs/templates/cm-node-disk-manager.yaml
@@ -22,7 +22,7 @@ data:
         state: true
       - key: seachest-probe
         name: seachest probe
-        state: true
+        state: {{ .Values.ndm.probes.enableSeachest }}
       - key: smart-probe
         name: smart probe
         state: true

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -85,6 +85,8 @@ ndm:
     excludeVendors: "CLOUDBYT,OpenEBS"
     includePaths: ""
     excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md"
+  probes:
+    enableSeachest: false
   nodeSelector: {}
   healthCheck:
     initialDelaySeconds: 30


### PR DESCRIPTION
NDM seachest probe has been made configurable using `values.yaml`. By default it will be disabled.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
