### PR TITLE
fix(yaml): add service account to NDM deployment

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -513,6 +513,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            # the service account of the ndm-operator pod
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE


### PR DESCRIPTION
add service account as an environment variable to be passed in the downward API. This service account will be used while creating cleanup jobs. Jobs without service account were facing issues in openshift cluster to run in privileged mode.

Fixes #2698 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
