### PR TITLE
fix(operator yaml): update deployment upgrade strategy as Recreate

### DIFF
--- a/k8s/charts/openebs/templates/deployment-admission-server.yaml
+++ b/k8s/charts/openebs/templates/deployment-admission-server.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   replicas: {{ .Values.webhook.replicas }}
   strategy:
-    type: {{ .Values.webhook.upgradeStrategy }}
+    type: "Recreate"
     rollingUpdate: null
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-admission-server.yaml
+++ b/k8s/charts/openebs/templates/deployment-admission-server.yaml
@@ -12,6 +12,9 @@ metadata:
     openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.webhook.replicas }}
+  strategy:
+    type: {{ .Values.webhook.upgradeStrategy }}
+    rollingUpdate: null
   selector:
     matchLabels:
       app: admission-webhook

--- a/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -12,6 +12,9 @@ metadata:
     openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.provisioner.replicas }}
+  strategy:
+    type: {{ .Values.provisioner.upgradeStrategy }}
+    rollingUpdate: null
   selector:
     matchLabels:
       app: {{ template "openebs.name" . }}

--- a/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -11,9 +11,9 @@ metadata:
     openebs.io/component-name: openebs-localpv-provisioner
     openebs.io/version: {{ .Values.release.version }}
 spec:
-  replicas: {{ .Values.provisioner.replicas }}
+  replicas: {{ .Values.localprovisioner.replicas }}
   strategy:
-    type: {{ .Values.provisioner.upgradeStrategy }}
+    type: "Recreate"
     rollingUpdate: null
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -13,6 +13,9 @@ metadata:
     openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.apiserver.replicas }}
+  strategy:
+    type: {{ .Values.apiserver.upgradeStrategy }}
+    rollingUpdate: null
   selector:
     matchLabels:
       app: {{ template "openebs.name" . }}

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   strategy:
-    type: {{ .Values.apiserver.upgradeStrategy }}
+    type: "Recreate"
     rollingUpdate: null
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   strategy:
-    type: {{ .Values.provisioner.upgradeStrategy }}
+    type: "Recreate"
     rollingUpdate: null
   selector:
     matchLabels:

--- a/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -13,6 +13,9 @@ metadata:
     openebs.io/version: {{ .Values.release.version }}
 spec:
   replicas: {{ .Values.provisioner.replicas }}
+  strategy:
+    type: {{ .Values.provisioner.upgradeStrategy }}
+    rollingUpdate: null
   selector:
     matchLabels:
       app: {{ template "openebs.name" . }}

--- a/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -17,7 +17,8 @@ spec:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
   strategy:
-    type: {{ .Values.snapshotOperator.upgradeStrategy }}
+    type: "Recreate"
+    rollingUpdate: null
   template:
     metadata:
       labels:

--- a/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
@@ -16,7 +16,7 @@ spec:
   replicas: {{ .Values.ndmOperator.replicas }}
   strategy:
     type: "Recreate"
-    upgradeStrategy: "Recreate"
+    rollingUpdate: null
   selector:
     matchLabels:
       app: {{ template "openebs.name" . }}

--- a/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
+++ b/k8s/charts/openebs/templates/deployment-ndm-operator.yaml
@@ -15,7 +15,8 @@ metadata:
 spec:
   replicas: {{ .Values.ndmOperator.replicas }}
   strategy:
-    type: {{ .Values.ndmOperator.upgradeStrategy }}
+    type: "Recreate"
+    upgradeStrategy: "Recreate"
   selector:
     matchLabels:
       app: {{ template "openebs.name" . }}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -21,6 +21,7 @@ apiserver:
   image: "quay.io/openebs/m-apiserver"
   imageTag: "1.1.0"
   replicas: 1
+  upgradeStrategy: "Recreate"
   ports:
     externalPort: 5656
     internalPort: 5656
@@ -40,6 +41,7 @@ provisioner:
   image: "quay.io/openebs/openebs-k8s-provisioner"
   imageTag: "1.1.0"
   replicas: 1
+  upgradeStrategy: "Recreate"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -53,6 +55,7 @@ localprovisioner:
   helperImage: "quay.io/openebs/openebs-tools"
   helperImageTag: "3.8"
   replicas: 1
+  upgradeStrategy: "Recreate"
   basePath: "/var/openebs/local"
   nodeSelector: {}
   tolerations: []
@@ -114,6 +117,7 @@ webhook:
   imageTag: "1.1.0"
   generateTLS: true
   replicas: 1
+  upgradeStrategy: "Recreate"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -21,7 +21,6 @@ apiserver:
   image: "quay.io/openebs/m-apiserver"
   imageTag: "1.1.0"
   replicas: 1
-  upgradeStrategy: "Recreate"
   ports:
     externalPort: 5656
     internalPort: 5656
@@ -41,7 +40,6 @@ provisioner:
   image: "quay.io/openebs/openebs-k8s-provisioner"
   imageTag: "1.1.0"
   replicas: 1
-  upgradeStrategy: "Recreate"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -55,7 +53,6 @@ localprovisioner:
   helperImage: "quay.io/openebs/openebs-tools"
   helperImageTag: "3.8"
   replicas: 1
-  upgradeStrategy: "Recreate"
   basePath: "/var/openebs/local"
   nodeSelector: {}
   tolerations: []
@@ -72,7 +69,6 @@ snapshotOperator:
     image: "quay.io/openebs/snapshot-provisioner"
     imageTag: "1.1.0"
   replicas: 1
-  upgradeStrategy: "Recreate"
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -102,7 +98,6 @@ ndmOperator:
   image: "quay.io/openebs/node-disk-operator-amd64"
   imageTag: "v0.4.1"
   replicas: 1
-  upgradeStrategy: Recreate
   nodeSelector: {}
   tolerations: []
   readinessCheck:
@@ -117,7 +112,6 @@ webhook:
   imageTag: "1.1.0"
   generateTLS: true
   replicas: 1
-  upgradeStrategy: "Recreate"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -89,6 +89,9 @@ spec:
       name: maya-apiserver
       openebs.io/component-name: maya-apiserver
   replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -214,6 +217,9 @@ spec:
       name: openebs-provisioner
       openebs.io/component-name: openebs-provisioner
   replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -276,6 +282,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -484,6 +491,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -562,6 +570,9 @@ metadata:
     openebs.io/version: dev
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: admission-webhook
@@ -632,6 +643,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   template:
     metadata:
       labels:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -282,7 +282,6 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -491,7 +490,6 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:
@@ -643,7 +641,6 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
-    rollingUpdate: null
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR updates the control plane deployment upgrade strategy to `Recreate`.
When we set the upgrade strategy to `Recreate` deployment controller will
make sure during upgrade time(patching pod template spec) after deleting old pod
new pod with the changes will come to running state.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
