### PR TITLE
Modify pgrep argument in localpv liveliness

### DIFF
--- a/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -66,8 +66,8 @@ spec:
         livenessProbe:
           exec:
             command:
-            - pgrep
-            - ".*provisioner-loc"
+            - pgrep -f
+            - ".*provisioner-localpv"
           initialDelaySeconds: {{ .Values.localprovisioner.healthCheck.initialDelaySeconds }}
           periodSeconds: {{ .Values.localprovisioner.healthCheck.periodSeconds }}
 {{- if .Values.localprovisioner.nodeSelector }}

--- a/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/k8s/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -67,7 +67,7 @@ spec:
           exec:
             command:
             - pgrep
-            - ".*localpv"
+            - ".*provisioner-loc"
           initialDelaySeconds: {{ .Values.localprovisioner.healthCheck.initialDelaySeconds }}
           periodSeconds: {{ .Values.localprovisioner.healthCheck.periodSeconds }}
 {{- if .Values.localprovisioner.nodeSelector }}

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -693,8 +693,8 @@ spec:
         livenessProbe:
           exec:
             command:
-            - pgrep
-            - ".*provisioner-loc"
+            - pgrep -f
+            - ".*provisioner-localpv"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -694,7 +694,7 @@ spec:
           exec:
             command:
             - pgrep
-            - ".*localpv"
+            - ".*provisioner-loc"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---


### PR DESCRIPTION
- `pgrep` command behaves differently on ARM and AMD.
- Modify and change the existing pgrep argument, i.e. `".*localpv"` to
  support liveliness check in arm64 kubernetes cluster, for provisoner-localpv

fixes: #2712 

Signed-off-by: harshvkarn <harshvardhan.karn@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
