### PR TITLE
feat(cspc-operator): add env to tune cspc-operator resync period cspi-mgmt image

### DIFF
--- a/k8s/cspc-operator.yaml
+++ b/k8s/cspc-operator.yaml
@@ -41,6 +41,8 @@ spec:
           value: "quay.io/openebs/cspi-mgmt:ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE 
           value: "quay.io/openebs/cstor-pool:ci"
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE 
+          value: "quay.io/openebs/m-exporter:ci"
         - name: RESYNC_INTERVAL
           value: "30"
 ---

--- a/k8s/cspc-operator.yaml
+++ b/k8s/cspc-operator.yaml
@@ -37,4 +37,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+          value: "quay.io/openebs/cspi-mgmt:ci"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE 
+          value: "quay.io/openebs/cstor-pool:ci"
+        - name: RESYNC_INTERVAL
+          value: "30"
 ---


### PR DESCRIPTION
This PR will add env for tuning  cspi-mgmt image and cspc-operator informer resync period.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
