### PR TITLE
refact(operator, helm): added rbac for "pods/exec"

### DIFF
--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
   resources: ["nodes", "nodes/proxy"]
   verbs: ["*"]
 - apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "deployments", "events", "endpoints", "configmaps", "jobs"]
+  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "events", "endpoints", "configmaps", "jobs"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -24,7 +24,7 @@ rules:
   resources: ["nodes", "nodes/proxy"]
   verbs: ["*"]
 - apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "deployments", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["statefulsets", "daemonsets"]


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does / why we need it:**
This PR adds rbac `pods/exec` for openebs service account. It is required to exec into the jiva controller pod and verify the sync of replicas while upgrade.
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
