### PR TITLE
fix(install): add missing ENV params to openebs-operator

### DIFF
--- a/k8s/charts/openebs/README.md
+++ b/k8s/charts/openebs/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `jiva.image`                            | Image for Jiva                                | `quay.io/openebs/jiva`                    |
 | `jiva.imageTag`                         | Image Tag for Jiva                            | `1.1.0`                                   |
 | `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
+| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
 | `cstor.pool.image`                      | Image for cStor Pool                          | `quay.io/openebs/cstor-pool`              |
 | `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `1.1.0`                                   |
 | `cstor.poolMgmt.image`                  | Image for cStor Pool  Management              | `quay.io/openebs/cstor-pool-mgmt`         |

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -48,17 +48,6 @@ spec:
         # This is supported for maya api server version 0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
-        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
-        # configured as a part of openebs installation.
-        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
-        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
-          value: "{{ .Values.apiserver.sparse.enabled }}"
-        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-          value: "{{ .Values.ndm.sparse.path }}"
-        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
-          value: "{{ .Values.defaultStorageConfig.enabled }}"
-        - name: OPENEBS_IO_CSTOR_TARGET_DIR
-          value: "{{ .Values.ndm.sparse.path }}"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE
@@ -77,6 +66,44 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default 
+        # storageclass and storagepool will not be created.
+        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+          value: "{{ .Values.defaultStorageConfig.enabled }}"
+        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+        # configured as a part of openebs installation.
+        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+          value: "{{ .Values.apiserver.sparse.enabled }}"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath 
+        # to be used for saving the shared content between the side cars
+        # of cstor volume pod. 
+        # The default path used is /var/openebs/sparse
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath 
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location 
+        # of the sparse devices. 
+        # The default path used is /var/openebs/sparse
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+        # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath 
+        # to be used for default Jiva StoragePool loaded by OpenEBS
+        # The default path used is /var/openebs
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "{{ .Values.jiva.defaultStoragePath }}"
+        # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath 
+        # to be used for default openebs-hostpath storageclass loaded by OpenEBS
+        # The default path used is /var/openebs/local
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "{{ .Values.localprovisioner.basePath }}"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -120,6 +120,7 @@ jiva:
   image: "quay.io/openebs/jiva"
   imageTag: "1.1.0"
   replicas: 3
+  defaultStoragePath: "/var/openebs"
 
 cstor:
   pool:

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -129,11 +129,6 @@ spec:
         # This is supported for maya api server version 0.5.2 onwards
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
-        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
-        # configured as a part of openebs installation.
-        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
-        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
-          value: "false"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE
@@ -152,6 +147,44 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default 
+        # storageclass and storagepool will not be created.
+        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+          value: "true"
+        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+        # configured as a part of openebs installation.
+        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+          value: "false"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath 
+        # to be used for saving the shared content between the side cars
+        # of cstor volume pod. 
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+        #  value: "/var/openebs/sparse"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath 
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location 
+        # of the sparse devices. 
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+        #  value: "/var/openebs/sparse"
+        # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath 
+        # to be used for default Jiva StoragePool loaded by OpenEBS
+        # The default path used is /var/openebs
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        #- name: OPENEBS_IO_JIVA_POOL_DIR
+        #  value: "/var/openebs"
+        # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath 
+        # to be used for default openebs-hostpath storageclass loaded by OpenEBS
+        # The default path used is /var/openebs/local
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        #- name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+        #  value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "quay.io/openebs/jiva:ci"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE


### PR DESCRIPTION
This PR adds information about some of the ENV variables
of openebs apiserver, used to customize the default
storage configuration.

Related Issue/PRs:
- https://github.com/openebs/maya/pull/1433
- https://github.com/openebs/openebs/issues/2730

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
