### PR TITLE
doc(governance): add initial draft on security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+OpenEBS follows similar security policy as other CNCF projects, primarily inspired from the Kubernetes project. As the community and adoption increases, a much more detailed process will be put in place. 
+
+## Announcements
+
+Security related issues once fixed will be tracked publicly on [GitHub Issues](https://github.com/openebs/openebs/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Aarea%2Fsecurity+in%3Atitle+CVE). New issue announcements are sent to cncf-openebs-announcements@lists.cncf.io
+
+## Reporting a Vulnerability
+
+If you find a security bug please report it privately to the maintainers listed in the MAINTAINERS of the relevant repository. We will fix the issue and coordinate a release date with you, acknowledging your effort and mentioning you by name if you want.
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers within 3 working days. As the security issue moves from triage, to identified fix, to release planning we will keep the reporter updated.
+
+## Public Disclosure Timing
+
+We prefer to fully disclose the bug as soon as possible once a user mitigation is available. The Fix Lead drives the schedule using their best judgment based on severity, development time, and release manager feedback. If the Fix Lead is dealing with a Public Disclosure all timelines become ASAP.
+


### PR DESCRIPTION
This PR adds process details related to reporting and
disclosure of security vulnerabilities.

Signed-off-by: kmova <kiran.mova@mayadata.io>
