### PR TITLE
chore(operator): update deprecated k8s APIs removed in k8s version 1.16

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -86,7 +86,7 @@ roleRef:
   name: openebs-maya-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: maya-apiserver
@@ -147,7 +147,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default 
+        # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default
         # storageclass and storagepool will not be created.
         - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
           value: "true"
@@ -158,27 +158,27 @@ spec:
         # is set to true
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
-        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath 
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
         # to be used for saving the shared content between the side cars
-        # of cstor volume pod. 
+        # of cstor volume pod.
         # The default path used is /var/openebs/sparse
         #- name: OPENEBS_IO_CSTOR_TARGET_DIR
         #  value: "/var/openebs/sparse"
-        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath 
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
         # to be used for saving the shared content between the side cars
-        # of cstor pool pod. This ENV is also used to indicate the location 
-        # of the sparse devices. 
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
         # The default path used is /var/openebs/sparse
         #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
         #  value: "/var/openebs/sparse"
-        # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath 
+        # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath
         # to be used for default Jiva StoragePool loaded by OpenEBS
         # The default path used is /var/openebs
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
         #- name: OPENEBS_IO_JIVA_POOL_DIR
         #  value: "/var/openebs"
-        # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath 
+        # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath
         # to be used for default openebs-hostpath storageclass loaded by OpenEBS
         # The default path used is /var/openebs/local
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
@@ -247,7 +247,7 @@ spec:
     name: maya-apiserver
   sessionAffinity: None
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: openebs-provisioner
@@ -310,7 +310,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: openebs-snapshot-operator
@@ -419,7 +419,7 @@ data:
         include: ""
         exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: openebs-ndm
@@ -673,7 +673,7 @@ webhooks:
         apiVersions: ["*"]
         resources: ["cstorpoolclusters"]
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: openebs-localpv-provisioner


### PR DESCRIPTION
The k8s v1.16 release will stop serving the deprecated API versions
in favor of newer and more stable API versions, more info can be found here
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
