### PR TITLE
Updated CONTRIBUTING-TO-DEVELOPER-DOC.md & oep-template.md

### DIFF
--- a/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
+++ b/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md
@@ -35,7 +35,7 @@ You can also help with some existing issues under this category available at [de
 
 ## Create your development branch
 
-- Fork the [OpenEBS](www.github.com/openebs/openebs) repository and if you have forked it already, rebase with master branch to fetch latest changes to your local system.
+- Fork the [OpenEBS](https://github.com/openebs/openebs/) repository and if you have forked it already, rebase with master branch to fetch latest changes to your local system.
 - Create a new development branch in your forked repository with the following naming convention: *"task description-#issue"*
 
   **Example:** This change is being developed with the branch named: *OpenEBS-DevDoc-PR-Workflow-#213*

--- a/contribute/process/oep-template.md
+++ b/contribute/process/oep-template.md
@@ -42,11 +42,11 @@ To get started with this template:
   Aim for single topic PRs to keep discussions focused.
   If you disagree with what is already in a document, open a new PR with suggested changes.
 
-The canonical place for the latest set of instructions (and the likely source of this file) is [here](/contribute/design/oep-template.md).
+The canonical place for the latest set of instructions (and the likely source of this file) is [here](https://github.com/openebs/openebs/blob/master/contribute/process/oep-template.md).
 
 The `Metadata` section above is intended to support the creation of tooling around the OEP process.
 This will be a YAML section that is fenced as a code block.
-See the [OEP process](/contribute/design/oep-process.md) for details on each of these items.
+See the [OEP process](https://github.com/openebs/openebs/blob/master/contribute/process/oep-process.md) for details on each of these items.
 
 ## Table of Contents
 


### PR DESCRIPTION
Under openebs/contribute/CONTRIBUTING-TO-DEVELOPER-DOC.md

Fork the OpenEBS repository link is broken:
https://github.com/openebs/openebs/blob/master/contribute/www.github.com/openebs/openebs

Updated link:
https://github.com/openebs/openebs/

-----------------------------------------------------

Under openebs/contribute/process/oep-template.md

The canonical place for the latest set of instructions (and the likely source of this file) is here - Link broken
https://github.com/openebs/openebs/blob/master/contribute/design/oep-template.md

Replace with - https://github.com/openebs/openebs/blob/master/contribute/process/oep-template.md

See the OEP process for details on each of these items - Link broken
https://github.com/openebs/openebs/blob/master/contribute/design/oep-process.md

Replace with - https://github.com/openebs/openebs/blob/master/contribute/process/oep-process.md