### PR TITLE
refact(upgrade, design): added status to versionDetails spec

### DIFF
--- a/contribute/design/1.x/upgrade/volume-pools-upgrade.md
+++ b/contribute/design/1.x/upgrade/volume-pools-upgrade.md
@@ -274,7 +274,7 @@ This design proposes the following key changes:
     The above spec will be used as a sub-resource under all the custom
     resource managed by OpenEBS. 
   
-    Status: Under Development, planned for 1.2
+    Status: Under Development, planned for 1.3
 
 5.  Downgrading a version. There are scenarios where the volumes will
     have to be downgraded to earlier versions. Some of the challenges

--- a/contribute/design/1.x/upgrade/volume-pools-upgrade.md
+++ b/contribute/design/1.x/upgrade/volume-pools-upgrade.md
@@ -243,7 +243,7 @@ This design proposes the following key changes:
     internal spec will be maintained that indicates if the backward
     compatibility checks need to be maintained. 
 
-    ```
+    ```yaml
     versionDetails:
       #Indicates if the resource should be auto upgraded 
       #More on this below (6). Default is false.
@@ -267,6 +267,8 @@ This design proposes the following key changes:
         message: Unable to set desired replication factor to CV
         #reason is the actual error recieved by the function calls
         reason: invalid config for the volume
+        #lastUpdateTime is the time last modification of status occured
+        lastUpdateTime: "2019-10-03T14:37:03Z"
     ```
 
     The above spec will be used as a sub-resource under all the custom

--- a/contribute/design/1.x/upgrade/volume-pools-upgrade.md
+++ b/contribute/design/1.x/upgrade/volume-pools-upgrade.md
@@ -245,19 +245,28 @@ This design proposes the following key changes:
 
     ```
     versionDetails:
-      #Indicates if the resource should be auto upgraded 
-      #More on this below (6). Default is false.
-      #autoUpgrade:
-      #Indicates the current version of the resource.
-      currentVersion: 
-      #Indicates the running version of the controller/component
-      #as part of the start-up, this flag will be changed
-      #running version if autoUpgrade is enabled. 
-      desiredVersion: 
-      #In some cases there can be a bunch of child resources
-      #this flag will be set to "no" when current != desired. 
-      #after upgrading all the child objects, this will be changed to yes. 
-      dependentsUpgraded:
+    #Indicates if the resource should be auto upgraded 
+    #More on this below (6). Default is false.
+    #autoUpgrade:
+    #Indicates the current version of the resource.
+    currentVersion: 
+    #Indicates the running version of the controller/component
+    #as part of the start-up, this flag will be changed
+    #running version if autoUpgrade is enabled. 
+    desiredVersion: 
+    #In some cases there can be a bunch of child resources
+    #this flag will be set to "no" when current != desired. 
+    #after upgrading all the child objects, this will be changed to yes. 
+    dependentsUpgraded:
+    #status gives the details about the reconciliation of the version
+    status:
+      #phase tells the phase of reconciliation of the current 
+      #and desired version.
+      phase: #STARTED, SUCCESS or ERROR can be the supported phases
+      #message is a human readable message in case of failure
+      message: Unable to set desired replication factor to CV
+      #reason is the actual error recieved by the function calls
+      reason: invalid config for the volume
     ```
 
     The above spec will be used as a sub-resource under all the custom

--- a/contribute/design/1.x/upgrade/volume-pools-upgrade.md
+++ b/contribute/design/1.x/upgrade/volume-pools-upgrade.md
@@ -245,28 +245,28 @@ This design proposes the following key changes:
 
     ```
     versionDetails:
-    #Indicates if the resource should be auto upgraded 
-    #More on this below (6). Default is false.
-    #autoUpgrade:
-    #Indicates the current version of the resource.
-    currentVersion: 
-    #Indicates the running version of the controller/component
-    #as part of the start-up, this flag will be changed
-    #running version if autoUpgrade is enabled. 
-    desiredVersion: 
-    #In some cases there can be a bunch of child resources
-    #this flag will be set to "no" when current != desired. 
-    #after upgrading all the child objects, this will be changed to yes. 
-    dependentsUpgraded:
-    #status gives the details about the reconciliation of the version
-    status:
-      #phase tells the phase of reconciliation of the current 
-      #and desired version.
-      phase: #STARTED, SUCCESS or ERROR can be the supported phases
-      #message is a human readable message in case of failure
-      message: Unable to set desired replication factor to CV
-      #reason is the actual error recieved by the function calls
-      reason: invalid config for the volume
+      #Indicates if the resource should be auto upgraded 
+      #More on this below (6). Default is false.
+      #autoUpgrade:
+      #Indicates the current version of the resource.
+      currentVersion: 
+      #Indicates the running version of the controller/component
+      #as part of the start-up, this flag will be changed
+      #running version if autoUpgrade is enabled. 
+      desiredVersion: 
+      #In some cases there can be a bunch of child resources
+      #this flag will be set to "no" when current != desired. 
+      #after upgrading all the child objects, this will be changed to yes. 
+      dependentsUpgraded:
+      #status gives the details about the reconciliation of the version
+      status:
+        #phase tells the phase of reconciliation of the current 
+        #and desired version.
+        phase: #STARTED, SUCCESS or ERROR can be the supported phases
+        #message is a human readable message in case of failure
+        message: Unable to set desired replication factor to CV
+        #reason is the actual error recieved by the function calls
+        reason: invalid config for the volume
     ```
 
     The above spec will be used as a sub-resource under all the custom


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does / why we need it:**
This PR adds status to the versionDetails spec. To update the upgradeTask CR we need the status of the reconciliation happening in the controller. The status of versionDetails will provide that status to the upgrade job which can be patched to the upgradeTask CR.
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
