### PR TITLE
chore(cspc-operator): update deployement kind to apps/v1

### DIFF
--- a/k8s/cspc-operator.yaml
+++ b/k8s/cspc-operator.yaml
@@ -22,7 +22,7 @@ spec:
     shortNames:
     - cspc
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cspc-operator
@@ -62,9 +62,9 @@ spec:
               fieldPath: metadata.name
         - name: OPENEBS_IO_CSPI_MGMT_IMAGE
           value: "quay.io/openebs/cspi-mgmt:ci"
-        - name: OPENEBS_IO_CSTOR_POOL_IMAGE 
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
           value: "quay.io/openebs/cstor-pool:ci"
-        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE 
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
           value: "quay.io/openebs/m-exporter:ci"
         - name: RESYNC_INTERVAL
           value: "30"


### PR DESCRIPTION
The k8s v1.16 release will stop serving the deprecated API versions
in favor of newer and more stable API versions, more info can be found here
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16

Refer #2746

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
