### PR TITLE
RBAC: Don't bind powerful permissions to default service account in default namespace

### DIFF
--- a/k8s/ci/maya/volume/cstor/service-account.yaml
+++ b/k8s/ci/maya/volume/cstor/service-account.yaml
@@ -22,9 +22,6 @@ subjects:
 - kind: ServiceAccount
   name: user-service-account
   namespace: default
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: system:serviceaccount:default:default
 roleRef:
   kind: ClusterRole
   name: user-privilege-role

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -81,9 +81,6 @@ subjects:
 - kind: ServiceAccount
   name: openebs-maya-operator
   namespace: openebs
-- kind: User
-  name: system:serviceaccount:default:default
-  apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
   name: openebs-maya-operator


### PR DESCRIPTION
The ClusterRoleBinding `openebs-maya-operator` binds very powerful
ClusterRole `openebs-maya-operator` to `default` service account in
`default` namespace. This commit removes the service account from the
list of `subjects`.
