### PR TITLE
fix(docs): fix multiple typos in documentation

### DIFF
--- a/contribute/design/1.x/autoscale/cstor/20191014-cstor-autoscale.md
+++ b/contribute/design/1.x/autoscale/cstor/20191014-cstor-autoscale.md
@@ -213,7 +213,7 @@ This being related to provision, field for this in CSPI is:
 `CORDONED` means CVC SHOULD NOT pick the CSPI for any further volume
 provisioning.
 
-There is NO reconcilation happens for this, but, this acts as a config
+There is NO reconciliation happens for this, but, this acts as a config
 parameter.
 
 This is not added to `spec` of CSPI as `spec` is shared with CSPC controller
@@ -293,7 +293,7 @@ It excludes the CSPIs whose provision.status is NOT ONLINE for provisioning
 replicas.
 
 #### More OEPs:
-- For cStor volume's replica scale down scenario, seperate OEP need to be raised
+- For cStor volume's replica scale down scenario, separate OEP need to be raised
 or existing OEP on replica scaleup need to be updated.
 - OEP for operator that cordons and drains the node need to be raised
 

--- a/contribute/design/1.x/replica_scaleup/dataplane/20190910-replica-scaleup.md
+++ b/contribute/design/1.x/replica_scaleup/dataplane/20190910-replica-scaleup.md
@@ -223,7 +223,7 @@ A listener will be created on UnixDomain socket in cstor-volume-mgmt container.
 istgt connects to this listener to update the replica related information if
 there is any change in the list.
 cstor-volume-mgmt updates the status.ReplicaList part of CStorVolume CR and
-sends the success/failure of CR update as reponse to istgt.
+sends the success/failure of CR update as response to istgt.
 
 During start phase of cstor-volume-mgmt container, it updates the istgt.conf
 file with values from spec.DesiredReplicationFactor and status.ReplicaList of

--- a/contribute/design/1.x/upgrade/volume-pools-upgrade.md
+++ b/contribute/design/1.x/upgrade/volume-pools-upgrade.md
@@ -265,9 +265,9 @@ This design proposes the following key changes:
         phase: #STARTED, SUCCESS or ERROR can be the supported phases
         #message is a human readable message in case of failure
         message: Unable to set desired replication factor to CV
-        #reason is the actual error recieved by the function calls
+        #reason is the actual error received by the function calls
         reason: invalid config for the volume
-        #lastUpdateTime is the time last modification of status occured
+        #lastUpdateTime is the time last modification of status occurred
         lastUpdateTime: "2019-10-03T14:37:03Z"
     ```
 


### PR DESCRIPTION
There was a typo in the documentation file and this has been fixed.


```
./contribute/design/1.x/autoscale/cstor/20191014-cstor-autoscale.md:216: reconcilation -> "reconciliation"
./contribute/design/1.x/autoscale/cstor/20191014-cstor-autoscale.md:296: seperate -> "separate"
./contribute/design/1.x/replica_scaleup/dataplane/20190910-replica-scaleup.md:226: reponse -> "response"
./contribute/design/1.x/upgrade/volume-pools-upgrade.md:268: recieved -> "received"
./contribute/design/1.x/upgrade/volume-pools-upgrade.md:270: occured -> "occurred"
```