### PR TITLE
oep(cstor): proposal to migrate pools and volumes from old schema to new schema

### DIFF
--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -96,7 +96,9 @@ This will require a new field in the PoolSpec of CSPC :
 // old pool name which needs to imported and renamed as new pool
 OldCSPUID string `json:"oldCSPUID,omitempty"`
 ```
-This field will be used to rename the pool which was named as `cstor-csp-uid` to `cstor-cspc-uid`. It  needs to be removed once the CSPI for that `poolSpec` comes into `ONLINE` phase. This field will be used to populate the `cspuid` annotation which will be added while creating CSPI CR. This annotation will be removed after successful import of the pool.
+The CSPC will come up with an additional field `OldCSPUID` which will be used to import the old CSP pool. Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool. Once the pool is imported successfully then the field `OldCSPUID` will be reset to empty string to avoid renaming of pool in future.
+
+The `OldCSPUID` field will be used to rename the pool which was named as `cstor-cspuid` to `cstor-cspcuid`. It  needs to be removed once the CSPI for that `poolSpec` comes into `ONLINE` phase. This field will be used to populate the `cspuid` annotation which will be added while creating CSPI CR. This annotation will be removed after successful import of the pool.
 
 The Job spec for migrating SPC is:
 ```yaml

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -90,7 +90,7 @@ The migration of SPC will be performed via a job which takes SPC name as one of 
 
 The CSPC CR will be with `reconcile.openebs.io/dependants` annotation to disable reconciliation of CSPI. Once all CSPI are successfully created the annotation will be removed.
 
-Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool. Once the pool is imported successfully then the field `OldCSPUID` will be reset to empty string to avoid renaming of pool in future.
+Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool.
 
 The `cstorpoolinstance.openebs.io/oldname` annotation will be used to rename the pool which was named as `cstor-cspuid` to `cstor-cspcuid`. This annotation will be removed after successful import of the pool.
 
@@ -147,7 +147,7 @@ The Job spec for migrating SPC is:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: migrate-cspc-cstor-sparse-pool-volumes
+  name: migrate-cstor-volume-pvc-b265427e-6a62-470a-a841-5a36be371e14
   namespace: openebs
 spec:
   backoffLimit: 4

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -126,6 +126,12 @@ For importing without renaming the command would look like:
 
 The `cstorpoolinstance.openebs.io/oldname` annotation will be used to rename the pool which was named as `cstor-cspuid` to `cstor-cspcuid`. This annotation will be removed after successful import of the pool.
 
+**Note: Before migrating make sure:**
+ - OpenEBS version of old resources(control-plane and data-plane) should be atleast 1.11.0.
+ - Apply new cstor-operators and csi driver which also should be atleast in 1.11.0 version.
+ - Identify the nodes on which the `CSP` are present and run `fdisk -l` command on that node. If the command is hung then bad block file exists on that node. If such case occurs, please resolve this issue before proceeding with the migration. To identify the nodes look for the `kubernetes.io/hostname` label on the `CSP`.
+
+
 The Job spec for migrating SPC is:
 ```yaml
 ---
@@ -145,7 +151,7 @@ spec:
       containers:
       - name:  migrate
         args:
-        - "pool"
+        - "cstor-spc"
         # name of the spc that is to be migrated
         - "--spc-name=cstor-sparse-pool"
 
@@ -217,6 +223,6 @@ After the successful completion of the job the applications can be scaled up to 
 ## Infrastructure Needed
 
 - Kubernetes version should be 1.14 or above.
-- OpenEBS version should be 1.3 or above.
-- CSPC operator should be installed.
-- CStor CSI operator should be installed.
+- OpenEBS version should be 1.11 or above.
+- CSPC operator 1.11 or above should be installed.
+- CStor CSI operator 1.11 or above should be installed.

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -162,9 +162,9 @@ spec:
       containers:
       - name:  migrate
         args:
-        - "volumes"
-        # name of the cspc on which volumes are provisioned
-        - "--cspc-name=cstor-sparse-pool"
+        - "cstor-volume"
+        # pv-name of the volume which has to be migrated
+        - "--pv-name=cstor-sparse-pool"
 
         #Following are optional parameters
         #Log Level

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -1,0 +1,73 @@
+---
+oep-number: draft Migrate 20191115
+title: Migration of SPC to CSPC
+authors:
+  - "@shubham14bajpai"
+owners:
+  - "@amitkumardas"
+  - "@vishnuitta"
+  - "@kmova"
+editor: "@shubham14bajpai"
+creation-date: 2019-11-15
+last-updated: 2019-11-15
+status: implementable
+see-also:
+  - NA
+replaces:
+  - current SPC with CSPC
+superseded-by:
+  - NA
+---
+
+# Migrate SPC to CSPC
+
+## Table of Contents
+
+* [Table of Contents](#table-of-contents)
+* [Summary](#summary)
+* [Motivation](#motivation)
+    * [Goals](#goals)
+* [Proposal](#proposal)
+    * [Proposed Implementation](#proposed-implementation)
+    * [High Level Design](#high-level-design)
+* [Infrastructure Needed](#infrastructure-needed)
+
+## Summary
+
+This design is aimed at providing a design for migrating SPC to CSPC
+via kubernetes job which will take SPC-name as input. 
+
+This proposed design will be rolled out in phases. At a high level the design is
+implemented in the following phases:
+- Phase 1: Ability to perform migration from SPC to CSPC using 
+  a Kubernetes Job.
+- Phase 2: Allow for migration of old CStor volumes to CSI CStor volumes. 
+
+## Motivation
+
+### Goals
+
+- Ease the process of migrating SPC to CSPC by automating it via kubernetes job. 
+- Enable day 2 operations on CStor Volumes by migrating them to CSI volumes.
+
+## Proposal
+
+### Proposed Implementation
+
+This design proposes the following key changes while migrating from a SPC to CSPC:
+
+  1. New CSPC CR will be created for the migrating SPC.
+
+  2. New CSPI CRs will be created which will replace the CSP for given SPC.
+
+  3. The BDC with SPC label and finalizer will be replaced by CSPC label and finalizer.
+  
+  4. The imported pools in each CSPI will be renamed to cstor-${CSPC uid}.
+
+  5. The CVR with CSPI labels and annotations will be replaced by CSPI labels and annotations.
+
+  6. New CVC CR for the volume will be created with the CV details.
+
+  7. New StorageClass with CSPC will be created and this will replace the old strageclass in the PVC of CStorVolume.
+
+  8. Clean up old SPC and csp after successfull creation of CSPC and cspi objects.

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -82,7 +82,6 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
   6. Update ownerreferences of CV, service with CVC and CVRs with CV.
 
-
 ### High Level Design
 
 #### Phase 1: Migration of SPC to CSPC
@@ -184,3 +183,10 @@ spec:
 ```
 
 After the successful completion of the job the applications can be scaled up to verify the migration of volumes. Once the application is up new `csivolume` CR will be generated for the volume.
+
+## Infrastructure Needed
+
+- Kubernetes version should be 1.14 or above.
+- OpenEBS version should be 1.3 or above.
+- CSPC operator should be installed.
+- CStor CSI operator should be installed.

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -88,9 +88,19 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
 The migration of SPC will be performed via a job which takes SPC name as one of its argument.
 
-The CSPC CR will be with `reconcile.openebs.io/dependants` annotation to disable reconciliation of CSPI. Once all CSPI are successfully created the annotation will be removed.
+The CSPC CR created via job will have `reconcile.openebs.io/disable-dependants` annotation set to  `true`. This will help in disabling reconciliation of on all CSPIs created for the CSPC. The reconciliation is set off on CSPIs to avoid import while the old CSP pods are still running. Once all CSPI are successfully created the annotation will be removed.
 
-Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool.
+Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool. 
+
+The import command will be modified to import with or without the oldname. For example for renaming the command would look like:
+```sh
+/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-poolpool.cache  -d /var/openebs/sparse cstor-08bfced5-6a28-4a63-a76b-c48c69be6ad5 cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
+```
+For importing without renaming the command would look like:
+```sh
+/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-poolpool.cache  -d /var/openebs/sparse cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
+```
+
 
 The `cstorpoolinstance.openebs.io/oldname` annotation will be used to rename the pool which was named as `cstor-cspuid` to `cstor-cspcuid`. This annotation will be removed after successful import of the pool.
 

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -88,13 +88,15 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
 The migration of SPC will be performed via a job which takes SPC name as one of its argument. 
 
+The CSPC CR will be with `reconcile.openebs.io/dependants` annotation to disable reconciliation of CSPI. Once all CSPI are successfully created the annotation will be removed.
+
 This will require a new field in the PoolSpec of CSPC : 
 ```go
 // OldCSPUID is used to migrate old csp to cspi. This will be the
 // old pool name which needs to imported and renamed as new pool
 OldCSPUID string `json:"oldCSPUID,omitempty"`
 ```
-This field will be used to rename the pool which was named as `cstor-csuid` to `cstor-cspc-uid`. It  needs to be removed once successful import of the pool is done after migration to CSPC.
+This field will be used to rename the pool which was named as `cstor-csp-uid` to `cstor-cspc-uid`. It  needs to be removed once the CSPI for that `poolSpec` comes into `ONLINE` phase. This field will be used to populate the `cspuid` annotation which will be added while creating CSPI CR. This annotation will be removed after successful import of the pool.
 
 The Job spec for migrating SPC is:
 ```yaml

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -9,7 +9,7 @@ owners:
   - "@kmova"
 editor: "@shubham14bajpai"
 creation-date: 2019-11-15
-last-updated: 2020-05-21
+last-updated: 2020-06-18
 status: implementable
 see-also:
   - NA
@@ -60,7 +60,7 @@ This design proposes the following key changes while migrating from a SPC to CSP
 
   2. Equivalent CSPC CR will be created for the migrating SPC.
 
-  3. Equivalent CSPI CRs will be created by operator which will replace the CSP for given SPC. The CSPI will reconcile disabled to avoid double import.
+  3. Equivalent CSPI CRs will be created by operator which will replace the CSP for given SPC. The CSPI will be created by disabling the reconciliation to avoid double import.
 
   4. The SPC owner reference on the BDCs will be replaced by equivalent CSPC owner reference.
 
@@ -79,7 +79,7 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
   2. Set the PV to `Retain` reclaim policy to prevent deletion of OpenEBS resources.
 
-  3. A temporary CStorVolumePolicy with target deploy configurations and CSPI names from old CVRs will be created. This is facilitate the creation `cstor/v1` CVRs on the same pool as the old `openebs.io/v1alpha1` CVRs were. I also help preserve any configuration set on the target deployment of old volume.
+  3. A temporary CStorVolumePolicy with target deploy configurations and CSPI names from old CVRs will be created. This is facilitate the creation `cstor/v1` CVRs on the same pool as the old `openebs.io/v1alpha1` CVRs were. It also help preserve any configuration set on the target deployment of old volume.
 
   4. Recreate PVC with volumeName already populated & csi driver info
  
@@ -175,7 +175,7 @@ After successful completion of pool migration the logs will list out all applica
 
 #### Phase 2: Migration of Non-CSI volume to CSI volume
 
-**Note: Before proceeding to the below steps the pool must be migrated successfully and all the applications having volumes on the pool must be scale down.**
+**Note: Before proceeding to the below steps the pool must be migrated successfully and the application using the volume to be migrated must be scale down.**
 
 The migration of volumes will be performed via a job which takes the migrated CSPC name as one of its argument.
 

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -95,15 +95,15 @@ The migration of SPC will be performed via a job which takes SPC name as one of 
 
 The CSPC CR created via job will have `reconcile.openebs.io/disable-dependants` annotation set to  `true`. This will help in disabling reconciliation of on all CSPIs created for the CSPC. The reconciliation is set off on CSPIs to avoid import while the old CSP pods are still running. Once all CSPI are successfully created the annotation will be removed.
 
-Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. Then CSPI reconciliation will be enabled which will create the CSPI deployment which will rename and import the pool. 
+Sequentially one CSPI is taken and the corresponding CSP is found using `kubernetes/hostname` label. The CSP deployment is scaled down to avoid multiple pods trying to import the same pool. Next the all the BDC for given CSPI are updated with CSPC information. The CSPI will be patched with the annotation `cstorpoolinstance.openebs.io/oldname`. When CSPI reconciliation is enabled then the pool manager will import the pool
 
 The import command will be modified to import with or without the oldname. For example for renaming the command would look like:
 ```sh
-/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-poolpool.cache  -d /var/openebs/sparse cstor-08bfced5-6a28-4a63-a76b-c48c69be6ad5 cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
+/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-pool/pool.cache  -d /var/openebs/sparse cstor-08bfced5-6a28-4a63-a76b-c48c69be6ad5 cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
 ```
 For importing without renaming the command would look like:
 ```sh
-/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-poolpool.cache  -d /var/openebs/sparse cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
+/usr/local/bin/zpool import  -o cachefile=/var/openebs/cstor-pool/pool.cache  -d /var/openebs/sparse cstor-6b3bbf9e-451d-4333-b119-1bb5217e5bc2
 ```
 
 

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -97,6 +97,13 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
   11. Remove the policy annotation from the CVC and clean up temporary policy and old CV and CVRs.
 
+  12. If snapshots are present for the given PVC migrate them from old schema to new schema.
+      - Check whether the snapshotClass `csi-cstor-snapshotclass` is installed.
+      - Create equivalent `volumesnapshotcontent` for old `volumesnapshotdata`.
+      - Create equivalent csi `volumesnapshot` for old `volumesnapshot`.
+      - Check whether the `volumesnapshotcontent` and the csi `volumesnapshot` are bound.
+      - Delete the old `volumesnapshot` which should automatically remove corresponding `volumesnapshotdata`.
+
 ### High Level Design
 
 #### Phase 1: Migration of SPC to CSPC

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -79,13 +79,23 @@ For migrating non-csi volumes to csi volumes following changes are proposed:
 
   2. Set the PV to `Retain` reclaim policy to prevent deletion of OpenEBS resources.
 
-  3. Recreate old PV with csi spec translation.
+  3. A temporary CStorVolumePolicy with target deploy configurations and CSPI names from old CVRs will be created. This is facilitate the creation `cstor/v1` CVRs on the same pool as the old `openebs.io/v1alpha1` CVRs were. I also help preserve any configuration set on the target deployment of old volume.
 
-  4. Recreate old PVC with updated csi spec PV and StorageClass.
+  4. Recreate PVC with volumeName already populated & csi driver info
+ 
+  5. Recreate PV with claimRef of PVC and csi spec
 
-  5. Create CVC CR for the volume with the CV details.
+  6. Delete old target deployment.
 
-  6. Update ownerreferences of CV, service with CVC and CVRs with CV.
+  7. Create new CVC for volume with basic provision info of volume and annotation to temporary policy
+
+  8. Update ownerreferences of target service with CVC.
+  
+  9. Wait for new `cstor/v1` CV to be Healthy.
+
+  10. Patch the pod affinity if present on policy to the new target deployment.
+
+  11. Remove the policy annotation from the CVC and clean up temporary policy and old CV and CVRs.
 
 ### High Level Design
 

--- a/contribute/design/1.x/migrate/spc-to-cspc-migration.md
+++ b/contribute/design/1.x/migrate/spc-to-cspc-migration.md
@@ -9,7 +9,7 @@ owners:
   - "@kmova"
 editor: "@shubham14bajpai"
 creation-date: 2019-11-15
-last-updated: 2019-11-15
+last-updated: 2020-05-21
 status: implementable
 see-also:
   - NA
@@ -56,17 +56,22 @@ implemented in the following phases:
 
 This design proposes the following key changes while migrating from a SPC to CSPC:
 
-  1. New CSPC CR will be created for the migrating SPC.
+  1. The SPC label and finalizer on BDCs will be replaced by CSPC label and finalizer. This is done to avoid webhook validation failure while creating equivalent CSPC.
 
-  2. New CSPI CRs will be created which will replace the CSP for given SPC.
+  2. Equivalent CSPC CR will be created for the migrating SPC.
 
-  3. The BDC with SPC label and finalizer will be replaced by CSPC label and finalizer.
+  3. Equivalent CSPI CRs will be created by operator which will replace the CSP for given SPC. The CSPI will reconcile disabled to avoid double import.
 
-  4. The imported pools in each CSPI will be renamed to cstor-${CSPC uid}.
+  4. The SPC owner reference on the BDCs will be replaced by equivalent CSPC owner reference.
 
-  5. The CVR with CSP labels and annotations will be replaced by CSPI labels and annotations.
+  5. Sequentially for each CSP
 
-  6. Clean up old SPC and csp after successfull creation of CSPC and cspi objects.
+      1. Old CSP deployment will be scaled down and sync will be enabled on equivalent CSPI.
+      2. Old pool will be imported by renaming it from `cstor-cspuid` to `cstor-cspcuid`.
+      3. The CVR with CSP labels and annotations will be replaced by CSPI labels and annotations.
+      4. Finalizers from CSP will be removed to for proper cleanup.
+
+  6. Clean up old SPC and CSP after successfull creation of CSPC and CSPI objects.
 
 For migrating non-csi volumes to csi volumes following changes are proposed:
 


### PR DESCRIPTION
**Note: This is on hold until the schema for CSPC and CVC is frozen.**
This OEP is having a proposal for high-level design to migrate SPC to CPSC and CStor volumes to CSI CStor volumes. 
Implementation PRs for SPC-CSPC are mentioned below:
https://github.com/openebs/api/pull/50
https://github.com/openebs/cstor-operators/pull/79
https://github.com/openebs/upgrade/pull/4
https://github.com/openebs/upgrade/pull/9

Signed-off-by: shubham <shubham.bajpai@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
