### PR TITLE
fix(operator): update the env variables for 1.5 release

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -575,7 +575,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "quay.io/openebs/linux-utils:3.9"
+              value: "quay.io/openebs/linux-utils:1.4.0"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -666,12 +666,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+        # environment variable
+        - name: OPENEBS_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
         - name: OPENEBS_IO_ENABLE_ANALYTICS
           value: "false"
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "openebs-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "quay.io/openebs/openebs-tools:3.8"
+          value: "quay.io/openebs/linux-utils:1.4.0"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Starting with 1.5, the helper pod image will be same across
ndm and openebs components. updated it with the latest tagged
image. Refer: https://github.com/openebs/maya/pull/1538,
https://github.com/openebs/node-disk-manager/pull/352

As a fix for openshift local hostpath, the helper pods
need to be launched with service account. Updated the local
provisioner with ENV. Refer: https://github.com/openebs/maya/pull/1542

Signed-off-by: kmova <kiran.mova@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
