### PR TITLE
Tighten OpenEBS RBAC permissions.

### DIFF
--- a/k8s/charts/openebs/templates/clusterrole.yaml
+++ b/k8s/charts/openebs/templates/clusterrole.yaml
@@ -9,57 +9,70 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+# Allow OpenEBS read-only access to a few cluster-wide objects.
 - apiGroups: ["*"]
-  resources: ["nodes", "nodes/proxy"]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["*"]
+  resources: ["nodes/proxy"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["namespaces"]
+  verbs: ["get", "watch"]
+# Allow OpenEBS to manage persistent storage cluster-wide.
+- apiGroups: ["*"]
+  resources:
+  - storageclasses
+  - persistentvolumeclaims
+  - persistentvolumes
   verbs: ["*"]
+# Allow OpenEBS to create events.
 - apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets",  "jobs", "cronjobs" ]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["statefulsets", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["resourcequotas", "limitranges"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "poddisruptionbudgets", "certificatesigningrequests"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
-  verbs: ["*"]
-- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
-  resources: ["volumesnapshots", "volumesnapshotdatas"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  resources:
+  - events
+  verbs: ["create"]
+# Allow OpenEBS to register its custom objects.
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
-  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+  verbs: ["*"]
+# Allow OpenEBS to manage its own custom objects cluster-wide.
 - apiGroups: ["*"]
-  resources: [ "disks", "blockdevices", "blockdeviceclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolclusters", "storagepoolclaims", "storagepoolclaims/finalizers", "cstorpoolclusters/finalizers", "storagepools"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "castemplates", "runtasks"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpools", "cstorpools/finalizers", "cstorvolumereplicas", "cstorvolumes", "cstorvolumeclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolinstances", "cstorpoolinstances/finalizers"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorbackups", "cstorrestores", "cstorcompletedbackups"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "upgradetasks"]
-  verbs: ["*" ]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
+  resources:
+  - disks
+  - blockdevices
+  - blockdeviceclaims
+  - cstorpoolclusters
+  - storagepoolclaims
+  - storagepoolclaims/finalizers
+  - cstorpoolclusters/finalizers
+  - storagepools
+  - castemplates
+  - runtasks
+  - upgradetasks
+  - cstorpools
+  - cstorpools/finalizers
+  - cstorvolumereplicas
+  - cstorvolumes
+  - cstorvolumeclaims
+  - cstorpoolinstances
+  - cstorpoolinstances/finalizers
+  - cstorbackups
+  - cstorrestores
+  - cstorcompletedbackups
+  verbs: ["*"]
+- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+  resources:
+  - volumesnapshots
+  - volumesnapshotdatas
+  verbs: ["*"]
+# Allow OpenEBS to install and manage its own admission webhooks.
 - apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "list", "delete", "update", "patch"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["list", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  resourceNames: ["openebs-validation-webhook-cfg"]
+  verbs: ["*"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}

--- a/k8s/charts/openebs/templates/role.yaml
+++ b/k8s/charts/openebs/templates/role.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.rbac.create }}
+# Allow OpenEBS to manage all core objects in its own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "openebs.fullname" . }}
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: ["*"]
+  resources:
+  - services
+  - pods
+  - deployments
+  - deployments/finalizers
+  - replicationcontrollers
+  - replicasets
+  - statefulsets
+  - daemonsets
+  - events
+  - endpoints
+  - configmaps
+  - secrets
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]
+{{- end }}

--- a/k8s/charts/openebs/templates/rolebinding.yaml
+++ b/k8s/charts/openebs/templates/rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "openebs.fullname" . }}
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "openebs.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "openebs.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -14,65 +14,122 @@ metadata:
   name: openebs-maya-operator
   namespace: openebs
 ---
-# Define Role that allows operations on K8s pods/deployments
+# Allow OpenEBS to manage all core objects in its own namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+rules:
+- apiGroups: ["*"]
+  resources:
+  - services
+  - pods
+  - deployments
+  - deployments/finalizers
+  - replicationcontrollers
+  - replicasets
+  - statefulsets
+  - daemonsets
+  - events
+  - endpoints
+  - configmaps
+  - secrets
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openebs-maya-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-maya-operator
 rules:
+# Allow OpenEBS read-only access to a few cluster-wide objects.
 - apiGroups: ["*"]
-  resources: ["nodes", "nodes/proxy"]
-  verbs: ["*"]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: ["*"]
-  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["statefulsets", "daemonsets"]
-  verbs: ["*"]
-- apiGroups: ["*"]
-  resources: ["resourcequotas", "limitranges"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "poddisruptionbudgets", "certificatesigningrequests"]
-  verbs: ["list", "watch"]
-- apiGroups: ["*"]
-  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
-  verbs: ["*"]
-- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
-  resources: ["volumesnapshots", "volumesnapshotdatas"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: [ "get", "list", "create", "update", "delete", "patch"]
-- apiGroups: ["*"]
-  resources: [ "disks", "blockdevices", "blockdeviceclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolclusters", "storagepoolclaims", "storagepoolclaims/finalizers", "cstorpoolclusters/finalizers", "storagepools"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "castemplates", "runtasks"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpools", "cstorpools/finalizers", "cstorvolumereplicas", "cstorvolumes", "cstorvolumeclaims"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorpoolinstances", "cstorpoolinstances/finalizers"]
-  verbs: ["*" ]
-- apiGroups: ["*"]
-  resources: [ "cstorbackups", "cstorrestores", "cstorcompletedbackups"]
-  verbs: ["*" ]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "watch", "list", "delete", "update", "create"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-  verbs: ["get", "create", "list", "delete", "update", "patch"]
-- nonResourceURLs: ["/metrics"]
+  resources: ["nodes/proxy"]
   verbs: ["get"]
 - apiGroups: ["*"]
-  resources: [ "upgradetasks"]
-  verbs: ["*" ]
+  resources: ["namespaces"]
+  verbs: ["get", "watch"]
+# Allow OpenEBS to manage persistent storage cluster-wide.
+- apiGroups: ["*"]
+  resources:
+  - storageclasses
+  - persistentvolumeclaims
+  - persistentvolumes
+  verbs: ["*"]
+# Allow OpenEBS to create events.
+- apiGroups: ["*"]
+  resources:
+  - events
+  verbs: ["create"]
+# Allow OpenEBS to register its custom objects.
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["*"]
+# Allow OpenEBS to manage its own custom objects cluster-wide.
+- apiGroups: ["*"]
+  resources:
+  - disks
+  - blockdevices
+  - blockdeviceclaims
+  - cstorpoolclusters
+  - storagepoolclaims
+  - storagepoolclaims/finalizers
+  - cstorpoolclusters/finalizers
+  - storagepools
+  - castemplates
+  - runtasks
+  - upgradetasks
+  - cstorpools
+  - cstorpools/finalizers
+  - cstorvolumereplicas
+  - cstorvolumes
+  - cstorvolumeclaims
+  - cstorpoolinstances
+  - cstorpoolinstances/finalizers
+  - cstorbackups
+  - cstorrestores
+  - cstorcompletedbackups
+  verbs: ["*"]
+- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+  resources:
+  - volumesnapshots
+  - volumesnapshotdatas
+  verbs: ["*"]
+# Allow OpenEBS to install and manage its own admission webhooks.
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  verbs: ["list", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations"]
+  resourceNames: ["openebs-validation-webhook-cfg"]
+  verbs: ["*"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
 ---
 # Bind the Service Account with the Role Privileges.
 # TODO: Check if default account also needs to be there
@@ -686,4 +743,3 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
-


### PR DESCRIPTION
### What problem is being solved

The default set of RBAC permissions that comes with OpenEBS is very broad: it allows cluster-wide access to all core objects, ability to exec into any container and so on which can pose a security risk.

### How this change solves the problem

This change updates both `openebs-operator.yaml` and the Helm chart in an attempt to limit OpenEBS permissions in the following ways:

* Restrict CRUD permissions for core objects to OpenEBS specific namespace.
* Allow read-only access to some cluster-wide objects.
* Allow cluster-wide access to OpenEBS specific resources.
* Remove seemingly unnecessary permissions (more on that below).

### Notes

Note that I've removed a few permissions such as "ingresses", "horizontalpodautoscalers" and a couple of others that _seemed_ unnecessary - I searched through OpenEBS code and couldn't find any mention on those being used in any way - but if they are in fact needed for some use-cases, I'd be happy to bring them back (maybe a comment/explanation on what they're used for would be in order).

I have run a few tests with Local Provisioner (both host path and device modes) and cStor engine after making these changes and things worked fine. It would be helpful to run this through your CI as well to make sure nothing is missed.

Let me know what you think.