### PR TITLE
refact(cstor-operator): add cvc deployement into the cstor-operator

### DIFF
--- a/k8s/cstor-operator.yaml
+++ b/k8s/cstor-operator.yaml
@@ -69,3 +69,44 @@ spec:
         - name: RESYNC_INTERVAL
           value: "30"
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: dev
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: dev
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cvc-operator
+        imagePullPolicy: IfNotPresent
+        image: quay.io/openebs/cvc-operator:ci
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "quay.io/openebs/cstor-istgt:ci"
+        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "quay.io/openebs/cstor-volume-mgmt:ci"
+        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "quay.io/openebs/m-exporter:ci"
+---


### PR DESCRIPTION
commits adds cvc deployement resource in cstor-operator yaml config
to arrange them in single operator file to use cstor csi
and cspc pool based provisioning.

more context related to PR : https://github.com/openebs/maya/pull/1559

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
