### PR TITLE
chore(openebs-operator yaml): add poddisruptionbudgets to openebs clusterrole

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -33,7 +33,7 @@ rules:
   resources: ["resourcequotas", "limitranges"]
   verbs: ["list", "watch"]
 - apiGroups: ["*"]
-  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "poddisruptionbudgets", "certificatesigningrequests"]
+  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "certificatesigningrequests"]
   verbs: ["list", "watch"]
 - apiGroups: ["*"]
   resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
@@ -75,7 +75,7 @@ rules:
   verbs: ["*"]
 - apiGroups: ["*"]
   resources: ["poddisruptionbudgets"]
-  verbs: ["get", "list", "create", "delete"]
+  verbs: ["get", "list", "create", "delete", "watch"]
 ---
 # Bind the Service Account with the Role Privileges.
 # TODO: Check if default account also needs to be there

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -71,8 +71,11 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 - apiGroups: ["*"]
-  resources: [ "upgradetasks"]
-  verbs: ["*" ]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete"]
 ---
 # Bind the Service Account with the Role Privileges.
 # TODO: Check if default account also needs to be there


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR adds a pod disruption budget to the OpenEBS cluster roles.
For more information, please refer: https://github.com/openebs/maya/pull/1573

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
