### PR TITLE
chore(cstor-operator): add ENV to configure sparse directory

### DIFF
--- a/k8s/cstor-operator.yaml
+++ b/k8s/cstor-operator.yaml
@@ -60,6 +60,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+        #  value: "/var/openebs/sparse"
         - name: OPENEBS_IO_CSPI_MGMT_IMAGE
           value: "quay.io/openebs/cspi-mgmt:ci"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE

--- a/k8s/cstor-operator.yaml
+++ b/k8s/cstor-operator.yaml
@@ -106,6 +106,11 @@ spec:
         imagePullPolicy: IfNotPresent
         image: quay.io/openebs/cvc-operator:ci
         env:
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+        # that to be used for saving the core dump of cstor volume pod.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+        #  value: "/var/openebs/sparse"
         - name: OPENEBS_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
This PR add configurable ENV to store cStor related items.
This ENV to be used for saving the shared content between
the side cars of cStor pool pod.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
