### PR TITLE
chore(travis_ci): enable provisioning for travis spc

### DIFF
--- a/k8s/sample-pv-yamls/spc-sparse-single.yaml
+++ b/k8s/sample-pv-yamls/spc-sparse-single.yaml
@@ -11,4 +11,4 @@ spec:
   poolSpec:
     poolType: striped
     cacheFile: /var/openebs/sparse/sparse-claim-auto.cache
-    overProvisioning: false
+    overProvisioning: true


### PR DESCRIPTION
The PR https://github.com/openebs/maya/pull/1577 adds capability to restrict the over-provisioning of the volumes.
This PR enables overprovisioning for Travis SPC else CI can fail.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>