### PR TITLE
feat(deployment, baseDir): add support to take baseDir as configurable value

### DIFF
--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -84,6 +84,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: basepath
+          mountPath: /var/openebs
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
         - name: sparsepath
@@ -104,6 +106,10 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: basepath
+        hostPath:
+          path: "{{ .Values.persistentStoragePath.baseDir }}/ndm"
+          type: DirectoryOrCreate
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
       - name: sparsepath

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -104,7 +104,7 @@ spec:
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
         - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
-          value: "{{ .Values.localprovisioner.basePath }}"
+          value: "{{ .Values.persistentStoragePath.baseDir }}"
         # OPENEBS_IO_BASE_DIR used to specify base directory to store OpenEBS
         # related files
         - name: OPENEBS_IO_BASE_DIR

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -105,6 +105,10 @@ spec:
         # is set to true
         - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
           value: "{{ .Values.localprovisioner.basePath }}"
+        # OPENEBS_IO_BASE_DIR used to specify base directory to store OpenEBS
+        # related files
+        - name: OPENEBS_IO_BASE_DIR
+          value: "{{ .Values.release.baseDir }}"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -104,11 +104,11 @@ spec:
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
         - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
-          value: "{{ .Values.persistentStoragePath.baseDir }}"
+          value: "{{ .Values.localprovisioner.basePath }}"
         # OPENEBS_IO_BASE_DIR used to specify base directory to store OpenEBS
         # related files
         - name: OPENEBS_IO_BASE_DIR
-          value: "{{ .Values.release.baseDir }}"
+          value: "{{ .Values.persistentStoragePath.baseDir }}"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -13,6 +13,9 @@ serviceAccount:
 release:
   # "openebs.io/version" label for control plane components
   version: "1.5.0"
+  # baseDir is the value used to store openebs related files in this base
+  # directory
+  baseDir: "/var/openebs"
 
 image:
   pullPolicy: IfNotPresent

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -13,9 +13,6 @@ serviceAccount:
 release:
   # "openebs.io/version" label for control plane components
   version: "1.5.0"
-  # baseDir is the value used to store openebs related files in this base
-  # directory
-  baseDir: "/var/openebs"
 
 image:
   pullPolicy: IfNotPresent
@@ -39,6 +36,11 @@ apiserver:
 
 defaultStorageConfig:
   enabled: "true"
+
+persistentStoragePath:
+  # baseDir is the value used to store openebs related files in this base
+  # directory
+  baseDir: "/var/openebs"
 
 provisioner:
   enabled: true


### PR DESCRIPTION
This PR add persistent storage path to store OpenEBS componets related files.
Following are the PRs to honor the changes:
- https://github.com/openebs/maya/pull/1583
- https://github.com/openebs/node-disk-manager/pull/362

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
