### PR TITLE
feat(deployment, baseDir): add support to take baseDir as configurable value

### DIFF
--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -85,7 +85,7 @@ spec:
           mountPath: /host/proc
           readOnly: true
         - name: basepath
-          mountPath: /var/openebs
+          mountPath: /var/openebs/ndm
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
         - name: sparsepath

--- a/k8s/charts/openebs/templates/daemonset-ndm.yaml
+++ b/k8s/charts/openebs/templates/daemonset-ndm.yaml
@@ -84,6 +84,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: basepath
+          mountPath: /var/openebs
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
         - name: sparsepath
@@ -104,6 +106,10 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: basepath
+        hostPath:
+          path: "{{ .Values.persistentStoragePath.baseDir }}/ndm"
+          type: DirectoryOrCreate
 {{- if .Values.ndm.sparse }}
 {{- if .Values.ndm.sparse.path }}
       - name: sparsepath

--- a/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/k8s/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -105,6 +105,10 @@ spec:
         # is set to true
         - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
           value: "{{ .Values.localprovisioner.basePath }}"
+        # OPENEBS_IO_BASE_DIR used to specify base directory to store OpenEBS
+        # related files
+        - name: OPENEBS_IO_BASE_DIR
+          value: "{{ .Values.persistentStoragePath.baseDir }}"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE

--- a/k8s/charts/openebs/values.yaml
+++ b/k8s/charts/openebs/values.yaml
@@ -38,6 +38,11 @@ apiserver:
 defaultStorageConfig:
   enabled: "true"
 
+persistentStoragePath:
+  # baseDir is the value used to store openebs related files in this base
+  # directory
+  baseDir: "/var/openebs"
+
 provisioner:
   enabled: true
   image: "quay.io/openebs/openebs-k8s-provisioner"

--- a/k8s/cstor-operator.yaml
+++ b/k8s/cstor-operator.yaml
@@ -60,6 +60,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
         # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
         # to be used for saving the shared content between the side cars
         # of cstor pool pod. This ENV is also used to indicate the location
@@ -106,6 +110,10 @@ spec:
         imagePullPolicy: IfNotPresent
         image: quay.io/openebs/cvc-operator:ci
         env:
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
         # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
         # that to be used for saving the core dump of cstor volume pod.
         # The default path used is /var/openebs/sparse

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -164,6 +164,10 @@ spec:
         # is set to true
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "false"
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
         # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
         # to be used for saving the shared content between the side cars
         # of cstor volume pod.

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -479,6 +479,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: basepath
+          mountPath: /var/openebs/ndm
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -524,6 +526,10 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: basepath
+        hostPath:
+          path: /var/openebs/ndm
+          type: DirectoryOrCreate
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse


### PR DESCRIPTION
<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->

This PR adds support to configure OpenEBS baseDir via OPENEBS_IO_BASE_DIR.
These changes have been reverted back before OpenEBS 1.6 release as planned to take in the next release(https://github.com/openebs/openebs/pull/2880).

