### PR TITLE
fix(Travis): increase PVC retry counts from 5 to 10 to fix maya travis

### DIFF
--- a/k8s/ci/test-script.sh
+++ b/k8s/ci/test-script.sh
@@ -110,7 +110,7 @@ kubectl apply -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/ci
 
 checkForPVC1GStatus(){
 PVC_NAME=$1
-PVC1G_MAX_RETRY=5
+PVC1G_MAX_RETRY=10
 for i in $(seq 1 $PVC1G_MAX_RETRY) ; do
 	PVC1GStatus=$(kubectl get pvc test-pvc-1gig --output="jsonpath={.status.phase}")
 		if [ "$PVC1GStatus" == "Bound" ]; then

--- a/k8s/ci/test-script.sh
+++ b/k8s/ci/test-script.sh
@@ -130,8 +130,8 @@ for i in $(seq 1 $PVC1G_MAX_RETRY) ; do
 checkForPVC10GStatus(){
 PVC10G_MAX_RETRY=5
 for i in $(seq 1 $PVC10G_MAX_RETRY) ; do
-	PVC1GStatus=$(kubectl get pvc test-pvc-10gigs --output="jsonpath={.status.phase}")
-		if [ "$PVC1GStatus" == "Bound" ]; then
+	PVC10GStatus=$(kubectl get pvc test-pvc-10gigs --output="jsonpath={.status.phase}")
+		if [ "$PVC10GStatus" == "Bound" ]; then
 			echo "PVC test-pvc-10gigs should NOT bound successfully due to overprovisioning restriction but got bound"
                         kubectl get pvc test-pvc-10gigs
 			exit 1
@@ -145,7 +145,9 @@ for i in $(seq 1 $PVC10G_MAX_RETRY) ; do
       			sleep 5
 		done
 }
+## Running OverProvisioning before general tests
 runVolumeOverProvisioningTest
+
 
 echo "--------------- Create Cstor and Jiva PersistentVolume ------------------"
 #kubectl create -f https://raw.githubusercontent.com/openebs/openebs/master/k8s/sample-pv-yamls/pvc-jiva-sc-1r.yaml
@@ -160,21 +162,21 @@ kubectl get pods --all-namespaces
 
 kubectl get deploy -l openebs.io/controller=jiva-controller
 JIVACTRL=$(kubectl get deploy -l openebs.io/controller=jiva-controller --no-headers | awk {'print $1'})
-for ctrl in "${JIVACTRL[@]}"
+for ctrl in `echo "${JIVACTRL[@]}" | tr "\n" " "`;
 do
 waitForDeployment ${ctrl} default
 done
 
 kubectl get deploy -l openebs.io/replica=jiva-replica
 JIVAREP=$(kubectl get deploy -l openebs.io/replica=jiva-replica --no-headers | awk {'print $1'})
-for rep in "${JIVAREP[@]}"
+for rep in `echo "${JIVAREP[@]}" | tr "\n" " "`;
 do
 waitForDeployment ${rep} default
 done
 
 kubectl get deploy -n openebs -l openebs.io/target=cstor-target
 CSTORTARGET=$(kubectl get deploy -n openebs -l openebs.io/target=cstor-target --no-headers | awk {'print $1'})
-for target in "${CSTORTARGET[@]}"
+for target in `echo  "${CSTORTARGET[@]}" | tr "\n" " "`;
 do
 waitForDeployment ${target} openebs
 done


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR increases the retry counts of PVC check from 5 to 10. 
Now PVC bound status will check for 50 seconds at the interval of 5seconds.
This PR also fixes the cStor volume target pod check bypassing valid arguments to `waitForDeployment`.
Before the fix:
```sh
for target in  "${CSTORTARGET[@]}
do
waitForDeployment ${target} openebs
done
```
Due to the existence of two cStor target pods, it passes "PV1" & "\nPV2" as arguments to waitForDeployment. After the fix it passes "PV1" "namespace" as an argument.

Here are the logs of Maya Travis: 
[log.txt](https://github.com/openebs/openebs/files/4163653/log.txt)



<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
