### PR TITLE
oep(schema) : freeze cstorvolumes related APIs schema and move to GA

### DIFF
--- a/contribute/design/1.x/apis/cstor_volume.md
+++ b/contribute/design/1.x/apis/cstor_volume.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-This proposal highlights the limitations of current `CStorVolumes` and `CStorVolumeReplicas` schema and
+This proposal highlights the enhancements and migration of current `CStorVolumes` and `CStorVolumeReplicas` schema and
 proposes improvements.
 
 # Goals
@@ -22,6 +22,16 @@ Apart from this the document focuses on following aspects too:
 - Migrating the `CStorVolumes` and `CStorVolumeReplica` CRD to `v1` apiversion.
 - Identify the breaking and upgrade changes and documentation around that.
 - List of possible high level status fields on `CStorVolumes` and `CStorVolumeReplica`.
+- Enhancements for operations based resource events based in `CStorVolumes` and `CStorVolumeReplicas`
+
+# Enhancements
+
+- Generate conditional events for different operations
+- Volume Replica Rebuild status information for individual replicas
+- VolumeReplica capacity details using logical referenced values
+- Enhanced and updated `CStorVolumeReplicas` health state on different failures observed via controllers
+- Enhanced and updated `CStorVolumes` health state on different failures observed via controllers
+- Add BlockSize and Compression properties to configure them on per volume bases
 
 # Non-Goals
 
@@ -109,7 +119,7 @@ type CStorVolumeList struct {
 	Items []CStorVolume `json:"items"`
 }
 
-// CVStatusResponse stores the reponse of istgt replica command output
+// CVStatusResponse stores the response of istgt replica command output
 // It may contain several volumes
 type CVStatusResponse struct {
 	CVStatuses []CVStatus `json:"volumeStatus"`
@@ -122,16 +132,30 @@ type CVStatus struct {
 	ReplicaStatuses []ReplicaStatus `json:"replicaStatus"`
 }
 
+
 // ReplicaStatus stores the status of replicas
 type ReplicaStatus struct {
-	ID                string `json:"replicaId"`
-	Mode              string `json:"mode"`
+	// ID is replica unique identifier
+	ID string `json:"replicaId"`
+	// Mode represents replica status i.e. Healthy, Degraded
+	Mode string `json:"mode"`
+	// Represents IO number of replicas persisted on the disk
 	CheckpointedIOSeq string `json:"checkpointedIOSeq"`
-	InflightRead      string `json:"inflightRead"`
-	InflightWrite     string `json:"inflightWrite"`
-	InflightSync      string `json:"inflightSync"`
-	UpTime            int    `json:"upTime"`
-	Quorum            string `json:"quorum"`
+	// Ongoing reads I/O from target to replica
+	InflightRead string `json:"inflightRead"`
+	// ongoing writes I/O from target to replica
+	InflightWrite string `json:"inflightWrite"`
+	// Ongoing sync I/O from target to replica
+	InflightSync string `json:"inflightSync"`
+	// time since the replica connected to target
+	UpTime int `json:"upTime"`
+	// Quorum indicates wheather data wrtitten to the replica
+	// is lost or exists.
+	// "0" means: data has been lost( might be ephimeral case)
+	// and will recostruct data from other Healthy replicas in a write-only
+	// mode
+	// 1 means: written data is exists on replica
+	Quorum string `json:"quorum"`
 }
 
 // CStorVolumeCondition contains details about state of cstorvolume
@@ -172,11 +196,11 @@ type ConditionStatus string
 const (
 	// ConditionInProgress states resize of underlying volumes are in progress
 	ConditionInProgress ConditionStatus = "InProgress"
-	// ConditionSuccess states resizing underlying volumes are successfull
+	// ConditionSuccess states resizing underlying volumes are successful
 	ConditionSuccess ConditionStatus = "Success"
 )
 ```
-# Changes to existing types
+## Changes to existing types
 
 - Remove the `Spec.Status` field of the `CStorvolumeSpec`. `Status` field has been used to set the initial `init` state of `CStorVolume` in case of openebs-director.
 
@@ -185,8 +209,9 @@ const (
 ```go
 
 // +genclient
-// +k8s:openapi-gen=true
+// +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=cstorvolumereplica
 
 // CStorVolumeReplica describes a cstor volume resource created as custom resource
 type CStorVolumeReplica struct {
@@ -197,21 +222,29 @@ type CStorVolumeReplica struct {
 	VersionDetails    VersionDetails           `json:"versionDetails"`
 }
 
+
 // CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
 type CStorVolumeReplicaSpec struct {
+	// TargetIP represents iscsi target IP through which replica cummunicates
+	// IO workloads and other volume operations like snapshot and resize requests
 	TargetIP string `json:"targetIP"`
+	//Represents the actual capacity of the underlying volume
 	Capacity string `json:"capacity"`
 	// ZvolWorkers represents number of threads that executes client IOs
 	ZvolWorkers string `json:"zvolWorkers"`
 	// ReplicaID is unique number to identify the replica
 	ReplicaID string `json:"replicaid"`
-
-    // BlockSize size of data block. The blocksize cannot be changed once
-    // the volume has been written, so it should be set at volume creation
-    // time.The default blocksize for volumes is 4 Kbytes. Any power of 2 
-    // from 512 bytes to 128 Kbytes is valid.
-	BlockSize string `json:"blockSize"`
+	// Controls the compression algorithm used for this volumes
+	// examples: on|off|gzip|gzip-N|lz4|lzjb|zle
+	Compression string `json:"compression"`
+	// BlockSize is the logical block size in multiple of 512 bytes
+	// BlockSize specifies the block size of the volume. The blocksize
+	// cannot be changed once the volume has been written, so it should be
+	// set at volume creation time. The default blocksize for volumes is 4 Kbytes.
+	// Any power of 2 from 512 bytes to 128 Kbytes is valid.
+	BlockSize uint32 `json:"blockSize"`
 }
+
 
 // CStorVolumeReplicaPhase is to hold result of action.
 type CStorVolumeReplicaPhase string
@@ -239,7 +272,7 @@ const (
 	// CVRStatusNewReplicaDegraded describes replica is recreated (due to pool
 	// recreation[underlying disk got changed]/volume replica scaleup cases) and
 	// just connected to the target. Volume replica has to start reconstructing
-	// entier data from another available healthy replica. Until volume replica
+	// entire data from another available healthy replica. Until volume replica
 	// becomes healthy whatever data written to it is lost(NewReplica also not part
 	// of any quorum decision)
 	CVRStatusNewReplicaDegraded CStorVolumeReplicaPhase = "NewReplicaDegraded"
@@ -249,7 +282,7 @@ const (
 	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
 
 	// CVRStatusReconstructingNewReplica describes volume replica is recreated
-	// and it started reconstructing entier data from other healthy replica
+	// and it started reconstructing entire data from other healthy replica
 	CVRStatusReconstructingNewReplica CStorVolumeReplicaPhase = "ReconstructingNewReplica"
 
 	// CVRStatusError describes either volume replica is not exist in cstor pool
@@ -272,27 +305,24 @@ const (
 
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
-	// Phase represents different states of CStorVolumeReplicas
-	Phase    CStorVolumeReplicaPhase `json:"phase"`
-	
-	// CStorVolumeCapacityDetails represents capacity information releated to volume
-    // replica
-    Capacity CStorVolumeCapacityDetails `json:"capacity"`
-	
-    // LastTransitionTime refers to the time when the phase changes
+	// CStorVolumeReplicaPhase is to holds different phases of replica
+	Phase CStorVolumeReplicaPhase `json:"phase"`
+	// CStorVolumeCapacityDetails represents capacity info of replica
+	Capacity CStorVolumeReplicaCapacityDetails `json:"capacity"`
+	// LastTransitionTime refers to the time when the phase changes
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
-	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
-	Message            string      `json:"message,omitempty"`
+	// The last updated time
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
+	// A human readable message indicating details about the transition.
+	Message string `json:"message,omitempty"`
 }
 
-
-// CStorVolumeCapacityDetails represents capacity information releated to volume
+// CStorVolumeReplicaCapacityDetails represents capacity information related to volume
 // replica
-type CStorVolumeCapacityDetails struct {
-	// The amount of space consumed by this volume replica and all its descendents
+type CStorVolumeReplicaCapacityDetails struct {
+	// The amount of space consumed by this volume replica and all its descendants
 	Total string `json:"total"`
-	
-    // The amount of space that is "logically" accessible by this dataset. The logical
+	// The amount of space that is "logically" accessible by this dataset. The logical
 	// space ignores the effect of the compression and copies properties, giving a
 	// quantity closer to the amount of data that applications see.  However, it does
 	// include space consumed by metadata
@@ -300,6 +330,7 @@ type CStorVolumeCapacityDetails struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +resource:path=cstorvolumereplicas
 
 // CStorVolumeReplicaList is a list of CStorVolumeReplica resources
 type CStorVolumeReplicaList struct {
@@ -310,10 +341,12 @@ type CStorVolumeReplicaList struct {
 }
 ```
 
-# Changes to existing types
-- Rename `CStorVolumeCapacityAttr` to `CStorVolumeCapacityDetails`
+## Changes to existing types
+
+- Rename `CStorVolumeCapacityAttr` to `CStorVolumeReplicaCapacityDetails`
 - Rename `TotalAllocated` to `Total` under `CStorVolumeCapacityDetails` referenced to `used` zfs get property
 - `Used` field under `CStorVolumeCapacityDetails.Used` will be referenced to `logicalreferenced` zfs get property.
+- Added `BlockSize`, `Compression` properties under `CStorVolumereplica` Spec to configure per volume replica bases
 
 # Risks and Mitigations
 

--- a/contribute/design/1.x/apis/cstor_volume.md
+++ b/contribute/design/1.x/apis/cstor_volume.md
@@ -1,0 +1,300 @@
+# Move `CStorVolumes`, `CStorVolumeReplica` resources Schema to version `v1`
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Goals](#goals)
+* [Non-Goals](#non-goals)
+* [Schema Proposal](#volume-schema-proposal)
+* [Risk and Mitigations](#risks-and-mitigations)
+* [CRD Migration and Graduation](#graduation-criteria)
+
+## Introduction
+
+This proposal highlights the limitations of current `CStorVolumes` and `CStorVolumeReplicas` schema and
+proposes improvements.
+
+# Goals
+
+The major goal of this document is to freeze the APIs schema for `CStorVolumes` and `CStorVolumeReplica`.
+Apart from this the document focuses on following aspects too:
+
+- Migrating the `CStorVolumes` and `CStorVolumeReplica` CRD to `v1` apiversion.
+- Identify the breaking and upgrade changes and documentation around that.
+- List of possible high level status fields on `CStorVolumes` and `CStorVolumeReplica`.
+
+# Non-Goals
+
+- Introduction of new fields in the `CStorVolumes` and `CStorVolumeReplica` to deliver feature etc.
+- List of possible events that should be recorded on `CStorVolumes` and `CStorVolumesReplicas`.
+- List of conditions that should be put on the `CStorVolumes` and `CStorVolumesReplicas` CRs.
+
+# Volume Schema Proposal
+
+## `CStorVolumes` APIs
+
+```go
+// +genclient
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// CStorVolume describes a cstor volume resource created as custom resource
+type CStorVolume struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              CStorVolumeSpec   `json:"spec"`
+	Status            CStorVolumeStatus `json:"status"`
+	VersionDetails    VersionDetails    `json:"versionDetails"`
+}
+
+// CStorVolumeSpec is the spec for a CStorVolume resource
+type CStorVolumeSpec struct {
+	// Capacity represents the desired size of the underlying volume.
+	Capacity          resource.Quantity `json:"capacity"`
+	TargetIP          string            `json:"targetIP"`
+	TargetPort        string            `json:"targetPort"`
+	Iqn               string            `json:"iqn"`
+	TargetPortal      string            `json:"targetPortal"`
+	NodeBase          string            `json:"nodeBase"`
+	ReplicationFactor int               `json:"replicationFactor"`
+	ConsistencyFactor int               `json:"consistencyFactor"`
+	// DesiredReplicationFactor represents maximum number of replicas
+	// that are allowed to connect to the target
+	DesiredReplicationFactor int `json:"desiredReplicationFactor"`
+	//ReplicaDetails refers to the trusty replica information
+	ReplicaDetails CStorVolumeReplicaDetails `json:"replicaDetails,omitempty"`
+}
+
+// ReplicaID is to hold replicaID information
+type ReplicaID string
+
+// CStorVolumePhase is to hold result of action.
+type CStorVolumePhase string
+
+// CStorVolumeStatus is for handling status of cvr.
+type CStorVolumeStatus struct {
+	Phase           CStorVolumePhase `json:"phase"`
+	ReplicaStatuses []ReplicaStatus  `json:"replicaStatuses,omitempty"`
+	// Represents the actual resources of the underlying volume.
+	Capacity resource.Quantity `json:"capacity,omitempty"`
+	// LastTransitionTime refers to the time when the phase changes
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
+	// Current Condition of cstorvolume. If underlying persistent volume is being
+	// resized then the Condition will be set to 'ResizePending'.
+	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
+	Conditions []CStorVolumeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
+	// ReplicaDetails refers to the trusty replica information which are
+	// connected at given time
+	ReplicaDetails CStorVolumeReplicaDetails `json:"replicaDetails,omitempty"`
+}
+
+// CStorVolumeReplicaDetails contains trusty replica inform which will be
+// updated by target
+type CStorVolumeReplicaDetails struct {
+	// KnownReplicas represents the replicas that target can trust to read data
+	KnownReplicas map[ReplicaID]string `json:"knownReplicas,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// CStorVolumeList is a list of CStorVolume resources
+type CStorVolumeList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []CStorVolume `json:"items"`
+}
+
+// CVStatusResponse stores the reponse of istgt replica command output
+// It may contain several volumes
+type CVStatusResponse struct {
+	CVStatuses []CVStatus `json:"volumeStatus"`
+}
+
+// CVStatus stores the status of a CstorVolume obtained from response
+type CVStatus struct {
+	Name            string          `json:"name"`
+	Status          string          `json:"status"`
+	ReplicaStatuses []ReplicaStatus `json:"replicaStatus"`
+}
+
+// ReplicaStatus stores the status of replicas
+type ReplicaStatus struct {
+	ID                string `json:"replicaId"`
+	Mode              string `json:"mode"`
+	CheckpointedIOSeq string `json:"checkpointedIOSeq"`
+	InflightRead      string `json:"inflightRead"`
+	InflightWrite     string `json:"inflightWrite"`
+	InflightSync      string `json:"inflightSync"`
+	UpTime            int    `json:"upTime"`
+	Quorum            string `json:"quorum"`
+}
+
+// CStorVolumeCondition contains details about state of cstorvolume
+type CStorVolumeCondition struct {
+	Type   CStorVolumeConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=CStorVolumeConditionType"`
+	Status ConditionStatus          `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
+	// Last time we probed the condition.
+	// +optional
+	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty" protobuf:"bytes,3,opt,name=lastProbeTime"`
+	// Last time the condition transitioned from one status to another.
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty" protobuf:"bytes,4,opt,name=lastTransitionTime"`
+	// Unique, this should be a short, machine understandable string that gives the reason
+	// for condition's last transition. If it reports "ResizePending" that means the underlying
+	// cstorvolume is being resized.
+	// +optional
+	Reason string `json:"reason,omitempty" protobuf:"bytes,5,opt,name=reason"`
+	// Human-readable message indicating details about last transition.
+	// +optional
+	Message string `json:"message,omitempty" protobuf:"bytes,6,opt,name=message"`
+}
+
+// CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+type CStorVolumeConditionType string
+
+const (
+	// CStorVolumeResizing - a user trigger resize of pvc has been started
+	CStorVolumeResizing CStorVolumeConditionType = "Resizing"
+)
+
+// ConditionStatus states in which state condition is present
+type ConditionStatus string
+
+// These are valid condition statuses. "ConditionInProgress" means corresponding
+// condition is inprogress. "ConditionSuccess" means corresponding condition is success
+const (
+	// ConditionInProgress states resize of underlying volumes are in progress
+	ConditionInProgress ConditionStatus = "InProgress"
+	// ConditionSuccess states resizing underlying volumes are successfull
+	ConditionSuccess ConditionStatus = "Success"
+)
+```
+# Changes to existing types
+
+- Remvoe the `Status` field of the `CStorvolumeSpec`. This should not be too problematic but `Status` filed has been used to   set the initial `init` state of `CStorVolume` to be used in other SAAS application like openebs-director etc.
+
+## `CStorVolumeReplicas` APIs
+
+```go
+
+// +genclient
+// +k8s:openapi-gen=true
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// CStorVolumeReplica describes a cstor volume resource created as custom resource
+type CStorVolumeReplica struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              CStorVolumeReplicaSpec   `json:"spec"`
+	Status            CStorVolumeReplicaStatus `json:"status"`
+	VersionDetails    VersionDetails           `json:"versionDetails"`
+}
+
+// CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
+type CStorVolumeReplicaSpec struct {
+	TargetIP string `json:"targetIP"`
+	Capacity string `json:"capacity"`
+	// ZvolWorkers represents number of threads that executes client IOs
+	ZvolWorkers string `json:"zvolWorkers"`
+	// ReplicaID is unique number to identify the replica
+	ReplicaID string `json:"replicaid"`
+}
+
+// CStorVolumeReplicaPhase is to hold result of action.
+type CStorVolumeReplicaPhase string
+
+// Status written onto CStorVolumeReplica objects.
+const (
+
+	// CVRStatusEmpty describes CVR resource is created but not yet monitored by
+	// controller(i.e resource is just created)
+	CVRStatusEmpty CStorVolumeReplicaPhase = ""
+
+	// CVRStatusOnline describes volume replica is Healthy and data existing on
+	// the healthy replica is up to date
+	CVRStatusOnline CStorVolumeReplicaPhase = "Healthy"
+
+	// CVRStatusOffline describes volume replica is created but not yet connected
+	// to the target
+	CVRStatusOffline CStorVolumeReplicaPhase = "Offline"
+
+	// CVRStatusDegraded describes volume replica is connected to the target and
+	// rebuilding from other replicas is not yet started but ready for serving
+	// IO's
+	CVRStatusDegraded CStorVolumeReplicaPhase = "Degraded"
+
+	// CVRStatusNewReplicaDegraded describes replica is recreated (due to pool
+	// recreation[underlying disk got changed]/volume replica scaleup cases) and
+	// just connected to the target. Volume replica has to start reconstructing
+	// entier data from another available healthy replica. Until volume replica
+	// becomes healthy whatever data written to it is lost(NewReplica also not part
+	// of any quorum decision)
+	CVRStatusNewReplicaDegraded CStorVolumeReplicaPhase = "NewReplicaDegraded"
+
+	// CVRStatusRebuilding describes volume replica has missing data and it
+	// started rebuilding missing data from other replicas
+	CVRStatusRebuilding CStorVolumeReplicaPhase = "Rebuilding"
+
+	// CVRStatusReconstructingNewReplica describes volume replica is recreated
+	// and it started reconstructing entier data from other healthy replica
+	CVRStatusReconstructingNewReplica CStorVolumeReplicaPhase = "ReconstructingNewReplica"
+
+	// CVRStatusError describes either volume replica is not exist in cstor pool
+	CVRStatusError CStorVolumeReplicaPhase = "Error"
+
+	// CVRStatusDeletionFailed describes volume replica deletion is failed
+	CVRStatusDeletionFailed CStorVolumeReplicaPhase = "DeletionFailed"
+
+	// CVRStatusInvalid ensures invalid resource(currently not honoring)
+	CVRStatusInvalid CStorVolumeReplicaPhase = "Invalid"
+
+	// CVRStatusInit describes CVR resource is newly created but it is not yet
+	// created zfs dataset
+	CVRStatusInit CStorVolumeReplicaPhase = "Init"
+
+	// CVRStatusRecreate describes the volume replica is recreated due to pool
+	// recreation/scaleup
+	CVRStatusRecreate CStorVolumeReplicaPhase = "Recreate"
+)
+
+// CStorVolumeReplicaStatus is for handling status of cvr.
+type CStorVolumeReplicaStatus struct {
+	Phase    CStorVolumeReplicaPhase `json:"phase"`
+	Capacity CStorVolumeCapacityAttr `json:"capacity"`
+	// LastTransitionTime refers to the time when the phase changes
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	Message            string      `json:"message,omitempty"`
+}
+
+// CStorVolumeCapacityAttr is for storing the volume capacity.
+type CStorVolumeCapacityAttr struct {
+	TotalAllocated string `json:"totalAllocated"`
+	Used           string `json:"used"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// CStorVolumeReplicaList is a list of CStorVolumeReplica resources
+type CStorVolumeReplicaList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []CStorVolumeReplica `json:"items"`
+}
+```
+
+# Risks and Mitigations
+
+# Graduation Criteria
+
+### Resource Migration from `v1alpha1` to `v1`:
+
+- CRD will ensure that `v1alpha1` as well as `v1` is served but `v1` is the only storage version.
+
+- A conversion webhook server will be deployed to support back and forth conversion of resources for the served version.

--- a/contribute/design/1.x/apis/cstor_volume.md
+++ b/contribute/design/1.x/apis/cstor_volume.md
@@ -43,8 +43,8 @@ type CStorVolume struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              CStorVolumeSpec   `json:"spec"`
-	Status            CStorVolumeStatus `json:"status"`
 	VersionDetails    VersionDetails    `json:"versionDetails"`
+  Status            CStorVolumeStatus `json:"status"`
 }
 
 // CStorVolumeSpec is the spec for a CStorVolume resource
@@ -198,11 +198,20 @@ type CStorVolumeReplica struct {
 // CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
 type CStorVolumeReplicaSpec struct {
 	TargetIP string `json:"targetIP"`
-	Capacity string `json:"capacity"`
-	// ZvolWorkers represents number of threads that executes client IOs
-	ZvolWorkers string `json:"zvolWorkers"`
-	// ReplicaID is unique number to identify the replica
-	ReplicaID string `json:"replicaid"`
+
+  Capacity string `json:"capacity"`
+
+  // ZvolWorkers represents number of threads that executes client IOs
+  ZvolWorkers *int32 `json:"zvolWorkers"`
+
+  // ReplicaID is unique number to identify the replica
+  ReplicaID string `json:"replicaid"`
+
+  // BlockSize size of data block. The blocksize cannot be changed once
+  // the volume has been written, so it should be set at volume creation
+  // time.The default blocksize for volumes is 4 Kbytes. Any power of 2 
+  // from 512 bytes to 128 Kbytes is valid.
+	BlockSize string `json:"blockSize"`
 }
 
 // CStorVolumeReplicaPhase is to hold result of action.

--- a/contribute/design/1.x/apis/cstor_volume.md
+++ b/contribute/design/1.x/apis/cstor_volume.md
@@ -44,7 +44,7 @@ type CStorVolume struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              CStorVolumeSpec   `json:"spec"`
 	VersionDetails    VersionDetails    `json:"versionDetails"`
-  Status            CStorVolumeStatus `json:"status"`
+	Status            CStorVolumeStatus `json:"status"`
 }
 
 // CStorVolumeSpec is the spec for a CStorVolume resource
@@ -198,14 +198,11 @@ type CStorVolumeReplica struct {
 // CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica resource
 type CStorVolumeReplicaSpec struct {
 	TargetIP string `json:"targetIP"`
-
-  Capacity string `json:"capacity"`
-
-  // ZvolWorkers represents number of threads that executes client IOs
-  ZvolWorkers *int32 `json:"zvolWorkers"`
-
-  // ReplicaID is unique number to identify the replica
-  ReplicaID string `json:"replicaid"`
+	Capacity string `json:"capacity"`
+	// ZvolWorkers represents number of threads that executes client IOs
+	ZvolWorkers string `json:"zvolWorkers"`
+	// ReplicaID is unique number to identify the replica
+	ReplicaID string `json:"replicaid"`
 
   // BlockSize size of data block. The blocksize cannot be changed once
   // the volume has been written, so it should be set at volume creation
@@ -274,17 +271,27 @@ const (
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
 	Phase    CStorVolumeReplicaPhase `json:"phase"`
-	Capacity CStorVolumeCapacityAttr `json:"capacity"`
-	// LastTransitionTime refers to the time when the phase changes
+
+  Capacity CStorVolumeCapacityDetails `json:"capacity"`
+	
+  // LastTransitionTime refers to the time when the phase changes
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
 	Message            string      `json:"message,omitempty"`
 }
 
-// CStorVolumeCapacityAttr is for storing the volume capacity.
-type CStorVolumeCapacityAttr struct {
-	TotalAllocated string `json:"totalAllocated"`
-	Used           string `json:"used"`
+
+// CStorVolumeCapacityDetails represents capacity information releated to volume
+// replica
+type CStorVolumeCapacityDetails struct {
+	// The amount of space consumed by this volume replica and all its descendents
+	Total string `json:"totalAllocated"`
+	
+  // The amount of space that is "logically" accessible by this dataset. The logical
+	// space ignores the effect of the compression and copies properties, giving a
+	// quantity closer to the amount of data that applications see.  However, it does
+	// include space consumed by metadata
+	Used string `json:"used"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/contribute/design/1.x/apis/cstor_volume.md
+++ b/contribute/design/1.x/apis/cstor_volume.md
@@ -136,8 +136,10 @@ type ReplicaStatus struct {
 
 // CStorVolumeCondition contains details about state of cstorvolume
 type CStorVolumeCondition struct {
+	// Type is a different valid value of CStorVolumeCondition
 	Type   CStorVolumeConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=CStorVolumeConditionType"`
-	Status ConditionStatus          `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
+	
+	Status ConditionStatus `json:"status" protobuf:"bytes,2,opt,name=status,casttype=ConditionStatus"`
 	// Last time we probed the condition.
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty" protobuf:"bytes,3,opt,name=lastProbeTime"`
@@ -176,7 +178,7 @@ const (
 ```
 # Changes to existing types
 
-- Remvoe the `Status` field of the `CStorvolumeSpec`. This should not be too problematic but `Status` filed has been used to   set the initial `init` state of `CStorVolume` to be used in other SAAS application like openebs-director etc.
+- Remove the `Spec.Status` field of the `CStorvolumeSpec`. `Status` field has been used to set the initial `init` state of `CStorVolume` in case of openebs-director.
 
 ## `CStorVolumeReplicas` APIs
 
@@ -204,10 +206,10 @@ type CStorVolumeReplicaSpec struct {
 	// ReplicaID is unique number to identify the replica
 	ReplicaID string `json:"replicaid"`
 
-  // BlockSize size of data block. The blocksize cannot be changed once
-  // the volume has been written, so it should be set at volume creation
-  // time.The default blocksize for volumes is 4 Kbytes. Any power of 2 
-  // from 512 bytes to 128 Kbytes is valid.
+    // BlockSize size of data block. The blocksize cannot be changed once
+    // the volume has been written, so it should be set at volume creation
+    // time.The default blocksize for volumes is 4 Kbytes. Any power of 2 
+    // from 512 bytes to 128 Kbytes is valid.
 	BlockSize string `json:"blockSize"`
 }
 
@@ -270,11 +272,14 @@ const (
 
 // CStorVolumeReplicaStatus is for handling status of cvr.
 type CStorVolumeReplicaStatus struct {
+	// Phase represents different states of CStorVolumeReplicas
 	Phase    CStorVolumeReplicaPhase `json:"phase"`
-
-  Capacity CStorVolumeCapacityDetails `json:"capacity"`
 	
-  // LastTransitionTime refers to the time when the phase changes
+	// CStorVolumeCapacityDetails represents capacity information releated to volume
+    // replica
+    Capacity CStorVolumeCapacityDetails `json:"capacity"`
+	
+    // LastTransitionTime refers to the time when the phase changes
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
 	Message            string      `json:"message,omitempty"`
@@ -285,9 +290,9 @@ type CStorVolumeReplicaStatus struct {
 // replica
 type CStorVolumeCapacityDetails struct {
 	// The amount of space consumed by this volume replica and all its descendents
-	Total string `json:"totalAllocated"`
+	Total string `json:"total"`
 	
-  // The amount of space that is "logically" accessible by this dataset. The logical
+    // The amount of space that is "logically" accessible by this dataset. The logical
 	// space ignores the effect of the compression and copies properties, giving a
 	// quantity closer to the amount of data that applications see.  However, it does
 	// include space consumed by metadata
@@ -304,6 +309,11 @@ type CStorVolumeReplicaList struct {
 	Items []CStorVolumeReplica `json:"items"`
 }
 ```
+
+# Changes to existing types
+- Rename `CStorVolumeCapacityAttr` to `CStorVolumeCapacityDetails`
+- Rename `TotalAllocated` to `Total` under `CStorVolumeCapacityDetails` referenced to `used` zfs get property
+- `Used` field under `CStorVolumeCapacityDetails.Used` will be referenced to `logicalreferenced` zfs get property.
 
 # Risks and Mitigations
 

--- a/contribute/design/1.x/apis/cstorvolume_policy.md
+++ b/contribute/design/1.x/apis/cstorvolume_policy.md
@@ -1,0 +1,320 @@
+# Move `CStorVolumeConfig`, `CStorVolumePolicy` resources Schema to version `v1`
+
+## Table of Contents
+
+* [Introduction](#introduction)
+* [Goals](#goals)
+* [Non-Goals](#non-goals)
+* [VolumeConfig Schema Proposal](#volume-config-schema-proposal)
+* [VolumePolicy Schema Proposal](#volume-policy-schema-proposal)
+* [Risk and Mitigations](#risks-and-mitigations)
+* [CRD Migration and Graduation](#graduation-criteria)
+
+## Introduction
+
+This proposal highlights the limitations of current `CStorVolumeConfig` and `CStorVolumePolicy` schema and
+proposes improvements and feature changes.
+
+# Goals
+
+The major goal of this document is to freeze the APIs schema for `CStorVolumeConfig` and `CStorVolumePolicy`.
+Apart from this the document focuses on following aspects too:
+
+- Migrating the `CStorVolumeConfig` and `CStorVolumePolicy` CRD to `v1` apiversion inder `cstor.openebs.io` api group.
+- Identify the breaking and upgrade changes and documentation around that.
+- List of possible high level status fields on `CStorVolumeConfig` and `CStorVolumePolicy`.
+
+# Non-Goals
+
+- Introduction of new fields in the `CStorVolumeConfig` and `CStorVolumePolicy` to deliver feature etc.
+- List of possible events that should be recorded on `CStorVolumeConfig` and `CStorVolumesPolicy`.
+- List of conditions that should be put on the `CStorVolumeConfig` and `CStorVolumePolicy` CRs.
+
+# Volume Config Schema Proposal
+
+## `CStorVolumeConfig` APIs
+
+```go
+
+// CStorVolumeConfig describes a cstor volume config resource created as
+// custom resource. CStorVolumeConfig is a request for creating cstor volume
+// related resources like target deployment, replica resources and service etc.
+type CStorVolumeConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Spec defines a specification of a cstor volume claim required
+	// to provisione cstor volume resources
+	Spec CStorVolumeConfigSpec `json:"spec"`
+
+	// Publish contains info related to attachment of a volume to a node.
+	// i.e. NodeId etc.
+	Publish CStorVolumeConfigPublish `json:"publish,omitempty"`
+
+	// Status represents the current information/status for the cstor volume
+	// claim, populated by the controller.
+	Status         CStorVolumeConfigStatus `json:"status"`
+  // VersionDetails contains version related info
+  VersionDetails VersionDetails         `json:"versionDetails"`
+}
+
+// CStorVolumeConfigSpec is the spec for a CStorVolumeConfig resource
+type CStorVolumeConfigSpec struct {
+	// Capacity represents the actual resources of the underlying
+	// cstor volume.
+	Capacity corev1.ResourceList `json:"capacity"`
+	
+  // ReplicaCount represents the desired replica count for the underlying
+	// cstor volume
+	ReplicaCount int `json:"ReplicaCount"`
+
+	// CStorVolumeRef has the information about where CstorVolumeClaim
+	// is created from.
+	CStorVolumeRef *corev1.ObjectReference `json:"cstorVolumeRef,omitempty"`
+	
+  // CstorVolumeSource contains the source volumeName@snapShotname
+	// combaination.  This will be filled only if it is a clone creation.
+	CstorVolumeSource string `json:"cstorVolumeSource,omitempty"`
+	
+  // Policy contains volume specific required policies target and replicas
+	Policy CStorVolumePolicySpec `json:"policy"`
+}
+
+// CStorVolumeConfigPublish contains info related to attachment of a volume to a node.
+// i.e. NodeId etc.
+type CStorVolumeConfigPublish struct {
+	// NodeID contains publish info related to attachment of a volume to a node.
+	NodeID string `json:"nodeId,omitempty"`
+}
+
+// CStorVolumeConfigPhase represents the current phase of CStorVolumeConfig.
+type CStorVolumeConfigPhase string
+
+const (
+	//CStorVolumeConfigPhasePending indicates that the cvc is still waiting for
+	//the cstorvolume to be created and bound
+	CStorVolumeConfigPhasePending CStorVolumeConfigPhase = "Pending"
+
+	//CStorVolumeConfigPhaseBound indiacates that the cstorvolume has been
+	//provisioned and bound to the cstor volume claim
+	CStorVolumeConfigPhaseBound CStorVolumeConfigPhase = "Bound"
+
+	//CStorVolumeConfigPhaseFailed indiacates that the cstorvolume provisioning
+	//has failed
+	CStorVolumeConfigPhaseFailed CStorVolumeConfigPhase = "Failed"
+
+  //CStorVolumeConfigPhaseReconcile indicates that the changes currently
+	//reconclied based on the cstor volume policy changes to achieve the desired
+	//state
+	CStorVolumeConfigPhaseReconcile CStorVolumeConfigPhase = "Reconile"
+
+)
+
+// CStorVolumeConfigStatus is for handling status of CstorVolume Claim.
+// defines the observed state of CStorVolumeConfig
+type CStorVolumeConfigStatus struct {
+	// Phase represents the current phase of CStorVolumeConfig.
+	Phase CStorVolumeConfigPhase `json:"phase"`
+
+	// PoolInfo represents current pool names where volume replicas exists
+	PoolInfo []string `json:"poolInfo"`
+	
+  // Capacity the actual resources of the underlying volume.
+	Capacity   corev1.ResourceList         `json:"capacity,omitempty"`
+	
+  Conditions []CStorVolumeConfigCondition `json:"condition,omitempty"`
+}
+
+// CStorVolumeConfigCondition contains details about state of cstor volume
+type CStorVolumeConfigCondition struct {
+	// Current Condition of cstor volume claim. If underlying persistent volume is being
+	// resized then the Condition will be set to 'ResizeStarted' etc
+	Type CStorVolumeConfigConditionType `json:"type"`
+	
+  // Last time we probed the condition.
+	// +optional
+	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty"`
+	
+  // Last time the condition transitioned from one status to another.
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	
+  // Reason is a brief CamelCase string that describes any failure
+	Reason string `json:"reason"`
+	
+  // Human-readable message indicating details about last transition.
+	Message string `json:"message"`
+}
+
+// CStorVolumeConfigConditionType is a valid value of CstorVolumeConfigCondition.Type
+type CStorVolumeConfigConditionType string
+
+// These constants are CVC condition types related to resize operation.
+const (
+	// CStorVolumeConfigResizePending means volume resize operation has been started
+	CStorVolumeConfigResizing CStorVolumeConfigConditionType = "Resizing"
+
+  // CStorVolumeConfigResizeFailed means volume resize operation has been failed
+	CStorVolumeConfigResizeFailed CStorVolumeConfigConditionType = "VolumeResizeFailed"
+	
+  // CStorVolumeConfigResizeSuccess means volume resize operation has been successful
+	CStorVolumeConfigResizeSuccess CStorVolumeConfigConditionType = "VolumeResizeSuccessful"
+	
+  // CStorVolumeConfigResizePending means volume resize operation has been pending
+	CStorVolumeConfigResizePending CStorVolumeConfigConditionType = "VolumeResizePending"
+)
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
+// CStorVolumeConfigList is a list of CStorVolumeConfig resources
+type CStorVolumeConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []CStorVolumeConfig `json:"items"`
+}
+```
+
+# Changes to existing types
+
+- No changes
+
+# Volume Policy Schema Proposal
+
+## `CStorVolumePolicy` APIs
+
+```go
+
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
+// CStorVolumePolicy describes a configuration required for cstor volume
+// resources
+type CStorVolumePolicy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// Spec defines a configuration info of a cstor volume required
+	// to provisione cstor volume resources
+	Spec   CStorVolumePolicySpec   `json:"spec"`
+	Status CStorVolumePolicyStatus `json:"status"`
+}
+
+// CStorVolumePolicySpec ...
+type CStorVolumePolicySpec struct {
+  // Provision represents volume provisioning configuration like replicaAffinity
+  // etc
+	Provision Provision `json:"provision"`
+
+  // TargetSpec represents configuration related to cstor target and its resources
+	Target TargetSpec `json:"target,omitempty"`
+
+  // ReplicaSpec represents configuration related to replicas resources
+	Replica ReplicaSpec `json:"replica,omitempty"`
+
+
+	// ReplicaPoolInfo holds the pool information of volume replicas.
+	// Ex: If volume is provisioned on which CStor pool volume replicas exist
+	ReplicaPoolInfo []ReplicaPoolInfo `json:"replicaPoolInfo,omitempty"`
+}
+
+// TargetSpec represents configuration related to cstor target and its resources
+type TargetSpec struct {
+	// QueueDepth sets the queue size at iSCSI target which limits the
+	// ongoing IO count from client
+	QueueDepth string `json:"queueDepth,omitempty"`
+
+	// Luworkers sets the number of threads that are working on above queue
+	LuWorkers int64 `json:"luWorkers,omitempty"`
+
+	// Monitor enables or disables the target exporter sidecar
+	Monitor bool `json:"monitor,omitempty"`
+
+	// ReplicationFactor represents maximum number of replicas
+	// that are allowed to connect to the target
+	ReplicationFactor int64 `json:"replicationFactor,omitempty"`
+
+	// Resources are the compute resources required by the cstor-target
+	// container.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// AuxResources are the compute resources required by the cstor-target pod
+	// side car containers.
+	AuxResources *corev1.ResourceRequirements `json:"auxResources,omitempty"`
+
+	// Tolerations, if specified, are the target pod's tolerations
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// Affinity if specified, are the target pod's affinities
+	Affinity *corev1.PodAffinity `json:"affinity,omitempty"`
+
+	// NodeSelector is the labels that will be used to select
+	// a node for target pod scheduleing
+	// Required field
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// PriorityClassName if specified applies to this target pod
+	// If left empty, no priority class is applied.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
+}
+
+// ReplicaSpec represents configuration related to replicas resources
+type ReplicaSpec struct {
+	// ZvolWorkers represents number of threads that executes client IOs
+	ZvolWorkers *int32 `json:"zvolWorkers,omitempty"`
+	// Affinity if specified, are the replica affinities
+	Affinity *corev1.PodAffinity `json:"affinity,omitempty"`
+}
+
+// Provision represents volume provisioning configuration
+type Provision struct {
+	// replicaAffinity is set to true then volume replica resources need to be
+	// distributed across the cstor pool instances based on the given topology
+	ReplicaAffinity bool `json:"replicaAffinity"`
+}
+
+// ReplicaPoolSpec represents the volume replicas pool information
+type ReplicaPoolSpec struct {
+	// PoolInfo represents the pool information of replicas
+	PoolInfo []ReplicaPoolInfo `json:"poolInfo,omitempty"`
+}
+
+// ReplicaPoolInfo represents the pool information of volume replica
+type ReplicaPoolInfo struct {
+	// PoolName represents the pool name where volume replica exists
+	PoolName string `json:"poolName,omitempty"`
+	//TODO: UID also can be added
+}
+
+// CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+type CStorVolumePolicyStatus struct {
+	Phase string `json:"phase,omitempty"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
+// CStorVolumePolicyList is a list of CStorVolumePolicy resources
+type CStorVolumePolicyList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata"`
+
+	Items []CStorVolumePolicy `json:"items"`
+}
+```
+
+# Changes to existing types
+
+- Added `ReplicaPoolSpec` in `VolumePolicy` schema represents pool related information required
+  for replica scaleup/scale down operation.
+
+
+# Risks and Mitigations
+
+# Graduation Criteria
+
+### Resource Migration from `v1alpha1` to `v1`:
+
+- CRD will ensure that `v1alpha1` as well as `v1` is served but `v1` is the only storage version.
+
+- A conversion webhook server will be deployed to support back and forth conversion of resources for the served version.

--- a/contribute/design/1.x/apis/cstorvolume_policy.md
+++ b/contribute/design/1.x/apis/cstorvolume_policy.md
@@ -12,17 +12,35 @@
 
 ## Introduction
 
-This proposal highlights the limitations of current `CStorVolumeConfig` and `CStorVolumePolicy` schema and
-proposes improvements and feature changes.
+This proposal highlights enhancements and migration of current `CStorVolumeConfig` and `CStorVolumePolicy` schema and
+proposes feature changes.
 
 # Goals
 
 The major goal of this document is to freeze the APIs schema for `CStorVolumeConfig` and `CStorVolumePolicy`.
 Apart from this the document focuses on following aspects too:
 
-- Migrating the `CStorVolumeConfig` and `CStorVolumePolicy` CRD to `v1` apiversion inder `cstor.openebs.io` api group.
+- Migrating the `CStorVolumeConfig` and `CStorVolumePolicy` CRD to `v1` API version under `cstor.openebs.io` api group.
 - Identify the breaking and upgrade changes and documentation around that.
 - List of possible high level status fields on `CStorVolumeConfig` and `CStorVolumePolicy`.
+- Enhancements related to Day 2 operations which going to be control via `CStorVolumeConfig`:
+    - Seamless Volume online resize operations via just changing PVC capacity
+    - Scaling up/down of CStor volume replicas by add/delete pool under poolInfo
+    - Replica migrations from one pool to another pool across the nodes (via scale down one pool and scale up in other pool operation)
+    - Support for policy tunnables reconciliation per volume bases like tolerations, resource limits etc.
+    - High available volumes will have PodDistruptionBudget enforced via `CStorVolumeConfig`
+    - Events based on different supported volume operations like resize and scale
+    - Initial capacity as meta information for volume clone support as part of day 2-ops
+    - IOWorkers and QueueDepth at runtime reconcilation per volume bases
+
+- Enhancements related to Day 2 operations which going to be control via `CStorVolumePolicy`:
+    - Volume replica distributions based on the provisioning topology configured in StorageClass
+    - Policy based scheduling based on properties like Resource/auxResources limits, defaults will be set if not provided
+    - Policy can be used to configure target PodAffinities, PriorityClass, tolerations, NodeSelector etc based on the user requirements
+    - To enable/disable ReplicaAffinity feature to replica distribution based on user requirements
+    - Using Policy user can configure cstor volume related tunnables like IOWorkers, QueueDepth
+    - Pool selection feature for selecting specific pools across the pool cluster via adding pool names under PoolInfo
+
 
 # Non-Goals
 
@@ -30,19 +48,35 @@ Apart from this the document focuses on following aspects too:
 - List of possible events that should be recorded on `CStorVolumeConfig` and `CStorVolumesPolicy`.
 - List of conditions that should be put on the `CStorVolumeConfig` and `CStorVolumePolicy` CRs.
 
+# Debugging and Measures
+
+- Enhanced `CStorVolumeConfig` conditional status and events performed on volumes
+- Enhanced `CStorVolumeConfig` Status to validate and verify scale up/down operations
+- Additional initial capacity and replica count information related to day 2-ops
+- Different  events has been added for step by step processing of resize and scale operations
+- For easy debugging status of cvc will have following details:
+    * Replicas phase information
+    * volume phase information
+    * Making sure phase and state information will be sync with exact state
+    * Active number of replicas are connected to target
+
 # Volume Config Schema Proposal
 
 ## `CStorVolumeConfig` APIs
 
 ```go
 
+// +genclient
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +k8s:openapi-gen=true
+
 // CStorVolumeConfig describes a cstor volume config resource created as
 // custom resource. CStorVolumeConfig is a request for creating cstor volume
-// related resources like target deployment, replica resources and service etc.
+// related resources like deployment, svc etc.
 type CStorVolumeConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// Spec defines a specification of a cstor volume claim required
+	// Spec defines a specification of a cstor volume config required
 	// to provisione cstor volume resources
 	Spec CStorVolumeConfigSpec `json:"spec"`
 
@@ -51,10 +85,9 @@ type CStorVolumeConfig struct {
 	Publish CStorVolumeConfigPublish `json:"publish,omitempty"`
 
 	// Status represents the current information/status for the cstor volume
-	// claim, populated by the controller.
+	// config, populated by the controller.
 	Status         CStorVolumeConfigStatus `json:"status"`
-  // VersionDetails contains version related info
-  VersionDetails VersionDetails         `json:"versionDetails"`
+	VersionDetails VersionDetails          `json:"versionDetails"`
 }
 
 // CStorVolumeConfigSpec is the spec for a CStorVolumeConfig resource
@@ -62,21 +95,28 @@ type CStorVolumeConfigSpec struct {
 	// Capacity represents the actual resources of the underlying
 	// cstor volume.
 	Capacity corev1.ResourceList `json:"capacity"`
-	
-  // ReplicaCount represents the desired replica count for the underlying
-	// cstor volume
-	ReplicaCount int `json:"ReplicaCount"`
-
 	// CStorVolumeRef has the information about where CstorVolumeClaim
 	// is created from.
 	CStorVolumeRef *corev1.ObjectReference `json:"cstorVolumeRef,omitempty"`
-	
-  // CStorVolumeSource contains the source volumeName@snapShotname
+	// CStorVolumeSource contains the source volumeName@snapShotname
 	// combaination.  This will be filled only if it is a clone creation.
 	CStorVolumeSource string `json:"cstorVolumeSource,omitempty"`
-	
-  // Policy contains volume specific required policies target and replicas
+	// Provision represents the initial volume configuration for the underlying
+	// cstor volume based on the persistent volume request by user.
+	Provision VolumeProvision `json:"provision"`
+	// Policy contains volume specific required policies target and replicas
 	Policy CStorVolumePolicySpec `json:"policy"`
+}
+
+type VolumeProvision struct {
+	// Capacity represents initial capacity of volume replica required during
+	// volume clone operations to maintain some metadata info related to child
+	// resources like snapshot, cloned volumes.
+	Capacity corev1.ResourceList `json:"capacity"`
+	// ReplicaCount represents initial cstor volume replica count, its will not
+	// be updated later on based on scale up/down operations, only readonly
+	// operations and validations.
+	ReplicaCount int `json:"replicaCount"`
 }
 
 // CStorVolumeConfigPublish contains info related to attachment of a volume to a node.
@@ -95,18 +135,12 @@ const (
 	CStorVolumeConfigPhasePending CStorVolumeConfigPhase = "Pending"
 
 	//CStorVolumeConfigPhaseBound indiacates that the cstorvolume has been
-	//provisioned and bound to the cstor volume claim
+	//provisioned and bound to the cstor volume config
 	CStorVolumeConfigPhaseBound CStorVolumeConfigPhase = "Bound"
 
 	//CStorVolumeConfigPhaseFailed indiacates that the cstorvolume provisioning
 	//has failed
 	CStorVolumeConfigPhaseFailed CStorVolumeConfigPhase = "Failed"
-
-  //CStorVolumeConfigPhaseReconcile indicates that the changes currently
-	//reconclied based on the cstor volume policy changes to achieve the desired
-	//state
-	CStorVolumeConfigPhaseReconcile CStorVolumeConfigPhase = "Reconcile"
-
 )
 
 // CStorVolumeConfigStatus is for handling status of CstorVolume Claim.
@@ -117,31 +151,27 @@ type CStorVolumeConfigStatus struct {
 
 	// PoolInfo represents current pool names where volume replicas exists
 	PoolInfo []string `json:"poolInfo"`
-	
-  // Capacity the actual resources of the underlying volume.
-	Capacity   corev1.ResourceList         `json:"capacity,omitempty"`
-	
-  Conditions []CStorVolumeConfigCondition `json:"condition,omitempty"`
+
+	// Capacity the actual resources of the underlying volume.
+	Capacity corev1.ResourceList `json:"capacity,omitempty"`
+
+	Conditions []CStorVolumeConfigCondition `json:"condition,omitempty"`
 }
 
 // CStorVolumeConfigCondition contains details about state of cstor volume
 type CStorVolumeConfigCondition struct {
-	// Current Condition of cstor volume claim. If underlying persistent volume is being
+	// Current Condition of cstor volume config. If underlying persistent volume is being
 	// resized then the Condition will be set to 'ResizeStarted' etc
 	Type CStorVolumeConfigConditionType `json:"type"`
-	
-  // Last time we probed the condition.
+	// Last time we probed the condition.
 	// +optional
 	LastProbeTime metav1.Time `json:"lastProbeTime,omitempty"`
-	
-  // Last time the condition transitioned from one status to another.
+	// Last time the condition transitioned from one status to another.
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
-	
-  // Reason is a brief CamelCase string that describes any failure
+	// Reason is a brief CamelCase string that describes any failure
 	Reason string `json:"reason"`
-	
-  // Human-readable message indicating details about last transition.
+	// Human-readable message indicating details about last transition.
 	Message string `json:"message"`
 }
 
@@ -150,16 +180,13 @@ type CStorVolumeConfigConditionType string
 
 // These constants are CVC condition types related to resize operation.
 const (
-	// CStorVolumeConfigResizePending means volume resize operation has been started
+	// CStorVolumeConfigResizePending ...
 	CStorVolumeConfigResizing CStorVolumeConfigConditionType = "Resizing"
-
-  // CStorVolumeConfigResizeFailed means volume resize operation has been failed
+	// CStorVolumeConfigResizeFailed ...
 	CStorVolumeConfigResizeFailed CStorVolumeConfigConditionType = "VolumeResizeFailed"
-	
-  // CStorVolumeConfigResizeSuccess means volume resize operation has been successful
+	// CStorVolumeConfigResizeSuccess ...
 	CStorVolumeConfigResizeSuccess CStorVolumeConfigConditionType = "VolumeResizeSuccessful"
-	
-  // CStorVolumeConfigResizePending means volume resize operation has been pending
+	// CStorVolumeConfigResizePending ...
 	CStorVolumeConfigResizePending CStorVolumeConfigConditionType = "VolumeResizePending"
 )
 
@@ -175,9 +202,11 @@ type CStorVolumeConfigList struct {
 }
 ```
 
-# Changes to existing types
+## Changes to existing types
 
-- No changes
+- Move `ReplicaCount` under `Spec.Provision` section from `Spec` (readonly property).
+- Add initial `Capacity` under `Spec.Provision` section (readonly property).
+
 
 # Volume Policy Schema Proposal
 
@@ -202,20 +231,19 @@ type CStorVolumePolicy struct {
 
 // CStorVolumePolicySpec ...
 type CStorVolumePolicySpec struct {
-  // Provision represents volume provisioning configuration like replicaAffinity
-  // etc
+	// replicaAffinity is set to true then volume replica resources need to be
+	// distributed across the pool instances
 	Provision Provision `json:"provision"`
 
-  // TargetSpec represents configuration related to cstor target and its resources
-	Target TargetSpec `json:"target,omitempty"`
+	// TargetSpec represents configuration related to cstor target and its resources
+	Target TargetSpec `json:"target"`
 
-  // ReplicaSpec represents configuration related to replicas resources
-	Replica ReplicaSpec `json:"replica,omitempty"`
-
+	// ReplicaSpec represents configuration related to replicas resources
+	Replica ReplicaSpec `json:"replica"`
 
 	// ReplicaPoolInfo holds the pool information of volume replicas.
 	// Ex: If volume is provisioned on which CStor pool volume replicas exist
-	ReplicaPoolInfo []ReplicaPoolInfo `json:"replicaPoolInfo,omitempty"`
+	ReplicaPoolInfo []ReplicaPoolInfo `json:"replicaPoolInfo"`
 }
 
 // TargetSpec represents configuration related to cstor target and its resources
@@ -224,8 +252,8 @@ type TargetSpec struct {
 	// ongoing IO count from client
 	QueueDepth string `json:"queueDepth,omitempty"`
 
-	// Luworkers sets the number of threads that are working on above queue
-	LuWorkers int64 `json:"luWorkers,omitempty"`
+	// IOWorkers sets the number of threads that are working on above queue
+	IOWorkers int64 `json:"luWorkers,omitempty"`
 
 	// Monitor enables or disables the target exporter sidecar
 	Monitor bool `json:"monitor,omitempty"`
@@ -260,33 +288,63 @@ type TargetSpec struct {
 
 // ReplicaSpec represents configuration related to replicas resources
 type ReplicaSpec struct {
-	// ZvolWorkers represents number of threads that executes client IOs
-	ZvolWorkers *int32 `json:"zvolWorkers,omitempty"`
+	// IOWorkers represents number of threads that executes client IOs
+	IOWorkers string `json:"zvolWorkers,omitempty"`
+	// Controls the compression algorithm used for this volumes
+	// examples: on|off|gzip|gzip-N|lz4|lzjb|zle
+	//
+	// Setting compression to "on" indicates that the current default compression
+	// algorithm should be used.The default balances compression and decompression
+	// speed, with compression ratio and is expected to work well on a wide variety
+	// of workloads. Unlike all other set‐tings for this property, on does not
+	// select a fixed compression type.  As new compression algorithms are added
+	// to ZFS and enabled on a pool, the default compression algorithm may change.
+	// The current default compression algorithm is either lzjb or, if the
+	// `lz4_compress feature is enabled, lz4.
+
+	// The lz4 compression algorithm is a high-performance replacement for the lzjb
+	// algorithm. It features significantly faster compression and decompression,
+	// as well as a moderately higher compression ratio than lzjb, but can only
+	// be used on pools with the lz4_compress
+
+	// feature set to enabled.  See zpool-features(5) for details on ZFS feature
+	// flags and the lz4_compress feature.
+
+	// The lzjb compression algorithm is optimized for performance while providing
+	// decent data compression.
+
+	// The gzip compression algorithm uses the same compression as the gzip(1)
+	// command.  You can specify the gzip level by using the value gzip-N,
+	// where N is an integer from 1 (fastest) to 9 (best compression ratio).
+	// Currently, gzip is equivalent to gzip-6 (which is also the default for gzip(1)).
+
+	// The zle compression algorithm compresses runs of zeros.
+	Compression string `json:"compression,omitempty"`
 }
 
-// Provision represents volume provisioning configuration
+// Provision represents different provisioning policy for cstor volumes
 type Provision struct {
 	// replicaAffinity is set to true then volume replica resources need to be
 	// distributed across the cstor pool instances based on the given topology
 	ReplicaAffinity bool `json:"replicaAffinity"`
-}
-
-// ReplicaPoolSpec represents the volume replicas pool information
-type ReplicaPoolSpec struct {
-	// PoolInfo represents the pool information of replicas
-	PoolInfo []ReplicaPoolInfo `json:"poolInfo,omitempty"`
+	// BlockSize is the logical block size in multiple of 512 bytes
+	// BlockSize specifies the block size of the volume. The blocksize
+	// cannot be changed once the volume has been written, so it should be
+	// set at volume creation time. The default blocksize for volumes is 4 Kbytes.
+	// Any power of 2 from 512 bytes to 128 Kbytes is valid.
+	BlockSize uint32 `json:"blockSize"`
 }
 
 // ReplicaPoolInfo represents the pool information of volume replica
 type ReplicaPoolInfo struct {
 	// PoolName represents the pool name where volume replica exists
-	PoolName string `json:"poolName,omitempty"`
-	//TODO: UID also can be added
+	PoolName string `json:"poolName"`
+	// UID also can be added
 }
 
 // CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
 type CStorVolumePolicyStatus struct {
-	Phase string `json:"phase,omitempty"`
+	Phase string `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -301,11 +359,11 @@ type CStorVolumePolicyList struct {
 }
 ```
 
-# Changes to existing types
+## Changes to existing types
 
-- Added `ReplicaPoolSpec` in `VolumePolicy` schema represents pool related information required
-  for replica scaleup/scale down operation.
-
+- Added initial `BlockSize` under `Provision` section in Policy ( readonly field).
+- Renamed `ZvolWorkers` and `Luworkers` as `IOWorkers` in `TargetSpec` and `ReplicaSpec`
+- Added `Compression` under ReplicaSpec in Policy
 
 # Risks and Mitigations
 

--- a/contribute/design/1.x/apis/cstorvolume_policy.md
+++ b/contribute/design/1.x/apis/cstorvolume_policy.md
@@ -71,9 +71,9 @@ type CStorVolumeConfigSpec struct {
 	// is created from.
 	CStorVolumeRef *corev1.ObjectReference `json:"cstorVolumeRef,omitempty"`
 	
-  // CstorVolumeSource contains the source volumeName@snapShotname
+  // CStorVolumeSource contains the source volumeName@snapShotname
 	// combaination.  This will be filled only if it is a clone creation.
-	CstorVolumeSource string `json:"cstorVolumeSource,omitempty"`
+	CStorVolumeSource string `json:"cstorVolumeSource,omitempty"`
 	
   // Policy contains volume specific required policies target and replicas
 	Policy CStorVolumePolicySpec `json:"policy"`
@@ -105,7 +105,7 @@ const (
   //CStorVolumeConfigPhaseReconcile indicates that the changes currently
 	//reconclied based on the cstor volume policy changes to achieve the desired
 	//state
-	CStorVolumeConfigPhaseReconcile CStorVolumeConfigPhase = "Reconile"
+	CStorVolumeConfigPhaseReconcile CStorVolumeConfigPhase = "Reconcile"
 
 )
 
@@ -245,8 +245,8 @@ type TargetSpec struct {
 	// Tolerations, if specified, are the target pod's tolerations
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
-	// Affinity if specified, are the target pod's affinities
-	Affinity *corev1.PodAffinity `json:"affinity,omitempty"`
+	// PodAffinity if specified, are the target pod's affinities
+	PodAffinity *corev1.PodAffinity `json:"affinity,omitempty"`
 
 	// NodeSelector is the labels that will be used to select
 	// a node for target pod scheduleing
@@ -262,8 +262,6 @@ type TargetSpec struct {
 type ReplicaSpec struct {
 	// ZvolWorkers represents number of threads that executes client IOs
 	ZvolWorkers *int32 `json:"zvolWorkers,omitempty"`
-	// Affinity if specified, are the replica affinities
-	Affinity *corev1.PodAffinity `json:"affinity,omitempty"`
 }
 
 // Provision represents volume provisioning configuration


### PR DESCRIPTION
OpenEBS enhancement proposal to freeze and stabelize the CStorVolumes related APIs and groups.

-  `CStorVolumeReplicas` API schema
-  `CStorVolumes` API schema
-  `CStorVolumeConfig` API schema
-  `CStorVolumePolicy` API schema


Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io> 