### PR TITLE
chore(operator): update liveness check for alpine based containers

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -316,6 +316,7 @@ spec:
           exec:
             command:
             - pgrep
+            - -f
             - ".*openebs"
           initialDelaySeconds: 30
           periodSeconds: 60
@@ -358,6 +359,7 @@ spec:
             exec:
               command:
               - pgrep
+              - -f
               - ".*controller"
             initialDelaySeconds: 30
             periodSeconds: 60
@@ -695,6 +697,7 @@ spec:
           exec:
             command:
             - pgrep
+            - -f
             - ".*localpv"
           initialDelaySeconds: 30
           periodSeconds: 60


### PR DESCRIPTION
commit update the liveness pgrep command to use `-f` to use
full process name to match, otherwise liveness probe will fail
to verify the process name and causes the container restart.

Required for 3.10+ alpine base image version used in below containers:
- localpv-provisioner
- snapshot-controller
- snapshot-provisioner

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
