### PR TITLE
chore(operator): update liveness checks in provisioner and ndm

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -387,6 +387,7 @@ spec:
             exec:
               command:
               - pgrep
+              - -f
               - ".*provisioner"
             initialDelaySeconds: 30
             periodSeconds: 60
@@ -511,6 +512,7 @@ spec:
           exec:
             command:
             - pgrep
+            - -f
             - ".*ndm"
           initialDelaySeconds: 30
           periodSeconds: 60


### PR DESCRIPTION
commit update the liveness pgrep command to use `-f` to use
full process name to match, make it consistent across all
the deployments

refer: #2992

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
