### PR TITLE
chore(operator): update liveness probes regular expression

### DIFF
--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -315,8 +315,10 @@ spec:
         livenessProbe:
           exec:
             command:
-            - pgrep
-            - "^openebs-provisi.*"
+            - sh
+            - -c
+            - pcount=$(pgrep "^openebs-provisi.*" | wc -l); if [ $pcount != 1 ]; then exit
+              1; else exit 0; fi;
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
@@ -357,8 +359,10 @@ spec:
           livenessProbe:
             exec:
               command:
-              - pgrep
-              - "^snapshot-contro.*"
+              - sh
+              - -c
+              - pcount=$(pgrep "^snapshot-contro.*" | wc -l); if [ $pcount != 1 ]; then exit
+                1; else exit 0; fi;
             initialDelaySeconds: 30
             periodSeconds: 60
         # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
@@ -384,8 +388,10 @@ spec:
           livenessProbe:
             exec:
               command:
-              - pgrep
-              - "^snapshot-provis.*"
+              - sh
+              - -c
+              - pcount=$(pgrep "^snapshot-provis.*" | wc -l); if [ $pcount != 1 ]; then exit
+                1; else exit 0; fi;
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -509,7 +515,7 @@ spec:
           exec:
             command:
             - pgrep
-            - "^ndm.*"
+            - "ndm"
           initialDelaySeconds: 30
           periodSeconds: 60
       volumes:
@@ -694,8 +700,10 @@ spec:
         livenessProbe:
           exec:
             command:
-            - pgrep
-            - "^provisioner-loc.*"
+            - sh
+            - -c
+            - pcount=$(pgrep "^provisioner-loc.*" | wc -l); if [ $pcount != 1 ]; then exit
+              1; else exit 0; fi;
           initialDelaySeconds: 30
           periodSeconds: 60
 ---

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -316,8 +316,7 @@ spec:
           exec:
             command:
             - pgrep
-            - -f
-            - ".*openebs"
+            - "^openebs-provisi.*"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
@@ -359,8 +358,7 @@ spec:
             exec:
               command:
               - pgrep
-              - -f
-              - ".*controller"
+              - "^snapshot-contro.*"
             initialDelaySeconds: 30
             periodSeconds: 60
         # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
@@ -387,8 +385,7 @@ spec:
             exec:
               command:
               - pgrep
-              - -f
-              - ".*provisioner"
+              - "^snapshot-provis.*"
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -512,8 +509,7 @@ spec:
           exec:
             command:
             - pgrep
-            - -f
-            - ".*ndm"
+            - "^ndm.*"
           initialDelaySeconds: 30
           periodSeconds: 60
       volumes:
@@ -699,8 +695,7 @@ spec:
           exec:
             command:
             - pgrep
-            - -f
-            - ".*localpv"
+            - "^provisioner-loc.*"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -315,7 +315,7 @@ spec:
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression
-         # that matches the enter command name has to specified.
+         # that matches the entire command name has to specified.
          # Anchor `^` : matches any string that starts with `openebs-provis`
          # `.*`: matches any string that has `openebs-provis` followed by zero or more char
         livenessProbe:
@@ -323,8 +323,7 @@ spec:
             command:
             - sh
             - -c
-            - pcount=$(pgrep "^openebs-provisi.*" | wc -l); if [ $pcount != 1 ]; then exit
-              1; else exit 0; fi;
+            - test `pgrep -c "^openebs-provisi.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
 ---
@@ -365,7 +364,7 @@ spec:
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression
-         # that matches the enter command name has to specified.
+         # that matches the entire command name has to specified.
          # Anchor `^` : matches any string that starts with `snapshot-contro`
          # `.*`: matches any string that has `snapshot-contro` followed by zero or more char
           livenessProbe:
@@ -373,8 +372,7 @@ spec:
               command:
               - sh
               - -c
-              - pcount=$(pgrep "^snapshot-contro.*" | wc -l); if [ $pcount != 1 ]; then exit
-                1; else exit 0; fi;
+              - test `pgrep -c "^snapshot-contro.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
         # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
@@ -400,7 +398,7 @@ spec:
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression
-         # that matches the enter command name has to specified.
+         # that matches the entire command name has to specified.
          # Anchor `^` : matches any string that starts with `snapshot-provis`
          # `.*`: matches any string that has `snapshot-provis` followed by zero or more char
           livenessProbe:
@@ -408,8 +406,7 @@ spec:
               command:
               - sh
               - -c
-              - pcount=$(pgrep "^snapshot-provis.*" | wc -l); if [ $pcount != 1 ]; then exit
-                1; else exit 0; fi;
+              - test `pgrep -c "^snapshot-provis.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -672,14 +669,13 @@ spec:
           # So fullname can't be used here with pgrep (>15 chars).A regular expression
           # Anchor `^` : matches any string that starts with `admission-serve`
           # `.*`: matche any string that has `admission-serve` followed by zero or more char
-          # that matches the enter command name has to specified.
+          # that matches the entire command name has to specified.
           livenessProbe:
             exec:
               command:
               - sh
               - -c
-              - pcount=$(pgrep "^admission-serve.*" | wc -l); if [ $pcount != 1 ]; then exit
-                1; else exit 0; fi;
+              - test `pgrep -c "^admission-serve.*"` = 1
             initialDelaySeconds: 30
             periodSeconds: 60
 ---
@@ -746,7 +742,7 @@ spec:
         # Process name used for matching is limited to the 15 characters
         # present in the pgrep output.
         # So fullname can't be used here with pgrep (>15 chars).A regular expression
-        # that matches the enter command name has to specified.
+        # that matches the entire command name has to specified.
         # Anchor `^` : matches any string that starts with `provisioner-loc`
         # `.*`: matches any string that has `provisioner-loc` followed by zero or more char
         livenessProbe:
@@ -754,8 +750,7 @@ spec:
             command:
             - sh
             - -c
-            - pcount=$(pgrep "^provisioner-loc.*" | wc -l); if [ $pcount != 1 ]; then exit
-              1; else exit 0; fi;
+            - test `pgrep -c "^provisioner-loc.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
 ---

--- a/k8s/openebs-operator.yaml
+++ b/k8s/openebs-operator.yaml
@@ -312,6 +312,12 @@ spec:
         # This is supported for openebs provisioner version 0.5.3-RC1 onwards
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the enter command name has to specified.
+         # Anchor `^` : matches any string that starts with `openebs-provis`
+         # `.*`: matches any string that has `openebs-provis` followed by zero or more char
         livenessProbe:
           exec:
             command:
@@ -356,6 +362,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the enter command name has to specified.
+         # Anchor `^` : matches any string that starts with `snapshot-contro`
+         # `.*`: matches any string that has `snapshot-contro` followed by zero or more char
           livenessProbe:
             exec:
               command:
@@ -385,6 +397,12 @@ spec:
         # This is supported for openebs provisioner version 0.5.3-RC1 onwards
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the enter command name has to specified.
+         # Anchor `^` : matches any string that starts with `snapshot-provis`
+         # `.*`: matches any string that has `snapshot-provis` followed by zero or more char
           livenessProbe:
             exec:
               command:
@@ -511,6 +529,9 @@ spec:
         # Specify the number of sparse files to be created
         - name: SPARSE_FILE_COUNT
           value: "1"
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can be used here with pgrep (cmd is < 15 chars).
         livenessProbe:
           exec:
             command:
@@ -595,6 +616,16 @@ spec:
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
               value: "quay.io/openebs/linux-utils:1.4.0"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can be used here with pgrep (cmd is < 15 chars).
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - "ndo"
+            initialDelaySeconds: 30
+            periodSeconds: 60
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -636,6 +667,21 @@ spec:
                   fieldPath: metadata.namespace
             - name: ADMISSION_WEBHOOK_NAME
               value: "openebs-admission-server"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # Anchor `^` : matches any string that starts with `admission-serve`
+          # `.*`: matche any string that has `admission-serve` followed by zero or more char
+          # that matches the enter command name has to specified.
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - pcount=$(pgrep "^admission-serve.*" | wc -l); if [ $pcount != 1 ]; then exit
+                1; else exit 0; fi;
+            initialDelaySeconds: 30
+            periodSeconds: 60
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -697,6 +743,12 @@ spec:
           value: "openebs-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
           value: "quay.io/openebs/linux-utils:1.4.0"
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can't be used here with pgrep (>15 chars).A regular expression
+        # that matches the enter command name has to specified.
+        # Anchor `^` : matches any string that starts with `provisioner-loc`
+        # `.*`: matches any string that has `provisioner-loc` followed by zero or more char
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Refactor the liveness check to check for the exact command name instead of using `pgrep -f`. 

`pgrep -f` can result in false positive is there another process with some arguments that can match the command name. 

**Note:** (from the pgrep man pages)
The process name used for matching is limited to the 15 characters present in the output of `/proc/pid/stat`.

- So updated the regular expression with 15 characters command name ( if applicable) for better handling.
- for NDM daemontset just using `ndm`  with pgrep as its only 3 char cmd name and don't need any regular expression.

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>