### PR TITLE
Add backup usecase for home user to adopters.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -25,6 +25,7 @@ The list of users that have publicly shared the usage of OpenEBS.
 | User | Stateful Workloads | Success Story |
 | :--- | :--- | :--- |
 | [Alin Jurj](https://github.com/Perfect-Web) | Elasticsearch | [English](./adopters/users/Perfect-Web/README.md)  | 
+| [Maartje Eyskens](https://github.com/meyskens) | Minio | [English](./adopters/users/meyskens/README.md)  | 
 | [proegssilb](https://github.com/proegssilb) | PostgreSQL, Redis, Factorio (video game server) | [English](./adopters/users/proegssilb/README.md)  | 
 | [radicand](https://github.com/radicand) | Wordpress, MariaDB on ARM64 cluster | [English](./adopters/users/radicand/README.md) | 
 | [tardich](https://github.com/tardich) | Postfix Mail Relay, NextCloud, Nexus Repository, Plex | [English](./adopters/users/tardich/README.md)  | 

--- a/adopters/users/meyskens/README.md
+++ b/adopters/users/meyskens/README.md
@@ -1,0 +1,11 @@
+_backup solution for home laptop_
+
+**Stateful Applications that you are running on OpenEBS**
+- Minio
+
+**Type of OpenEBS Storage Engines behind the above application - cStor, Jiva or Local PV**
+- Jiva
+
+**A brief description of the use case or details on how OpenEBS is helping your projects.**
+- Restic uploads my laptop to Minio running on my home k8s cluster (powered by openebs). A “mc mirror” pod then uploads it to the cloud. I get full speed backups on my laptop and still have a cloud copy
+

--- a/adopters/users/meyskens/README.md
+++ b/adopters/users/meyskens/README.md
@@ -7,5 +7,4 @@ _backup solution for home laptop_
 - Jiva
 
 **A brief description of the use case or details on how OpenEBS is helping your projects.**
-- Restic uploads my laptop to Minio running on my home k8s cluster (powered by openebs). A “mc mirror” pod then uploads it to the cloud. I get full speed backups on my laptop and still have a cloud copy
-
+- Restic uploads my laptop to Minio running on my home Kubernetes cluster. Minio runs on a 2 replica OpenEBS cStor PV . A `mc mirror` pod then watches the bucket and uploads it's content to the cloud. I get full speed backups on my laptop and still have a cloud copy

--- a/adopters/users/meyskens/README.md
+++ b/adopters/users/meyskens/README.md
@@ -4,7 +4,7 @@ _backup solution for home laptop_
 - Minio
 
 **Type of OpenEBS Storage Engines behind the above application - cStor, Jiva or Local PV**
-- Jiva
+- cStor
 
 **A brief description of the use case or details on how OpenEBS is helping your projects.**
 - Restic uploads my laptop to Minio running on my home Kubernetes cluster. Minio runs on a 2 replica OpenEBS cStor PV . A `mc mirror` pod then watches the bucket and uploads it's content to the cloud. I get full speed backups on my laptop and still have a cloud copy


### PR DESCRIPTION
Found the OpenEBS adoption story for home backup solution over
here: https://twitter.com/MaartjeME/status/1261747549272236032

It will be helpful to share this story to OpenEBS community.

Signed-off-by: kmova <kiran.mova@mayadata.io>

