### PR TITLE
fix(YAML): Update MinIO according to latest API

### DIFF
--- a/k8s/demo/minio/minio-standalone-cstor.yaml
+++ b/k8s/demo/minio/minio-standalone-cstor.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+# For k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -12,19 +16,19 @@ spec:
         # Label is used as selector in the service.
         app: minio
     spec:
-      # Refer to the PVC created earlier
+      # Refer to the PVC 
       volumes:
-      - name: storage1
+      - name: storage
         persistentVolumeClaim:
           # Name of the PVC created earlier
-                claimName: minio-pv-claim1
+          claimName: minio-pv-claim
       containers:
       - name: minio
         # Pulls the default Minio image from Docker Hub
-        image: minio/minio
+        image: minio/minio:latest
         args:
         - server
-        - /storage1
+        - /storage
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
@@ -32,35 +36,35 @@ spec:
         - name: MINIO_SECRET_KEY
           value: "minio123"
         - name: MINIO_PROMETHEUS_AUTH_TYPE
-          value: "public"         
+          value: "public"           
         ports:
         - containerPort: 9000
+          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
-        - name: storage1 # must match the volume name, above
-          mountPath: "/storage1"
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: minio-pv-claim1
+  name: minio-pv-claim
   labels:
-    app: minio-storage-claim1
+    app: minio-storage-claim
 spec:
   storageClassName: openebs-sc-rep3
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi  
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
-  labels:
-    app: minio
 spec:
+#  type: LoadBalancer
   ports:
     - port: 9000
       nodePort: 32701

--- a/k8s/demo/minio/minio-standalone-jiva-default.yaml
+++ b/k8s/demo/minio/minio-standalone-jiva-default.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+# For k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -11,21 +15,20 @@ spec:
       labels:
         # Label is used as selector in the service.
         app: minio
-        openebs.io/target-affinity: minio
     spec:
-      # Refer to the PVC created earlier
+      # Refer to the PVC 
       volumes:
-      - name: storage1
+      - name: storage
         persistentVolumeClaim:
           # Name of the PVC created earlier
-                claimName: minio-pv-claim1
+          claimName: minio-pv-claim
       containers:
       - name: minio
         # Pulls the default Minio image from Docker Hub
-        image: minio/minio
+        image: minio/minio:latest
         args:
         - server
-        - /storage1
+        - /storage
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
@@ -33,36 +36,35 @@ spec:
         - name: MINIO_SECRET_KEY
           value: "minio123"
         - name: MINIO_PROMETHEUS_AUTH_TYPE
-          value: "public"          
+          value: "public"           
         ports:
         - containerPort: 9000
+          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
-        - name: storage1 # must match the volume name, above
-          mountPath: "/storage1"
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: minio-pv-claim1
+  name: minio-pv-claim
   labels:
-    openebs.io/target-affinity: minio      
-    app: minio-storage-claim1
+    app: minio-storage-claim
 spec:
   storageClassName: openebs-jiva-default
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi  
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
-  labels:
-    app: minio
 spec:
+#  type: LoadBalancer
   ports:
     - port: 9000
       nodePort: 32701

--- a/k8s/demo/minio/minio-standalone-jiva-storagepool.yaml
+++ b/k8s/demo/minio/minio-standalone-jiva-storagepool.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+# For k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -11,21 +15,20 @@ spec:
       labels:
         # Label is used as selector in the service.
         app: minio
-        openebs.io/target-affinity: minio
     spec:
-      # Refer to the PVC created earlier
+      # Refer to the PVC 
       volumes:
-      - name: storage1
+      - name: storage
         persistentVolumeClaim:
           # Name of the PVC created earlier
-                claimName: minio-pv-claim1
+          claimName: minio-pv-claim
       containers:
       - name: minio
         # Pulls the default Minio image from Docker Hub
-        image: minio/minio
+        image: minio/minio:latest
         args:
         - server
-        - /storage1
+        - /storage
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
@@ -33,36 +36,35 @@ spec:
         - name: MINIO_SECRET_KEY
           value: "minio123"
         - name: MINIO_PROMETHEUS_AUTH_TYPE
-          value: "public"          
+          value: "public"           
         ports:
         - containerPort: 9000
+          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
-        - name: storage1 # must match the volume name, above
-          mountPath: "/storage1"
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: minio-pv-claim1
+  name: minio-pv-claim
   labels:
-    openebs.io/target-affinity: minio      
-    app: minio-storage-claim1
+    app: minio-storage-claim
 spec:
   storageClassName: openebs-jiva-3rep
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi  
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
-  labels:
-    app: minio
 spec:
+#  type: LoadBalancer
   ports:
     - port: 9000
       nodePort: 32701

--- a/k8s/demo/minio/minio-standalone-localpv-device.yaml
+++ b/k8s/demo/minio/minio-standalone-localpv-device.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+# For k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -12,55 +16,53 @@ spec:
         # Label is used as selector in the service.
         app: minio
     spec:
-      # Refer to the PVC created earlier
+      # Refer to the PVC 
       volumes:
-      - name: storage1
+      - name: storage
         persistentVolumeClaim:
           # Name of the PVC created earlier
-                claimName: minio-pv-claim1
+          claimName: minio-pv-claim
       containers:
       - name: minio
         # Pulls the default Minio image from Docker Hub
-        image: minio/minio
+        image: minio/minio:latest
         args:
         - server
-        - /storage1
+        - /storage
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
           value: "minio"
         - name: MINIO_SECRET_KEY
           value: "minio123"
-        - name: MINIO_PROMETHEUS_AUTH_TYPE
-          value: "public"        
         ports:
         - containerPort: 9000
+          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
-        - name: storage1 # must match the volume name, above
-          mountPath: "/storage1"
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: minio-pv-claim1
+  name: minio-pv-claim
   labels:
-    app: minio-storage-claim1
+    app: minio-storage-claim
 spec:
-  storageClassName: openebs-device 
+  storageClassName: openebs-device
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi  
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
-  labels:
-    app: minio
 spec:
+#  type: LoadBalancer
   ports:
     - port: 9000
       nodePort: 32701

--- a/k8s/demo/minio/minio-standalone-localpv-device.yaml
+++ b/k8s/demo/minio/minio-standalone-localpv-device.yaml
@@ -35,6 +35,8 @@ spec:
           value: "minio"
         - name: MINIO_SECRET_KEY
           value: "minio123"
+        - name: MINIO_PROMETHEUS_AUTH_TYPE
+          value: "public"           
         ports:
         - containerPort: 9000
           hostPort: 9000

--- a/k8s/demo/minio/minio-standalone-localpv-hostpath-default.yaml
+++ b/k8s/demo/minio/minio-standalone-localpv-hostpath-default.yaml
@@ -1,9 +1,13 @@
-apiVersion: extensions/v1beta1
+# For k8s versions before 1.9.0 use apps/v1beta2  and before 1.8.0 use extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   # This name uniquely identifies the Deployment
   name: minio-deployment
 spec:
+  selector:
+    matchLabels:
+      app: minio
   strategy:
     type: Recreate
   template:
@@ -12,19 +16,19 @@ spec:
         # Label is used as selector in the service.
         app: minio
     spec:
-      # Refer to the PVC created earlier
+      # Refer to the PVC 
       volumes:
-      - name: storage1
+      - name: storage
         persistentVolumeClaim:
           # Name of the PVC created earlier
-                claimName: minio-pv-claim1
+          claimName: minio-pv-claim
       containers:
       - name: minio
         # Pulls the default Minio image from Docker Hub
-        image: minio/minio
+        image: minio/minio:latest
         args:
         - server
-        - /storage1
+        - /storage
         env:
         # Minio access key and secret key
         - name: MINIO_ACCESS_KEY
@@ -32,35 +36,35 @@ spec:
         - name: MINIO_SECRET_KEY
           value: "minio123"
         - name: MINIO_PROMETHEUS_AUTH_TYPE
-          value: "public"      
+          value: "public"
         ports:
         - containerPort: 9000
+          hostPort: 9000
         # Mount the volume into the pod
         volumeMounts:
-        - name: storage1 # must match the volume name, above
-          mountPath: "/storage1"
+        - name: storage # must match the volume name, above
+          mountPath: "/storage"
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: minio-pv-claim1
+  name: minio-pv-claim
   labels:
-    app: minio-storage-claim1
+    app: minio-storage-claim
 spec:
   storageClassName: openebs-hostpath
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi  
+      storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: minio-service
-  labels:
-    app: minio
 spec:
+#  type: LoadBalancer
   ports:
     - port: 9000
       nodePort: 32701


### PR DESCRIPTION
- Update standalone MinIO YAML spec for openebs-hostpath, openebs-device,openebs Jiva default, Jiva disk storagepool,cStor  according to latest API version to work in K8s version >= 1.16

Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>

