### PR TITLE
chore(doc): update the order of release tagging

### DIFF
--- a/contribute/process/release-management.md
+++ b/contribute/process/release-management.md
@@ -72,17 +72,17 @@ Once a release made on a repository, Travis will trigger the release on the depe
 
 - openebs/linux-utils
   - openebs/jiva
+  - openebs/cstor
   - openebs/libcstor
-    - openebs/cstor
-      - openebs/istgt
-        - openebs/cstor-operators
-        - openebs/external-storage
-          - openebs/maya
-            - openebs/velero-plugin
-            - openebs/cstor-csi
-            - openebs/upgrade
-            - openebs/jiva-operator
-              - openebs/jiva-csi
+    - openebs/istgt
+      - openebs/cstor-operators
+      - openebs/external-storage
+        - openebs/maya
+          - openebs/velero-plugin
+          - openebs/cstor-csi
+          - openebs/upgrade
+          - openebs/jiva-operator
+            - openebs/jiva-csi
 
 The following repositories currently follow a different release versioning than other components, so these are triggered parallely. 
 - openebs/node-disk-manager


### PR DESCRIPTION
This PR is required to update the release tagging
with the latest changes made on cStor data plane
repositories(Since the building and pushing images
has been moved from `openebs/cstor` to `openebs/libcstor`).

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
