### PR TITLE
docs(adopters): add bytedance and kuja53 to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -10,6 +10,7 @@ The list of organizations that have publicly shared the usage of OpenEBS:
 | :--- | :--- | :--- |
 | [Agnes Intelligence](https://www.agnesintel.com/) | Apache Kafka, Apache Solr, NFS | [English](./adopters/agnesintel/README.md) |
 | [Arista Networks](https://www.arista.com/en/) | Gerrit (multiple flavors), NPM, Maven, Redis, NFS, Sonarqube, Internal tools | [English](./adopters/arista/README.md) |
+| [ByteDance](https://www.bytedance.com/) | Elasticsearch | [English](./adopters/bytedance/README.md) |
 | [CLEW Medical](https://clewmed.com/) | PostgreSQL, Keycloak, RabbitMQ | [English](./adopters/clewmedical/README.md) |
 | [Clouds Sky GmbH](https://cloudssky.com/en/) | Confluent Kafka, Strimzi Kafka, Elasticsearch, Prometheus | [English](./adopters/cloudssky/README.md) |
 | [CNCF, The Linux Foundation](https://www.linuxfoundation.org/) | PostgreSQL, MariaDB, ElasticSearch, Redis, DevStats | [English](./adopters/cncf/README.md) |
@@ -34,6 +35,7 @@ The list of users that have publicly shared the usage of OpenEBS.
 | [Alin Jurj](https://github.com/Perfect-Web) | Elasticsearch | [English](./adopters/users/Perfect-Web/README.md)  | 
 | [Daniel Sand](https://github.com/danielsand) | Gitea, Postgres, Concourse... | [English](./adopters/users/danielsand/README.md)
 | [Dean Stathos](https://github.com/dstathos) | MariaDB, homegrown applications | [English](./adopters/users/dstathos/README.md)  |
+| [jkuzelka](https://github.com/kuja53) | GitLab, Prometheus, Grafana, Nexus Repository, Elasticsearch, RabbitMQ | [English](./adopters/users/kuja53/README.md) |
 | [Maartje Eyskens](https://github.com/meyskens) | Minio | [English](./adopters/users/meyskens/README.md)  | 
 | [Mark V.](https://github.com/mikroskeem) | Concourse CI, Mattermost, Minio, Few game servers, Bunch of micro services | [English](./adopters/users/mikroskeem/README.md)  | 
 | [proegssilb](https://github.com/proegssilb) | PostgreSQL, Redis, Factorio (video game server) | [English](./adopters/users/proegssilb/README.md)  | 

--- a/adopters/bytedance/README.md
+++ b/adopters/bytedance/README.md
@@ -1,0 +1,16 @@
+### Company: ByteDance ([bytedance.com](https://www.bytedance.com/))
+
+### Stateful applications that you are using OpenEBS
+* Elasticsearch
+
+### Type of OpenEBS Storage Engines behind the above application
+* Local PV
+
+### Are you evaluating or already using in development, CI/CD, production
+* Have being using it in elasticsearch cluster, and evaluating wider usage.
+
+### Are you using for home use or for your organization
+* In company environment.
+
+### A brief description of the use case or details on how OpenEBS is helping your projects:
+* The dynamic provisioning feature is great in our use case, as we save lots of time on setup and maintain storage disk, in ES cluster.

--- a/adopters/users/kuja53/README.md
+++ b/adopters/users/kuja53/README.md
@@ -1,0 +1,24 @@
+### Stateful Applications that you are running on OpenEBS
+
+* Gitlab
+* Prometheus
+* Grafana
+* Nexus
+* Elasticsearch
+* RabbitMQ
+
+### Type of OpenEBS Storage Engines behind the above application - cStor, Jiva or Local PV?
+
+* LocalPV and in some cases cStor, I would like also test MayaStor
+
+### Are you evaluating or already using in development, CI/CD, production
+
+* I have OpenEBS on development and production clusters
+
+### Are you using for home use or for your organization
+
+* I have various projects which I used OpenEBS on.
+
+### A brief description of the use case or details on how OpenEBS is helping your projects:
+
+* Mainly as storage backend to have complete agnostic approach to make easiness of operations part.


### PR DESCRIPTION
Adding the details of ByteDance (organization) and jkuzelka ([github.com/kuja53](https://github.com/kuja53)) to ADOPTERS.md.
ref: openebs#2719

cc: @kuja53 @yydzhou

Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>
