### PR TITLE
feat(governance): add Sebastien Dionne as new reviewer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -46,6 +46,7 @@
 "Ranjith R",@ranjithwingrider,MayaData #content-maintainers
 "Sagar Kumar",@sagarkrsd,MayaData #content-maintainers
 "Sai Chaithanya",@mittachaitu,MayaData #control-plane-maintainers
+"Sebastien Dionne",@survivant,Jerabi inc. #control-plane-maintainers
 "Shubham Bajpai",@shubham14bajpai,MayaData #control-plane-maintainers
 "Uma Mukkara",@umamukkara,MayaData #content-maintainers, e2e-maintainers
 "Utkarsh Mani Tripathi",@utkarshmani1997,MayaData #control-plane-maintainers, jiva-engine-maintainers


### PR DESCRIPTION
Refer: [GOVERNANCE.md](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).

Sebastien has been helping with enhancing and testing
of several areas of the OpenEBS project that broadly fall
in the purview of the control plane.

Based on his [past contributions](https://github.com/search?q=org%3Aopenebs+survivant&type=issues)
and his interest/commitment to contributing to OpenEBS,
we take pride in adding him as a reviewer to the OpenEBS project.

Signed-off-by: kmova <kiran.mova@mayadata.io>
