### PR TITLE
Bump up actions/stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Issues go stale after 90d of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'


### PR DESCRIPTION
fixes: #3492

~TODO: Check if any breaking changes are there b/w v1 & v4~

# List of breaking changes

1. Doesn't impact us.
2. [new-feature] We can limit or modify the `operations-per-run` to limit the API-usage or increase the limit to ensure that everything is processed in one single run. I don't think this should impact us, but we'd know if it exceeds the default number via the Action runs log.

Ref: https://github.com/actions/stale/releases/tag/v4.0.0

Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>