### PR TITLE
fix(readme.md): correct status of mayastor engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The status of various storage engines that power the OpenEBS Persistent Volumes 
 | Jiva | stable | Best suited for running Replicated Block Storage on nodes that make use of ephemeral storage on the Kubernetes worker nodes |
 | cStor | stable | A preferred option for running on nodes that have Block Devices. Recommended option if Snapshot and Clones are required |
 | Local Volumes | stable | Best suited for Distributed Application that need low latency storage - direct-attached storage from the Kubernetes nodes. |
-| Mayastor | beta | A new storage engine that operates at the efficiency of Local Storage but also offers storage services like Replication. Development is underway to support Snapshots and Clones. |
+| Mayastor | stable | Container native persistent storage solution for Kubernetes, with near-native NVMe performance and advanced data services. |
 
 For more details, please refer to [OpenEBS Documentation](https://openebs.io/docs/).
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The status of various storage engines that power the OpenEBS Persistent Volumes 
 | Jiva | stable | Best suited for running Replicated Block Storage on nodes that make use of ephemeral storage on the Kubernetes worker nodes |
 | cStor | stable | A preferred option for running on nodes that have Block Devices. Recommended option if Snapshot and Clones are required |
 | Local Volumes | stable | Best suited for Distributed Application that need low latency storage - direct-attached storage from the Kubernetes nodes. |
-| Mayastor | stable | Container native persistent storage solution for Kubernetes, with near-native NVMe performance and advanced data services. |
+| Mayastor | stable | Persistent storage solution for Kubernetes, with near-native NVMe performance and advanced data services. |
 
 For more details, please refer to [OpenEBS Documentation](https://openebs.io/docs/).
 


### PR DESCRIPTION
The first stable release of Mayastor (v1.0.0) was made on 19th January 2022.
The maintainers deem it to be production ready.

Signed-off-by: Glenn Bullingham <glenn.bullingham@datacore.com>

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
