### PR TITLE
chore(ci): add stale GitHub Action configuration to allow issue exemption

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v4
+    - uses: actions/stale@v7
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Issues go stale after 90d of inactivity. Please comment or re-open the issue if you are still interested in getting this issue fixed.'
@@ -18,3 +18,4 @@ jobs:
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'
         days-before-stale: 90
+        exempt-issue-labels: 'ignore-no-issue-activity'


### PR DESCRIPTION
This change is required to allow some issues to stay open indefinitely, e.g.: https://github.com/openebs/openebs/issues/2719