### PR TITLE
Add a new category for chairs in the GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,7 +74,7 @@ Maintainers have admin access to the GitHub organization.
 
 ### Chairs
 
-OpenEBS Chairs are ex-maintainers that have stepped down from active contributions, 
+OpenEBS Chairs are maintainers that have stepped down from active contributions, 
 but continue to support the existing maintainers with: 
 * Open Source Governance of the project
 * Coaching on leadership and prioritization for the existing maintainers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -72,6 +72,19 @@ depend on and trust to make decisions in the best interest of the project.
 
 Maintainers have admin access to the GitHub organization.
 
+### Chairs
+
+OpenEBS Chairs are ex-maintainers that have stepped down from active contributions, 
+but continue to support the existing maintainers with: 
+* Open Source Governance of the project
+* Coaching on leadership and prioritization for the existing maintainers
+* Facilitate reviews/audits on the project, resolve conflicts between maintainers. 
+
+Chairs have admin access to the GitHub organization. 
+
+Chairs can become active maintainers of the project in the future. 
+
+
 ## Adding a reviewer or maintainer 
 
 Periodically, the existing maintainers curate a list of contributors that have

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -74,16 +74,23 @@ Maintainers have admin access to the GitHub organization.
 
 ### Chairs
 
-OpenEBS Chairs are maintainers that have stepped down from active contributions, 
-but continue to support the existing maintainers with: 
+OpenEBS Chairs comprises of key current maintainers, maintainers that have stepped 
+down from active contributions but are providing support to the existing maintainers
+in the form of: 
 * Open Source Governance of the project
 * Coaching on leadership and prioritization for the existing maintainers
 * Facilitate reviews/audits on the project, resolve conflicts between maintainers. 
 
-Chairs have admin access to the GitHub organization. 
+Chairs will meet quarterly along with the maintainers to review the health of the 
+project and publicly document the outcomes.
 
-Chairs can become active maintainers of the project in the future. 
+An active user or maintainer of the OpenEBS project can be nominated by the existing 
+maintainers and/or chairs into a Chair role, if they are helping with any of the above 
+activities.  
 
+A Chair can be removed from an active role if: 
+* They are no longer able to contribute to the above responsibilities. 
+* They are not alinged with the [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md) guidelines set forth by CNCF. 
 
 ## Adding a reviewer or maintainer 
 


### PR DESCRIPTION
In an complex turn of events, most of the maintainers had to move away (due to various reasons) from actively being  involved in the project in day-to-day basis. The maintainers were still involved in the background/slack channel providing the needed help for the contributors to step up as maintainers. This involvement was hard to capture in github stats.

The lack of github involvement from listed maintainers and coupled with missing of a proper transition on community aspects to the new contributors resulted in a "justified" perception that project isn't active. 

To avoid this from happening again, one way is to clearly communicate the level of involvement of active maintainers (existing definition) vs those providing mentorship/guidance.

I am proposing to: 
- Include a category for chairs that are still associated with the project in terms of shepherding the direction/governance of the project.

Audit the governance at a regular intervals to:
- Move the maintainers that have to step down for a while into chairs. 
- Move the maintainers that can't be involved in anyway with the project going forward to Emeritus status 
- Add the contributors that are stepping up as maintainers. 


