### PR TITLE
chore(charts): expose 'etcd.clusterDomain' from the mayastor chart

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -108,10 +108,9 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | localpv-provisioner.rbac.create | bool | `true` |  |
 | lvm-localpv.crds.csi.volumeSnapshots.enabled | bool | `false` |  |
 | lvm-localpv.crds.lvmLocalPv.enabled | bool | `true` |  |
-| lvm-localpv.enabled | bool | `true` |  |
 | mayastor.crds.csi.volumeSnapshots.enabled | bool | `false` |  |
 | mayastor.csi.node.initContainers.enabled | bool | `true` |  |
-| mayastor.enabled | bool | `true` |  |
+| mayastor.etcd.clusterDomain | string | `"cluster.local"` | Kubernetes Cluster Domain |
 | mayastor.localpv-provisioner.enabled | bool | `false` |  |
 | openebs-crds.csi.volumeSnapshots.enabled | bool | `true` |  |
 | openebs-crds.csi.volumeSnapshots.keep | bool | `true` |  |
@@ -123,4 +122,3 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | release.version | string | `"4.0.1"` |  |
 | zfs-localpv.crds.csi.volumeSnapshots.enabled | bool | `false` |  |
 | zfs-localpv.crds.zfsLocalPv.enabled | bool | `true` |  |
-| zfs-localpv.enabled | bool | `true` |  |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -39,7 +39,9 @@ mayastor:
     node:
       initContainers:
         enabled: true
-
+  etcd:
+    # -- Kubernetes Cluster Domain
+    clusterDomain: cluster.local
   localpv-provisioner:
     enabled: false
   crds:


### PR DESCRIPTION
This exposes the etcd.clusterDomain value from the mayastor chart. This is commented by default, so that its presence is conveyed while still using the mayastor chart's value by default.

Ref: #3741

@balaharish7 -- we could refer to this value in our docs.