### PR TITLE
refactor: update the oep tracking number

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement-proposal.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-proposal.md
@@ -1,0 +1,22 @@
+---
+name: OpenEBS Enhancement Proposal [ OEP ]
+about: Create the tracking parent issue for an OEP
+
+---
+
+### Enhancement Description
+
+- Clear and concise enhancement description (one-liner):
+- OpenEBS Enhancement Proposal: <!-- link to oep file; if none yet, link to PR -->
+- Discussion Link: <!-- link to any issue, thread, or recording where the Enhancement was discussed before OEP creation -->
+- Primary contact (assignee):
+- Responsible OWNERs:
+- Targeted milestone:
+  - OpenEBS vx.y:
+- [ ] Targets
+  - [ ] OEP update PR(s):
+  - [ ] Code update PR(s):
+  - [ ] E2E Test PR(s):
+  - [ ] Docs update PR(s):
+
+_Please keep this description up to date. This will help track the evolution of the enhancement efficiently._

--- a/designs/oep-process.md
+++ b/designs/oep-process.md
@@ -112,11 +112,11 @@ to coordinate and communicate.
 
 Enhancements that have major impacts on multiple OWNERs should use the OEP process.
 A single OWNER will own the OEP but it is expected that the set of approvers will
-span the impacted OWNERs. The OEP process is the way that OWNERs can negotiate 
+span the impacted OWNERs. The OEP process is the way that OWNERs can negotiate
 and communicate changes that cross boundaries.
 
-OEPs will also be used to drive large changes that will cut across all parts of 
-the project. These OEPs will be owned among the OWNERs and should be seen as a 
+OEPs will also be used to drive large changes that will cut across all parts of
+the project. These OEPs will be owned among the OWNERs and should be seen as a
 way to communicate the most fundamental aspects of what OpenEBS is.
 
 ### OEP Template
@@ -134,13 +134,7 @@ Metadata items:
   * Each proposal has a number.  This is to make all references to proposals as
     clear as possible.  This is especially important as we create a network
     cross references between proposals.
-  * Before having the `Approved` status, the number for the OEP will be in the
-    form of `draft-YYYYMMDD`.  The `YYYYMMDD` is replaced with the current date
-    when first creating the OEP.  The goal is to enable fast parallel merges of
-    pre-acceptance OEPs.
-  * On acceptance a sequential dense number will be assigned.  This will be done
-    by the editor and will be done in such a way as to minimize the chances of
-    conflicts.  The final number for a OEP will have no prefix.
+  * This number is the associated tracking issue number.
 * **title** Required
   * The title of the OEP in plain language.  The title will also be used in the
     OEP filename.  See the template for instructions and details.
@@ -189,7 +183,7 @@ A OEP has the following states
 - `provisional`: The OEP has been proposed and is actively being defined.
   This is the starting state while the OEP is being fleshed out and actively defined and discussed.
   The OWNER has accepted that this is work that needs to be done.
-- `implementable`: The approvers have approved this OEP for implementation and OWNERs create, if appropriate, 
+- `implementable`: The approvers have approved this OEP for implementation and OWNERs create, if appropriate,
   a [milestone](https://github.com/openebs/openebs/milestones) to track implementation work.
 - `implemented`: The OEP has been implemented and is no longer actively changed. OWNERs reflect
   the status change and close its matching milestone, if appropriate.
@@ -202,12 +196,12 @@ A OEP has the following states
 
 ### Git and GitHub Implementation
 
-OEPs are checked into under the `/contribute/design/feature` directory.
+OEPs are checked into under the `/designs/xxx` directory.
 
-New OEPs can be checked in with a file name in the form of `draft-YYYYMMDD-my-title.md`.
-As significant work is done on the OEP the authors can assign a OEP number.
+At least before merging the first provisional draft of an OEP, a GitHub tracking issue must be created.
+The OEP number is taken from the GitHub tracking issue.
+
 No other changes should be put in that PR so that it can be approved quickly and minimize merge conflicts.
-The OEP number can also be done as part of the initial submission if the PR is likely to be uncontested and merged quickly.
 
 ### OEP Editor Role
 
@@ -220,7 +214,7 @@ In keeping with the OEP editors which
 > technical sense, even if they don't seem likely to be accepted.
 > The title should accurately describe the content.
 > Edit the OEP for language (spelling, grammar, sentence structure, etc.), markup
-> (for yaml, schema naming conventions), code style (examples should match 
+> (for yaml, schema naming conventions), code style (examples should match
 idiomatic openebs standards).
 
 OEP editors should generally not pass judgement on a OEP beyond editorial corrections.

--- a/designs/oep-template.md
+++ b/designs/oep-template.md
@@ -1,5 +1,5 @@
 ---
-oep-number: OEP 101
+oep-number: OEP 1
 title: My First OEP
 authors:
   - "@user1"
@@ -29,11 +29,13 @@ The title should be lowercased and spaces/punctuation should be replaced with `-
 
 To get started with this template:
 1. **Make a copy of this template.**
-  Name it `YYYYMMDD-my-title.md`.
+  Name it `my-title.md`.
 1. **Fill out the "overview" sections.**
   This includes the Summary and Motivation sections.
+1. **Create a tracking Issue.**
+  This should follow the GitHub OEP Issue template.
 1. **Create a PR.**
-  Name it `[OEP NUMBER] Title`, e.g. `[OEP 0001] Snapshot for LVM localpv volumes`.
+  Name it `[OEP NUMBER] Title`, e.g. `[OEP 101] Snapshot for LVM localpv volumes`.
   Assign it to owner(s) that are sponsoring this process.
 1. **Merge early.**
   Avoid getting hung up on specific details and instead aim to get the goal of the OEP merged quickly.
@@ -129,9 +131,6 @@ For example, consider both security and how this will impact the larger kubernet
 
 How will we know that this has succeeded?
 Gathering user feedback is crucial for building high quality experiences and owners have the important responsibility of setting milestones for stability and completeness.
-Hopefully the content previously contained in [umbrella issues][] will be tracked in the `Graduation Criteria` section.
-
-[umbrella issues]: https://github.com/kubernetes/kubernetes/issues/42752
 
 ## Implementation History
 


### PR DESCRIPTION
As discussed in the maintainers mtg, the oep's tracking number should be its parent github issue number.
Also adds a simple template for the parent tracking issue, highly based off the kubernetes KEP issue template.