### PR TITLE
feat(charts): add openebs v4.1.2

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-version: 4.1.1
+version: 4.1.2
 name: openebs
-appVersion: 4.1.1
+appVersion: 4.1.2
 description: Containerized Attached Storage for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/icon/color/openebs-icon-color.png
 home: https://www.openebs.io/
@@ -16,9 +16,9 @@ sources:
   - https://github.com/openebs/openebs
 dependencies:
   - name: openebs-crds
-    version: 4.1.1
+    version: 4.1.2
   - name: localpv-provisioner
-    version: 4.1.1
+    version: 4.1.2
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
   - name: zfs-localpv
     version: 2.6.2
@@ -29,6 +29,6 @@ dependencies:
     repository: "https://openebs.github.io/lvm-localpv"
     condition: engines.local.lvm.enabled
   - name: mayastor
-    version: 2.7.1
+    version: 2.7.2
     repository: "https://openebs.github.io/mayastor-extensions"
     condition: engines.replicated.mayastor.enabled

--- a/charts/README.md
+++ b/charts/README.md
@@ -72,7 +72,7 @@ To view the chart and get the following output.
 helm ls -n openebs 
 
 NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
-openebs openebs         1               2024-07-07 09:13:00.903321318 +0000 UTC deployed        openebs-4.1.0   4.1.0
+openebs openebs         1               2025-01-10 09:13:00.903321318 +0000 UTC deployed        openebs-4.1.2   4.1.2
 ```
 
 As a next step [verify the installation](https://openebs.io/docs/quickstart-guide/installation#verifying-openebs-installation) and do the [post installation](https://openebs.io/docs/quickstart-guide/installation#post-installation-considerations) steps.
@@ -92,11 +92,11 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 
 | Repository | Name | Version |
 |------------|------|---------|
-|  | openebs-crds | 4.1.0 |
-| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.0 |
-| https://openebs.github.io/lvm-localpv | lvm-localpv | 1.6.0 |
-| https://openebs.github.io/mayastor-extensions | mayastor | 2.7.0 |
-| https://openebs.github.io/zfs-localpv | zfs-localpv | 2.6.0 |
+|  | openebs-crds | 4.1.2 |
+| https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.1.2 |
+| https://openebs.github.io/lvm-localpv | lvm-localpv | 1.6.2 |
+| https://openebs.github.io/mayastor-extensions | mayastor | 2.7.2 |
+| https://openebs.github.io/zfs-localpv | zfs-localpv | 2.6.2 |
 
 ## Values
 
@@ -119,6 +119,5 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | preUpgradeHook.image.registry | string | `"docker.io"` | The container image registry URL for the hook job |
 | preUpgradeHook.image.repo | string | `"bitnami/kubectl"` | The container repository for the hook job |
 | preUpgradeHook.image.tag | string | `"1.25.15"` | The container image tag for the hook job |
-| release.version | string | `"4.1.0"` |  |
 | zfs-localpv.crds.csi.volumeSnapshots.enabled | bool | `false` |  |
 | zfs-localpv.crds.zfsLocalPv.enabled | bool | `true` |  |

--- a/charts/charts/openebs-crds/Chart.yaml
+++ b/charts/charts/openebs-crds/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: openebs-crds
-version: 4.1.1
+version: 4.1.2
 description: A Helm chart that collects CustomResourceDefinitions (CRDs) from OpenEBS.

--- a/charts/charts/openebs-crds/helm.md
+++ b/charts/charts/openebs-crds/helm.md
@@ -1,6 +1,6 @@
 # openebs-crds
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square)
+![Version: 4.1.2](https://img.shields.io/badge/Version-4.1.2-informational?style=flat-square)
 
 A Helm chart that collects CustomResourceDefinitions (CRDs) from OpenEBS.
 

--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -6,7 +6,7 @@ Check the status by running: kubectl get pods -n {{ .Release.Namespace }}
 The default values will install both Local PV and Replicated PV. However,
 the Replicated PV will require additional configuration to be fuctional.
 The Local PV offers non-replicated local storage using 3 different storage
-backends i.e HostPath, LVM and ZFS, while the Replicated PV provides one replicated highly-available
+backends i.e Hostpath, LVM and ZFS, while the Replicated PV provides one replicated highly-available
 storage backend i.e Mayastor.
 
 For more information, 

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -4,7 +4,7 @@ openebs-crds:
       enabled: true
       keep: true
 
-# Refer to https://github.com/openebs/dynamic-localpv-provisioner/blob/HEAD/deploy/helm/charts/values.yaml for complete set of values.
+# Refer to https://github.com/openebs/dynamic-localpv-provisioner/blob/v4.1.2/deploy/helm/charts/values.yaml for complete set of values.
 localpv-provisioner:
   rbac:
     create: true
@@ -27,7 +27,7 @@ lvm-localpv:
       volumeSnapshots:
         enabled: false
 
-# Refer to https://github.com/openebs/mayastor-extensions/blob/v2.7.1/chart/values.yaml for complete set of values.
+# Refer to https://github.com/openebs/mayastor-extensions/blob/v2.7.2/chart/values.yaml for complete set of values.
 mayastor:
   csi:
     node:


### PR DESCRIPTION
Changes:
- Bump LocalPV Hostpath to v4.1.2
- Bump Mayastor to v2.7.2
- Bump version and appVersion to v4.1.2
- Bump openebs-crds subchart version to v4.1.2
- Update README.md with correct dependency versions
- Update values.yaml comments with correct links to dependecy chart values.yaml's
- Fix Hostpath spelling typo in NOTES.txt

I've tested this change for install and upgrade scenarios.