### PR TITLE
[Fix] Fix invalid YAMLs in CRDs

### DIFF
--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot-class.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot-class.yaml
@@ -41,9 +41,10 @@ spec:
             are non-namespaced
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             deletionPolicy:
               description: deletionPolicy determines whether a VolumeSnapshotContent
@@ -62,9 +63,10 @@ spec:
                 VolumeSnapshotClass. Required.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             parameters:
               additionalProperties:
@@ -83,7 +85,8 @@ spec:
         - jsonPath: .driver
           name: Driver
           type: string
-        - description: Determines whether a VolumeSnapshotContent created through the
+        - description: >
+            Determines whether a VolumeSnapshotContent created through the
             VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
           jsonPath: .deletionPolicy
           name: DeletionPolicy
@@ -103,9 +106,10 @@ spec:
             are non-namespaced
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             deletionPolicy:
               description: deletionPolicy determines whether a VolumeSnapshotContent
@@ -124,9 +128,10 @@ spec:
                 VolumeSnapshotClass. Required.
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             parameters:
               additionalProperties:

--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot-class.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot-class.yaml
@@ -41,7 +41,7 @@ spec:
             are non-namespaced
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -63,7 +63,7 @@ spec:
                 VolumeSnapshotClass. Required.
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -85,7 +85,7 @@ spec:
         - jsonPath: .driver
           name: Driver
           type: string
-        - description: >
+        - description: |
             Determines whether a VolumeSnapshotContent created through the
             VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
           jsonPath: .deletionPolicy
@@ -106,7 +106,7 @@ spec:
             are non-namespaced
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
@@ -128,7 +128,7 @@ spec:
                 VolumeSnapshotClass. Required.
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds

--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot-content.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot-content.yaml
@@ -64,13 +64,13 @@ spec:
             object in the underlying storage system
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -149,7 +149,7 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: >
+                      description: |
                         If referring to a piece of an object instead of
                         an entire object, this string should contain a valid JSON/Go
                         field access statement, such as desiredState.manifest.containers[2].
@@ -172,7 +172,7 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: >
+                      description: |
                         Specific resourceVersion to which this reference
                         is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
@@ -191,7 +191,7 @@ spec:
               description: status represents the current information of a snapshot.
               properties:
                 creationTime:
-                  description: >
+                  description: |
                     creationTime is the timestamp when the point-in-time
                     snapshot is taken by the underlying storage system. In dynamic snapshot
                     creation case, this field will be filled in by the CSI snapshotter
@@ -210,7 +210,7 @@ spec:
                     if any. Upon success after retry, this error field will be cleared.
                   properties:
                     message:
-                      description: >
+                      description: |
                         message is a string detailing the encountered error
                         during snapshot creation if specified. NOTE: message may be
                         logged, and it should not contain sensitive information.
@@ -309,13 +309,13 @@ spec:
             object in the underlying storage system
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -383,7 +383,7 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: >
+                      description: |
                         If referring to a piece of an object instead of
                         an entire object, this string should contain a valid JSON/Go
                         field access statement, such as desiredState.manifest.containers[2].
@@ -406,7 +406,7 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: >
+                      description: |
                         Specific resourceVersion to which this reference
                         is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
@@ -442,7 +442,7 @@ spec:
                     if any. Upon success after retry, this error field will be cleared.
                   properties:
                     message:
-                      description: >
+                      description: |
                         message is a string detailing the encountered error
                         during snapshot creation if specified. NOTE: message may be
                         logged, and it should not contain sensitive information.

--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot-content.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot-content.yaml
@@ -64,14 +64,16 @@ spec:
             object in the underlying storage system
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             spec:
               description: spec defines properties of a VolumeSnapshotContent created
@@ -147,17 +149,18 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                      description: >
+                        If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -169,8 +172,9 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: >
+                        Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -187,7 +191,8 @@ spec:
               description: status represents the current information of a snapshot.
               properties:
                 creationTime:
-                  description: creationTime is the timestamp when the point-in-time
+                  description: >
+                    creationTime is the timestamp when the point-in-time
                     snapshot is taken by the underlying storage system. In dynamic snapshot
                     creation case, this field will be filled in by the CSI snapshotter
                     sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
@@ -205,9 +210,10 @@ spec:
                     if any. Upon success after retry, this error field will be cleared.
                   properties:
                     message:
-                      description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                      description: >
+                        message is a string detailing the encountered error
+                        during snapshot creation if specified. NOTE: message may be
+                        logged, and it should not contain sensitive information.
                       type: string
                     time:
                       description: time is the timestamp when the error was encountered.
@@ -303,14 +309,16 @@ spec:
             object in the underlying storage system
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             spec:
               description: spec defines properties of a VolumeSnapshotContent created
@@ -375,17 +383,18 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                      description: >
+                        If referring to a piece of an object instead of
+                        an entire object, this string should contain a valid JSON/Go
+                        field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within
+                        a pod, this would take on a value like: "spec.containers{name}"
+                        (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]"
+                        (container with index 2 in this pod). This syntax is chosen
+                        only to have some well-defined way of referencing a part of
+                        an object. TODO: this design is not final and this field is
+                        subject to change in the future.
                       type: string
                     kind:
                       description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
@@ -397,8 +406,9 @@ spec:
                       description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
                     resourceVersion:
-                      description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: >
+                        Specific resourceVersion to which this reference
+                        is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
                       description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
@@ -432,9 +442,10 @@ spec:
                     if any. Upon success after retry, this error field will be cleared.
                   properties:
                     message:
-                      description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                      description: >
+                        message is a string detailing the encountered error
+                        during snapshot creation if specified. NOTE: message may be
+                        logged, and it should not contain sensitive information.
                       type: string
                     time:
                       description: time is the timestamp when the error was encountered.

--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot.yaml
@@ -66,14 +66,16 @@ spec:
             snapshot of a persistent volume, or binding to a pre-existing snapshot.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             spec:
               description: 'spec defines the desired characteristics of a snapshot requested
@@ -106,17 +108,18 @@ spec:
                       type: string
                   type: object
                 volumeSnapshotClassName:
-                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
-                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
-                  left nil to indicate that the default SnapshotClass should be used.
-                  A given cluster may have multiple default Volume SnapshotClasses:
-                  one default per CSI Driver. If a VolumeSnapshot does not specify
-                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
-                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
-                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
-                  exist for a given CSI Driver and more than one have been marked
-                  as default, CreateSnapshot will fail and generate an event. Empty
-                  string is not allowed for this field.'
+                  description: >
+                    VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                    requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+                    left nil to indicate that the default SnapshotClass should be used.
+                    A given cluster may have multiple default Volume SnapshotClasses:
+                    one default per CSI Driver. If a VolumeSnapshot does not specify
+                    a SnapshotClass, VolumeSnapshotSource will be checked to figure
+                    out what the associated CSI Driver is, and the default VolumeSnapshotClass
+                    associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
+                    exist for a given CSI Driver and more than one have been marked
+                    as default, CreateSnapshot will fail and generate an event. Empty
+                    string is not allowed for this field.
                   type: string
               required:
                 - source
@@ -128,14 +131,15 @@ spec:
                 point at each other) before using this object.
               properties:
                 boundVolumeSnapshotContentName:
-                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
-                  object to which this VolumeSnapshot object intends to bind to. If
-                  not specified, it indicates that the VolumeSnapshot object has not
-                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
-                  To avoid possible security issues, consumers must verify binding
-                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
-                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
-                  point at each other) before using this object.'
+                  description: >
+                    boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                    object to which this VolumeSnapshot object intends to bind to. If
+                    not specified, it indicates that the VolumeSnapshot object has not
+                    been successfully bound to a VolumeSnapshotContent object yet. NOTE:
+                    To avoid possible security issues, consumers must verify binding
+                    between VolumeSnapshot and VolumeSnapshotContent objects is successful
+                    (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                    point at each other) before using this object.
                   type: string
                 creationTime:
                   description: creationTime is the timestamp when the point-in-time
@@ -253,19 +257,22 @@ spec:
             snapshot of a persistent volume, or binding to a pre-existing snapshot.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: >
+                APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: >
+                Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             spec:
-              description: 'spec defines the desired characteristics of a snapshot requested
-              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
-              Required.'
+              description: >
+                spec defines the desired characteristics of a snapshot requested
+                by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+                Required.
               properties:
                 source:
                   description: source specifies where a snapshot will be created from.
@@ -288,17 +295,18 @@ spec:
                       type: string
                   type: object
                 volumeSnapshotClassName:
-                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
-                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
-                  left nil to indicate that the default SnapshotClass should be used.
-                  A given cluster may have multiple default Volume SnapshotClasses:
-                  one default per CSI Driver. If a VolumeSnapshot does not specify
-                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
-                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
-                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
-                  exist for a given CSI Driver and more than one have been marked
-                  as default, CreateSnapshot will fail and generate an event. Empty
-                  string is not allowed for this field.'
+                  description: >
+                    VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                    requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+                    left nil to indicate that the default SnapshotClass should be used.
+                    A given cluster may have multiple default Volume SnapshotClasses:
+                    one default per CSI Driver. If a VolumeSnapshot does not specify
+                    a SnapshotClass, VolumeSnapshotSource will be checked to figure
+                    out what the associated CSI Driver is, and the default VolumeSnapshotClass
+                    associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
+                    exist for a given CSI Driver and more than one have been marked
+                    as default, CreateSnapshot will fail and generate an event. Empty
+                    string is not allowed for this field.
                   type: string
               required:
                 - source
@@ -310,14 +318,15 @@ spec:
                 point at each other) before using this object.
               properties:
                 boundVolumeSnapshotContentName:
-                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
-                  object to which this VolumeSnapshot object intends to bind to. If
-                  not specified, it indicates that the VolumeSnapshot object has not
-                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
-                  To avoid possible security issues, consumers must verify binding
-                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
-                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
-                  point at each other) before using this object.'
+                  description: >
+                    boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                    object to which this VolumeSnapshot object intends to bind to. If
+                    not specified, it indicates that the VolumeSnapshot object has not
+                    been successfully bound to a VolumeSnapshotContent object yet. NOTE:
+                    To avoid possible security issues, consumers must verify binding
+                    between VolumeSnapshot and VolumeSnapshotContent objects is successful
+                    (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                    point at each other) before using this object.
                   type: string
                 creationTime:
                   description: creationTime is the timestamp when the point-in-time
@@ -340,9 +349,10 @@ spec:
                     will be cleared.
                   properties:
                     message:
-                      description: 'message is a string detailing the encountered error
-                      during snapshot creation if specified. NOTE: message may be
-                      logged, and it should not contain sensitive information.'
+                      description: >
+                        message is a string detailing the encountered error
+                        during snapshot creation if specified. NOTE: message may be
+                        logged, and it should not contain sensitive information.
                       type: string
                     time:
                       description: time is the timestamp when the error was encountered.

--- a/charts/charts/openebs-crds/templates/csi-volume-snapshot.yaml
+++ b/charts/charts/openebs-crds/templates/csi-volume-snapshot.yaml
@@ -66,13 +66,13 @@ spec:
             snapshot of a persistent volume, or binding to a pre-existing snapshot.
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
@@ -108,7 +108,7 @@ spec:
                       type: string
                   type: object
                 volumeSnapshotClassName:
-                  description: >
+                  description: |
                     VolumeSnapshotClassName is the name of the VolumeSnapshotClass
                     requested by the VolumeSnapshot. VolumeSnapshotClassName may be
                     left nil to indicate that the default SnapshotClass should be used.
@@ -131,7 +131,7 @@ spec:
                 point at each other) before using this object.
               properties:
                 boundVolumeSnapshotContentName:
-                  description: >
+                  description: |
                     boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
                     object to which this VolumeSnapshot object intends to bind to. If
                     not specified, it indicates that the VolumeSnapshot object has not
@@ -257,19 +257,19 @@ spec:
             snapshot of a persistent volume, or binding to a pre-existing snapshot.
           properties:
             apiVersion:
-              description: >
+              description: |
                 APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
                 internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: >
+              description: |
                 Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
                 submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             spec:
-              description: >
+              description: |
                 spec defines the desired characteristics of a snapshot requested
                 by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
                 Required.
@@ -295,7 +295,7 @@ spec:
                       type: string
                   type: object
                 volumeSnapshotClassName:
-                  description: >
+                  description: |
                     VolumeSnapshotClassName is the name of the VolumeSnapshotClass
                     requested by the VolumeSnapshot. VolumeSnapshotClassName may be
                     left nil to indicate that the default SnapshotClass should be used.
@@ -318,7 +318,7 @@ spec:
                 point at each other) before using this object.
               properties:
                 boundVolumeSnapshotContentName:
-                  description: >
+                  description: |
                     boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
                     object to which this VolumeSnapshot object intends to bind to. If
                     not specified, it indicates that the VolumeSnapshot object has not
@@ -349,7 +349,7 @@ spec:
                     will be cleared.
                   properties:
                     message:
-                      description: >
+                      description: |
                         message is a string detailing the encountered error
                         during snapshot creation if specified. NOTE: message may be
                         logged, and it should not contain sensitive information.


### PR DESCRIPTION
There are some invalid YAML in the CRDs and this PR aims to fix those. We are using cdk8s to synthesise this helm chart and it fails to apply because of the invalid YAML. See an example of invalid YAML below:

![Screenshot 2025-01-10 at 18 34 58](https://github.com/user-attachments/assets/367f2116-d01e-4682-b440-1fe5b560269b)

A similar issue was reported earlier [here](https://github.com/cdk8s-team/cdk8s-core/issues/1850) in cdk8s and it turned out there is some invalid YAML in the CRDs