### PR TITLE
dont convert zfs pool stats into human readable format

### DIFF
--- a/plugin/src/cli_utils/localpv/zfs/node/types.rs
+++ b/plugin/src/cli_utils/localpv/zfs/node/types.rs
@@ -1,7 +1,5 @@
 use super::Error;
-use crate::cli_utils::localpv::adjust_bytes;
 
-use anyhow::anyhow;
 use k8s_openapi::NamespaceResourceScope;
 use kube::{api::ObjectMeta, Resource, ResourceExt};
 use serde::{Deserialize, Serialize};
@@ -132,20 +130,8 @@ impl TryFrom<(&Pool, &String)> for ZfsPool {
             name: pool.name.clone(),
             node: node.to_string(),
             uuid: pool.uuid.clone(),
-            free: adjust_bytes(pool.free.parse::<u128>().map_err(|e| Error::Generic {
-                source: anyhow!(
-                    "Failed to parse free bytes for zpool {}, error: {}",
-                    pool.name,
-                    e.to_string()
-                ),
-            })?),
-            used: adjust_bytes(pool.used.parse::<u128>().map_err(|e| Error::Generic {
-                source: anyhow!(
-                    "Failed to parse used bytes for zpool {}, error: {}",
-                    pool.name,
-                    e.to_string()
-                ),
-            })?),
+            free: pool.free.clone(),
+            used: pool.used.clone(),
         })
     }
 }


### PR DESCRIPTION
zfsnode resource capacity fields are represented in bytes and human-readable. Its bound to change also with every update on CR.

For example:

Here are 2 pools with no zvols on different nodes. Both zpools were created on 30G disk.

```
kubectl get zfsnodes node-0-309787 -oyaml
apiVersion: zfs.openebs.io/v1
kind: ZFSNode
metadata:
  creationTimestamp: "2025-01-30T06:53:24Z"
  generation: 2
  name: node-0-309787
  namespace: puls8
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: Node
    name: node-0-309787
    uid: d4ae440a-2fcc-487e-a056-8b1af6de985a
  resourceVersion: "39456"
  uid: d58cd02d-66ed-4921-ad44-a2ae39bc7557
pools:
- free: 29966204Ki
  name: zfspv-pool
  used: 99Ki
  uuid: "965947675669908193"
 
[nix-shell:~/mayarepo/openebs]# kubectl get zfsnodes node-1-309787 -n puls8 
apiVersion: zfs.openebs.io/v1
kind: ZFSNode
metadata:
  creationTimestamp: "2025-01-30T06:53:31Z"
  generation: 2
  name: node-1-309787
  namespace: puls8
  ownerReferences:
  - apiVersion: v1
    controller: true
    kind: Node
    name: node-1-309787
    uid: 75975c2a-14b7-4f19-ab5c-c22d32ae836c
  resourceVersion: "39478"
  uid: f6da8b1d-6439-480f-bebe-dc431cb88516
pools:
- free: "30685394432"
  name: zfspv-pool
  used: "99840"
  uuid: "10029612145612829144"
```

Here 1st pool is in human readable 2nd is in bytes. Now same 2 pools after getting 1 volumes each

```
 kubectl get zfsnode node-0-309787 node-1-309787 -oyaml
apiVersion: v1
items:
- apiVersion: zfs.openebs.io/v1
  kind: ZFSNode
  metadata:
    creationTimestamp: "2025-01-30T06:53:24Z"
    generation: 3
    name: node-0-309787
    namespace: puls8
    ownerReferences:
    - apiVersion: v1
      controller: true
      kind: Node
      name: node-0-309787
      uid: d4ae440a-2fcc-487e-a056-8b1af6de985a
    resourceVersion: "45216"
    uid: d58cd02d-66ed-4921-ad44-a2ae39bc7557
  pools:
  - free: "30685332992"
    name: zfspv-pool
    used: 156Ki
    uuid: "965947675669908193"
- apiVersion: zfs.openebs.io/v1
  kind: ZFSNode
  metadata:
    creationTimestamp: "2025-01-30T06:53:31Z"
    generation: 3
    name: node-1-309787
    namespace: puls8
    ownerReferences:
    - apiVersion: v1
      controller: true
      kind: Node
      name: node-1-309787
      uid: 75975c2a-14b7-4f19-ab5c-c22d32ae836c
    resourceVersion: "45238"
    uid: f6da8b1d-6439-480f-bebe-dc431cb88516
  pools:
  - free: 29966144Ki
    name: zfspv-pool
    used: "158208"
    uuid: "10029612145612829144"
kind: List
metadata:
  resourceVersion: ""
  ```
  
 Here its mixed, each pool has 1 metric in human readable and other in bytes. 

So we should just not do any conversion.

@Abhinandan-Purkait , @sinhaashish 

