### PR TITLE
ci: disable usage metrics for CI test runs

### DIFF
--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -28,17 +28,17 @@ jobs:
         if: steps.changes.outputs.chart == 'true'
         uses: azure/setup-helm@v4
         with:
-          version: v3.14.3
+          version: v3.17.1
 
       - uses: actions/setup-python@v5
         if: steps.changes.outputs.chart == 'true'
         with:
-          python-version: '3.10'
+          python-version: '3.x'
           check-latest: true
 
       - name: Set up chart-testing
         if: steps.changes.outputs.chart == 'true'
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         if: steps.changes.outputs.chart == 'true'
@@ -54,7 +54,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.9.0
+        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Add dependency chart repos

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,3 +2,5 @@ remote: origin
 target-branch: develop
 helm-extra-args: --timeout=500s
 validate-maintainers: false
+helm-repo-extra-args:
+  - "--set localpv-provisioner.analytics.enabled=false,lvm-localpv.analytics.enabled=false,mayastor.etcd.livenessProbe.initialDelaySeconds=5,mayastor.etcd.readinessProbe.initialDelaySeconds=5,mayastor.etcd.replicaCount=1,mayastor.obs.callhome.sendReport=false,mayastor.nats.cluster.enabled=false,mayastor.nats.cluster.replicas=1,zfs-localpv.analytics.enabled=false"


### PR DESCRIPTION
Changes:
1. Disabled analytics for the localpvs, disables call-home for mayastor
2. Set etcd probes to a lower initial delay
3. set etcd and nats to use a single replica.