### PR TITLE
CI: ensure path filters work with protection settings

### DIFF
--- a/.github/workflows/chart-images.yml
+++ b/.github/workflows/chart-images.yml
@@ -32,6 +32,7 @@ jobs:
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
       - name: Pre-populate K8s nix-shell
+        if: steps.changes.outputs.chart == 'true'
         run: nix-shell ./scripts/k8s/shell.nix --run "echo"
       - name: Pre-populate helm nix-shell
         run: nix-shell ./scripts/helm/shell.nix --run "echo"

--- a/.github/workflows/chart-lint.yml
+++ b/.github/workflows/chart-lint.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - develop
+      - 'release/**'
   pull_request:
-    branches:
-      - develop
+    types: [ 'opened', 'edited', 'reopened', 'synchronize' ]
 
 jobs:
   lint-test:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,30 @@
+name: Nix Lint CI
+on:
+  pull_request:
+    types: [ 'opened', 'edited', 'reopened', 'synchronize' ]
+  push:
+    branches:
+      - develop
+      - 'release/**'
+
+env:
+  CI: 1
+
+jobs:
+  nix-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            nix:
+              - '**.nix'
+      - uses: DeterminateSystems/nix-installer-action@v14
+        if: steps.changes.outputs.nix == 'true'
+      - name: Lint nix code
+        if: steps.changes.outputs.nix == 'true'
+        run: nix-shell -p nixpkgs-fmt --run "nixpkgs-fmt --check ."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,9 @@ on:
       - develop
       - "release/**"
 
+env:
+  CI: 1
+
 jobs:
   markdown-spell-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - "release/**"
-      - main
 
 jobs:
   markdown-spell-check:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  CI: 1
 
 jobs:
   rust-linter-build:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -2,9 +2,6 @@ name: Rust CI
 on:
   pull_request:
     types: [ 'opened', 'edited', 'reopened', 'synchronize' ]
-    paths:
-      - 'plugin/**'
-      - '**.nix'
   push:
     branches:
       - develop
@@ -21,18 +18,36 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            rust:
+              - 'plugin/**'
+              - 'nix/**'
+              - shell.nix
+              - default.nix
+              - Cargo.toml
+              - Cargo.lock
+              - 'mayastor/**'
       - uses: DeterminateSystems/nix-installer-action@v14
+        if: steps.changes.outputs.rust == 'true'
       - uses: DeterminateSystems/magic-nix-cache-action@v8
+        if: steps.changes.outputs.rust == 'true'
       - name: Pre-populate nix-shell
+        if: steps.changes.outputs.rust == 'true'
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --run "echo" shell.nix
       - name: Handle Rust dependencies caching
+        if: steps.changes.outputs.rust == 'true'
         uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ startsWith(github.ref_name, 'release/') || github.ref_name == 'develop' }}
       - name: Lint rust code
+        if: steps.changes.outputs.rust == 'true'
         run: nix-shell --run "./scripts/rust/linter.sh"
       - name: Build rust binaries
+        if: steps.changes.outputs.rust == 'true'
         run: nix-shell --run "./scripts/rust/builder.sh"

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -52,3 +52,9 @@ jobs:
       - name: Build rust binaries
         if: steps.changes.outputs.rust == 'true'
         run: nix-shell --run "./scripts/rust/builder.sh"
+      - name: Ensure Cargo.lock is up to date
+        run: |
+          if git diff --name-only | grep -q 'Cargo.lock'; then
+            echo "Cargo.lock is not up to date!"
+            exit 1
+          fi


### PR DESCRIPTION
GitHub doesn't handle path filters for a workflow properly. If it doesn't run, then the branch protection setting prevents the PR from passing!
Instead, let's run the workflow but filter from the job steps.
