### PR TITLE
ci: disable man-pages update

### DIFF
--- a/.github/workflows/chart-images.yml
+++ b/.github/workflows/chart-images.yml
@@ -42,7 +42,10 @@ jobs:
         run: nix-shell ./scripts/helm/shell.nix --run "./scripts/helm/images.sh patch --exit-code"
       - name: BootStrap k8s cluster
         if: steps.changes.outputs.chart == 'true'
-        run: nix-shell ./scripts/k8s/shell.nix --run "./scripts/k8s/deployer.sh start --mayastor --zfs --lvm --label"
+        run: |
+          sudo debconf-communicate <<< "set man-db/auto-update false" || true
+          sudo dpkg-reconfigure man-db || true
+          nix-shell ./scripts/k8s/shell.nix --run "./scripts/k8s/deployer.sh start --mayastor --zfs --lvm --label"
       - name: Install helm chart
         if: steps.changes.outputs.chart == 'true'
         run: nix-shell ./scripts/helm/shell.nix --run "./scripts/helm/install.sh --mayastor --zfs --lvm --wait"


### PR DESCRIPTION
When running image test we install kernel modules which triggers a very slow update of man-pages.