### PR TITLE
fix(CODEOWNERS): remove @org-maintainers from default code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default code owners
-*                           @openebs/org-maintainers @openebs/localpv-hostpath-approvers @openebs/localpv-zfs-approvers @openebs/localpv-lvm-approvers @openebs/mayastor-approvers @openebs/ci-buildscript-approvers
+*                           @openebs/localpv-hostpath-approvers @openebs/localpv-zfs-approvers @openebs/localpv-lvm-approvers @openebs/mayastor-approvers @openebs/ci-buildscript-approvers
 
 # CODEOWNERS file owners
 /.github/CODEOWNERS         @openebs/org-maintainers


### PR DESCRIPTION
Change:
- Remove requirement for an @openebs/org-maintainers member's review when merging non-policy documents.
- Settings changes:
  - Mandate code owner approval
  - Ensure required approval is set to 1