### PR TITLE
chore(CODEOWNERS): add OEP owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # Default code owners
 *                           @openebs/localpv-hostpath-approvers @openebs/localpv-zfs-approvers @openebs/localpv-lvm-approvers @openebs/mayastor-approvers @openebs/ci-buildscript-approvers
 
+# OEP owners
+/designs                    @openebs/org-maintainers
+
 # CODEOWNERS file owners
 /.github/CODEOWNERS         @openebs/org-maintainers
 


### PR DESCRIPTION
Makes it so that OEPs requires at least 1 review from an @openebs/org-maintainers.
