### PR TITLE
feat(chart): add podLabels to pre upgrade hook job

### DIFF
--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -77,6 +77,9 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- with .Values.preUpgradeHook.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: "{{ .Release.Name }}-pre-upgrade-hook"
       restartPolicy: Never

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -43,6 +43,8 @@ mayastor:
 
 # -- Configuration options for pre-upgrade helm hook job.
 preUpgradeHook:
+  # -- Labels to be added to the pod hook job
+  podLabels: {}
   image:
     # -- The container image registry URL for the hook job
     registry: docker.io


### PR DESCRIPTION
This PR adds support for `podLabels` to the pod created by the pre-upgrade hook job. Adding custom labels allow to integrate with network policies for example.