### PR TITLE
fix(helm chart): Added tolerations statement to preUpgradeHook

### DIFF
--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -89,3 +89,7 @@ spec:
         - "-c"
         args:
         - "(kubectl annotate --overwrite crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io helm.sh/resource-policy=keep || true) && (kubectl -n {{ .Release.Namespace }} delete deploy -l openebs.io/component-name=openebs-localpv-provisioner --ignore-not-found)"
+{{- if .Values.preUpgradeHook.tolerations }}
+        tolerations:
+{{ toYaml .Values.preUpgradeHook.tolerations | indent 10 }}
+{{- end }}


### PR DESCRIPTION
1. Why is this change necessary ?

This change allow toleration to be applied to preUpgradeHook - needed for instalation on tainted environments.

2. How does this change address the issue ?

Adding proper helm templating to pre-upgrade-hook.yaml

3. How to verify this change ?

Proper `helm install --dry-run --debug` command with values adjusted must return something like:

```yaml
preUpgradeHook:
  image:
    pullPolicy: IfNotPresent
    registry: docker.io
    repo: bitnami/kubectl
    tag: 1.25.15
  tolerations:
  - effect: NoSchedule
    key: mycluster/mytaint
    operator: Equal
    value: myvalue
```

4. What side effects does this change have ?

None

5. Other details

Signed-off-by: Leonardo Amaral <contato@leonardoamaral.com.br>

fix: #3798

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
