### PR TITLE
Update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/branch-preparation.yml
+++ b/.github/workflows/branch-preparation.yml
@@ -49,7 +49,7 @@ jobs:
 
   prepare-branch:
     needs: create-release-branch
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     outputs:
       pr_title: ${{ steps.set-title.outputs.title }}
     steps:

--- a/.github/workflows/branch-preparation.yml
+++ b/.github/workflows/branch-preparation.yml
@@ -49,7 +49,7 @@ jobs:
 
   prepare-branch:
     needs: create-release-branch
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     outputs:
       pr_title: ${{ steps.set-title.outputs.title }}
     steps:

--- a/.github/workflows/chart-images.yml
+++ b/.github/workflows/chart-images.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   helm-images:
-    runs-on: oracle-8cpu-32gb-x86-64
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/chart-images.yml
+++ b/.github/workflows/chart-images.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   helm-images:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           # NOTE: Update the .krew.yaml file (if required) when making changes here.
-          - os: ubuntu-latest-8-cores
+          - os: oracle-8cpu-32gb-x86-64
             target: linux-musl
             arch: x86_64
-          - os: ubuntu-latest-8-cores
+          - os: oracle-8cpu-32gb-x86-64
             target: linux-musl
             arch: aarch64
           - os: macos-14
@@ -30,7 +30,7 @@ jobs:
           - os: macos-13
             target: apple-darwin
             arch: x86_64
-          - os: ubuntu-latest-8-cores
+          - os: oracle-8cpu-32gb-x86-64
             target: windows-gnu
             arch: x86_64
             suffix: .exe

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,10 +18,10 @@ jobs:
       matrix:
         include:
           # NOTE: Update the .krew.yaml file (if required) when making changes here.
-          - os: oracle-8cpu-32gb-x86-64
+          - os: oracle-vm-8cpu-32gb-x86-64
             target: linux-musl
             arch: x86_64
-          - os: oracle-8cpu-32gb-x86-64
+          - os: oracle-vm-8cpu-32gb-x86-64
             target: linux-musl
             arch: aarch64
           - os: macos-14
@@ -30,7 +30,7 @@ jobs:
           - os: macos-13
             target: apple-darwin
             arch: x86_64
-          - os: oracle-8cpu-32gb-x86-64
+          - os: oracle-vm-8cpu-32gb-x86-64
             target: windows-gnu
             arch: x86_64
             suffix: .exe


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. (or #cncf-ci-infra channel on the CNCF Slack)
