### PR TITLE
fix: remove callhome enabled false

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -44,9 +44,6 @@ mayastor:
     enabled: false
   alloy:
     enabled: false
-  obs:
-    callhome:
-      enabled: false
 
 # -- Configuration options for pre-upgrade helm hook job.
 preUpgradeHook:


### PR DESCRIPTION
- Removes the disabled callhome from umbrella.
- Makes the script use single replica loki.
