### PR TITLE
fix(helm): add imagePullSecrets to pre-upgrade hook (#3892)

### DIFF
--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -92,7 +92,10 @@ spec:
         - "-c"
         args:
         - "(kubectl annotate --overwrite crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io helm.sh/resource-policy=keep || true) && (kubectl -n {{ .Release.Namespace }} delete deploy -l openebs.io/component-name=openebs-localpv-provisioner --ignore-not-found)"
-{{- if .Values.preUpgradeHook.tolerations }}
+        {{- if .Values.preUpgradeHook.tolerations }}
         tolerations:
-{{ toYaml .Values.preUpgradeHook.tolerations | indent 10 }}
-{{- end }}
+        {{ toYaml .Values.preUpgradeHook.tolerations | indent 10 }}
+        {{- end }}
+      {{- if .Values.preUpgradeHook.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
+      {{- end }}

--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -82,6 +82,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: "{{ .Release.Name }}-pre-upgrade-hook"
+      {{- with .Values.preUpgradeHook.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: pre-upgrade-job
@@ -92,10 +96,6 @@ spec:
         - "-c"
         args:
         - "(kubectl annotate --overwrite crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io helm.sh/resource-policy=keep || true) && (kubectl -n {{ .Release.Namespace }} delete deploy -l openebs.io/component-name=openebs-localpv-provisioner --ignore-not-found)"
-        {{- if .Values.preUpgradeHook.tolerations }}
-        tolerations:
-        {{ toYaml .Values.preUpgradeHook.tolerations | indent 10 }}
-        {{- end }}
       {{- if .Values.preUpgradeHook.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
       {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -47,6 +47,14 @@ mayastor:
 
 # -- Configuration options for pre-upgrade helm hook job.
 preUpgradeHook:
+  # -- Node tolerations for server scheduling to nodes with taints
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  ##
+  tolerations: []
+  # -- Optional array of imagePullSecrets containing private registry credentials
+  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+  # - name: secretName
   # -- Labels to be added to the pod hook job
   podLabels: {}
   image:


### PR DESCRIPTION
1. Why is this change necessary ?
- Helm chart pre-upgrade hook job fails in private registries
- `imagePullSecrets` were missing from the job spec
- Users behind private registries can't upgrade without manual patching

2. How does this change address the issue ?
- Adds `.Values.preUpgradeHook.imagePullSecrets` to the hook's Job spec
- Ensures hook jobs can pull images when secrets are required

3. How to verify this change ?
- Deploy OpenEBS Helm chart in a cluster using a private registry
- Set `imagePullSecrets` in `values.yaml`
- Helm upgrade should now complete without image pull error

4. What side effects does this change have ?
- None expected
- Applies only to the upgrade hook job

5. Other details:
Fixes https://github.com/openebs/openebs/issues/3892

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
