### PR TITLE
feat(chart): enable preUpgradeHook only for upgrades from v3 to v4

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -49,8 +49,6 @@ annotations:
   helm.sh/images: |
     - name: etcd
       image: docker.io/bitnami/etcd:3.6.2-debian-12-r0
-    - name: kubectl
-      image: docker.io/bitnami/kubectl:1.25.15
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki

--- a/charts/README.md
+++ b/charts/README.md
@@ -102,37 +102,27 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| alloy.enabled | bool | `true` |  |
-| alloy.logging_config.labels | object | `{"openebs.io/logging":true}` | Labels to enable scraping on, at-least one of these labels should be present. |
-| alloy.logging_config.tenant_id | string | `"openebs"` | X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same. |
-| engines.local.lvm.enabled | bool | `true` |  |
-| engines.local.zfs.enabled | bool | `true` |  |
-| engines.replicated.mayastor.enabled | bool | `true` |  |
-| loki.localpvScConfig.enabled | bool | `true` |  |
-| loki.localpvScConfig.loki.basePath | string | `"/var/local/{{ .Release.Name }}/localpv-hostpath/loki"` | Host path where local loki data is stored in. |
-| loki.localpvScConfig.loki.name | string | `"openebs-loki-localpv"` |  |
-| loki.localpvScConfig.loki.reclaimPolicy | string | `"Delete"` | ReclaimPolicy of loki's localpv hostpath storage class. |
-| loki.localpvScConfig.loki.volumeBindingMode | string | `"WaitForFirstConsumer"` | VolumeBindingMode of loki's localpv hostpath storage class. |
-| loki.localpvScConfig.minio.basePath | string | `"/var/local/{{ .Release.Name }}/localpv-hostpath/minio"` | Host path where local minio data is stored in. |
-| loki.localpvScConfig.minio.name | string | `"openebs-minio-localpv"` |  |
-| loki.localpvScConfig.minio.reclaimPolicy | string | `"Delete"` | ReclaimPolicy of minio's localpv hostpath storage class. |
-| loki.localpvScConfig.minio.volumeBindingMode | string | `"WaitForFirstConsumer"` | VolumeBindingMode of minio's localpv hostpath storage class. |
-| loki.loki.commonConfig.replication_factor | int | `3` |  |
-| loki.minio.persistence.enabled | bool | `true` | Enable persistence for minio |
-| loki.minio.persistence.size | string | `"2Gi"` | Size of minio local storage volume |
-| loki.minio.persistence.storageClass | string | `"openebs-minio-localpv"` | Storage class for minio storage |
-| loki.minio.replicas | int | `3` |  |
-| loki.singleBinary.persistence.enabled | bool | `true` | Enable persistence for loki |
-| loki.singleBinary.persistence.size | string | `"2Gi"` | Size of loki local storage volume |
-| loki.singleBinary.persistence.storageClass | string | `"openebs-loki-localpv"` | Storage class for loki storage |
-| loki.singleBinary.replicas | int | `3` |  |
-| openebs-crds.csi.volumeSnapshots.enabled | bool | `true` |  |
-| openebs-crds.csi.volumeSnapshots.keep | bool | `true` |  |
-| preUpgradeHook | object | `{"image":{"pullPolicy":"IfNotPresent","registry":"docker.io","repo":"bitnami/kubectl","tag":"1.25.15"},"podLabels":{}}` | Configuration options for pre-upgrade helm hook job. |
-| preUpgradeHook.image.pullPolicy | string | `"IfNotPresent"` | The imagePullPolicy for the container |
-| preUpgradeHook.image.registry | string | `"docker.io"` | The container image registry URL for the hook job |
-| preUpgradeHook.image.repo | string | `"bitnami/kubectl"` | The container repository for the hook job |
-| preUpgradeHook.image.tag | string | `"1.25.15"` | The container image tag for the hook job |
-| preUpgradeHook.podLabels | object | `{}` | Labels to be added to the pod hook job |
++| Key | Description | Default |
++|:----|:------------|:--------|
++| alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;labels | Labels to enable scraping on, at-least one of these labels should be present. | <pre>{<br>"openebs.io/logging":true<br>}</pre> |
++| alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;tenant_id | X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same. | `"openebs"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;loki.&ZeroWidthSpace;basePath | Host path where local loki data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/loki"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;loki.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of loki's localpv hostpath storage class. | `"Delete"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;loki.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of loki's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;basePath | Host path where local minio data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/minio"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of minio's localpv hostpath storage class. | `"Delete"` |
++| loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;minio.&ZeroWidthSpace;volumeBindingMode | VolumeBindingMode of minio's localpv hostpath storage class. | `"WaitForFirstConsumer"` |
++| loki.&ZeroWidthSpace;minio.&ZeroWidthSpace;persistence.&ZeroWidthSpace;enabled | Enabled persistence for minio | `true` |
++| loki.&ZeroWidthSpace;minio.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Size of minio local storage volume | `"2Gi"` |
++| loki.&ZeroWidthSpace;minio.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClass | Storage class for minio storage | `"openebs-minio-localpv"` |
++| loki.&ZeroWidthSpace;singleBinary.&ZeroWidthSpace;persistence.&ZeroWidthSpace;enabled | Enabled persistence for loki | `true` |
++| loki.&ZeroWidthSpace;singleBinary.&ZeroWidthSpace;persistence.&ZeroWidthSpace;size | Size of loki local storage volume | `"2Gi"` |
++| loki.&ZeroWidthSpace;singleBinary.&ZeroWidthSpace;persistence.&ZeroWidthSpace;storageClass | Storage class for loki storage | `"openebs-loki-localpv"` |
++| mayastor.&ZeroWidthSpace;etcd.&ZeroWidthSpace;clusterDomain | Kubernetes Cluster Domain | `"cluster.local"` |
++| preUpgradeHook.&ZeroWidthSpace;enabled | Enable/Disable openebs pre-upgrade hook | `true` |
++| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | The imagePullPolicy for the container | `"IfNotPresent"` |
++| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | The container image registry URL for the hook job | `"docker.io"` |
++| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the hook job | `"bitnami/kubectl"` |
++| preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the hook job | `"1.25.15"` |
++| preUpgradeHook.&ZeroWidthSpace;imagePullSecrets | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]` |
++| preUpgradeHook.&ZeroWidthSpace;tolerations | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # | `[]` |

--- a/charts/images.txt
+++ b/charts/images.txt
@@ -1,5 +1,4 @@
 docker.io/bitnami/etcd:3.6.2-debian-12-r0
-docker.io/bitnami/kubectl:1.25.15
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0

--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -1,3 +1,6 @@
+{{- if .Values.preUpgradeHook.enabled }}
+{{- if .Release.IsUpgrade }}
+{{- if include "hostpath_is_v3" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,7 +14,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- with .Values.preUpgradeHook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,7 +30,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- with .Values.preUpgradeHook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
@@ -46,7 +53,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- with .Values.preUpgradeHook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: openebs-pre-upgrade-hook
@@ -68,7 +77,9 @@ metadata:
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    {{- with .Values.preUpgradeHook.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:
@@ -78,7 +89,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         {{- with .Values.preUpgradeHook.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: "openebs-pre-upgrade-hook"
@@ -99,3 +110,6 @@ spec:
       {{- if .Values.preUpgradeHook.imagePullSecrets }}
       imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
       {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -52,8 +52,10 @@ mayastor:
   alloy:
     enabled: false
 
-# -- Configuration options for pre-upgrade helm hook job.
+# This runs only for upgrades from openebs v3 to v4. Uses the localpv-provisioner deployment to decide if it's v3 or v4.
 preUpgradeHook:
+  # -- Enable/Disable openebs pre-upgrade hook
+  enabled: true
   # -- Node tolerations for server scheduling to nodes with taints
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   ##
@@ -62,8 +64,12 @@ preUpgradeHook:
   ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   imagePullSecrets: []
   # - name: secretName
-  # -- Labels to be added to the pod hook job
-  podLabels: {}
+  # Labels to be added to the pod hook job
+  podLabels:
+    openebs.io/logging: "true"
+  # This helps in debugging by leaving the Job/Pod instances lying around
+  annotations:
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
   image:
     # -- The container image registry URL for the hook job
     registry: docker.io


### PR DESCRIPTION
The pre-upgrade-hook for the openebs helm chart runs for every upgrade. This need only run for upgrades from openebs v3 to openebs v4.

This change checks for the localpv-provisioner deployment's `chart:` label for the chart name, and checks to see if the version set on the chart name starts with a `3`, using regex. If not, it doesn't run.

If we don't find an appropriate localpv-provisioner deployment, we run anyway, just to be safe.

Additional changes:
- Moves deletion annotations to values.yaml
- Adds `before-hook-creation` to deletion policy, so that it's not necessary to cleanup failed run resource to run a new run of the pre-upgrade hook
- Adds a toggle for the pre-upgrade job, for convenience.
- Set a check to only perform the localpv-provisioner find and read label logic if it's an upgrade action on helm