### PR TITLE
fix(upgrade): fix upgrade from openebs v3

### DIFF
--- a/plugin/src/cli_utils/upgrade/mod.rs
+++ b/plugin/src/cli_utils/upgrade/mod.rs
@@ -81,8 +81,15 @@ impl ImageProperties {
          * specific sections.
          */
 
-        let hostpath_localpv_image_name = format!("{release_name}-localpv-provisioner");
+        // From https://github.com/openebs/dynamic-localpv-provisioner/blob/develop/deploy/helm/charts/templates/deployment.yaml#L50
+        let hostpath_localpv_image_name: String = if release_name.contains("localpv-provisioner") {
+            "localpv-provisioner".to_string()
+        } else {
+            format!("{release_name}-localpv-provisioner")
+        };
         let openebs_containers: HashSet<&str> = [
+            // From https://github.com/openebs/charts/blob/main/charts/openebs/templates/localprovisioner/deployment-local-provisioner.yaml#L42
+            "openebs-localpv-provisioner",
             "api-rest",
             "openebs-zfs-plugin",
             "openebs-lvm-plugin",
@@ -93,7 +100,7 @@ impl ImageProperties {
 
         // The 'app in <labels>' is used to pick out the CSI Controllers from the LocalPV, Mayastor
         // and the Hostpath Provisioner.
-        let openebs_pod_spec = list_pods(args.namespace.clone(), Some("app in (api-rest,localpv-provisioner,openebs-zfs-controller,openebs-lvm-controller)".to_string()), None).await
+        let openebs_pod_spec = list_pods(args.namespace.clone(), Some("app in (openebs,api-rest,localpv-provisioner,openebs-zfs-controller,openebs-lvm-controller)".to_string()), None).await
             .map_err(|error| anyhow!(error))?
             .into_iter()
             .filter_map(|pod| pod.spec)


### PR DESCRIPTION
Changes:
- Fix plugin logic to check if mayastor is enabled
- Fix bug where etcd preUpgradeJob gets stuck trying to mount the etcd jwt token if Etcd is missing in the source chart, but enabled in the target chart. This was done when going from openebs v3 to v4. For all other cases, the reset-then-reuse-values option will carry forward the disabled state of mayastor in the values.yaml. The solution here is to perform helm upgrade with `--set mayastor.etcd.preUpgradeJob.enabled=false` once, and then perform a same version helm upgrade with `--set mayastor.etcd.preUpgradeJob.enabled=true`. The second upgrade will make sure all future upgrades with `--reuse-values` or similar flags doesn't have the preUpgradeJob disabled.