### PR TITLE
fix: staging shell, script and change namespaces

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           nix-shell --pure --run "./scripts/staging/kubectl-oci.sh pull \
             --tag ${{ github.ref_name }} \
-            --namespace ${{ github.repository_owner }}/dev \
+            --namespace ${{ github.repository_owner }}/dev/plugin \
             --username ${{ github.actor }} \
             --password ${{ secrets.GITHUB_TOKEN }}" ./scripts/staging/shell.nix
 
@@ -99,7 +99,7 @@ jobs:
           rm -rf charts
           mkdir -p charts-staged charts-final charts
 
-          CHART_REF=oci://ghcr.io/${IMAGE_ORG}/helm/openebs
+          CHART_REF=oci://ghcr.io/${IMAGE_ORG}/dev/helm/openebs
           helm pull "$CHART_REF" \
             --version ${VERSION} \
             --destination charts-staged

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           nix-shell --pure --run "./scripts/staging/kubectl-oci.sh push\
             --tag ${TAG} \
-            --namespace ${{ github.repository_owner }}/dev \
+            --namespace ${{ github.repository_owner }}/dev/plugin \
             --username ${{ github.actor }} \
             --password ${{ secrets.GITHUB_TOKEN }}" ./scripts/staging/shell.nix
 
@@ -96,7 +96,7 @@ jobs:
         uses: appany/helm-oci-chart-releaser@v0.4.2
         with:
           name: openebs
-          repository: ${{ github.repository_owner }}/helm
+          repository: ${{ github.repository_owner }}/dev/helm
           tag: ${{ env.CHART_VERSION }}
           path: ./charts
           registry: ghcr.io

--- a/scripts/staging/mirror-images.sh
+++ b/scripts/staging/mirror-images.sh
@@ -6,11 +6,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]:-"$0"}")")"
+CURRENT_ROOT_DIR="${SCRIPT_DIR}/../.."
 
 # if ROOT_DIR is not defined use the one below
-: "${ROOT_DIR:=${SCRIPT_DIR}/../..}"
+: "${ROOT_DIR:=$CURRENT_ROOT_DIR}"
 
-source "$ROOT_DIR/mayastor/scripts/utils/log.sh"
+source "$CURRENT_ROOT_DIR/mayastor/scripts/utils/log.sh"
 NO_RUN=true . "$ROOT_DIR/scripts/release.sh"
 
 IMAGES=()

--- a/scripts/staging/shell.nix
+++ b/scripts/staging/shell.nix
@@ -9,5 +9,12 @@ pkgs.mkShell {
     crane
     yq-go
     jq
+  ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure" && pkgs.system != "aarch64-darwin") [
+    docker
+    git
+    curl
+    nix
+    kubernetes-helm-wrapped
+    cacert
   ];
 }


### PR DESCRIPTION
- Change the namespaces for plugin and helm to `/dev/plugin` and `/dev/helm`
- Add packages to staging shell
- Fix the mirror-images script to accept ROOT_DIR while not modifying the current.