### PR TITLE
fix(plugin/upgrade): remove unimplemented dry-run option

### DIFF
--- a/plugin/src/cli_utils/upgrade/cli.rs
+++ b/plugin/src/cli_utils/upgrade/cli.rs
@@ -34,10 +34,6 @@ pub struct UpgradeCommonArgs {
     #[arg(long, hide = true, default_value_t = false)]
     pub allow_unstable: bool,
 
-    /// Display all the validations output but will not execute upgrade.
-    #[arg(long, short, default_value_t = false)]
-    pub dry_run: bool,
-
     /// If set then upgrade will skip the io-engine pods restart.
     #[arg(long, default_value_t = false)]
     pub skip_data_plane_restart: bool,


### PR DESCRIPTION
Removes the `--dry-run` CLI option for upgrade. This feature is not implemented for the `kubectl openebs`

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
