### PR TITLE
Kubectl Plugin: snapshot delete

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -47,10 +47,6 @@ dependencies:
 
 annotations:
   helm.sh/images: |
-    - name: etcd
-      image: docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
-    - name: kubectl
-      image: docker.io/bitnamilegacy/kubectl:1.25.15
     - name: alloy
       image: docker.io/grafana/alloy:v1.8.1
     - name: loki
@@ -59,6 +55,10 @@ annotations:
       image: docker.io/openebs/alpine-bash:4.2.0
     - name: alpine-sh
       image: docker.io/openebs/alpine-sh:4.2.0
+    - name: etcd
+      image: docker.io/openebs/etcd:3.6.4-debian-12-r0
+    - name: kubectl
+      image: docker.io/openebs/kubectl:1.25.15
     - name: mayastor-agent-core
       image: docker.io/openebs/mayastor-agent-core:develop
     - name: mayastor-agent-ha-cluster

--- a/charts/images.txt
+++ b/charts/images.txt
@@ -1,9 +1,9 @@
-docker.io/bitnamilegacy/etcd:3.6.4-debian-12-r0
-docker.io/bitnamilegacy/kubectl:1.25.15
 docker.io/grafana/alloy:v1.8.1
 docker.io/grafana/loki:3.4.2
 docker.io/openebs/alpine-bash:4.2.0
 docker.io/openebs/alpine-sh:4.2.0
+docker.io/openebs/etcd:3.6.4-debian-12-r0
+docker.io/openebs/kubectl:1.25.15
 docker.io/openebs/mayastor-agent-core:develop
 docker.io/openebs/mayastor-agent-ha-cluster:develop
 docker.io/openebs/mayastor-agent-ha-node:develop

--- a/charts/shell.nix
+++ b/charts/shell.nix
@@ -2,7 +2,7 @@
     overlays = [ (_: _: { inherit (import ../nix/sources.nix); }) (import ../nix/overlay.nix { }) ];
   }
 }:
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "helm-scripts-shell";
   buildInputs = with pkgs; [
     coreutils

--- a/scripts/k8s/shell.nix
+++ b/scripts/k8s/shell.nix
@@ -5,7 +5,7 @@
 let
   inPureNixShell = builtins.getEnv "IN_NIX_SHELL" == "pure";
 in
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "k8s-cluster-shell";
   buildInputs = with pkgs; [
     kubernetes-helm-wrapped

--- a/scripts/staging/shell.nix
+++ b/scripts/staging/shell.nix
@@ -2,7 +2,7 @@
     overlays = [ (_: _: { inherit (import ../../nix/sources.nix); }) (import ../../nix/overlay.nix { }) ];
   }
 }:
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   name = "staging-shell";
   buildInputs = with pkgs; [
     oras

--- a/shell.nix
+++ b/shell.nix
@@ -23,7 +23,7 @@ let
     cp ${pkgs.pre-commit}/bin/pre-commit $out/bin/pre-commit
   '';
 in
-mkShell {
+mkShellNoCC {
   name = "openebs-shell";
   buildInputs = [
     cargo-expand
@@ -50,7 +50,7 @@ mkShell {
   # copy the rust toolchain to a writable directory, see: https://github.com/rust-lang/cargo/issues/10096
   # the whole toolchain is copied to allow the src to be retrievable through "rustc --print sysroot"
   RUST_TOOLCHAIN = ".rust-toolchain/${rust.version}";
-  RUST_TOOLCHAIN_NIX = "${rust}";
+  RUST_TOOLCHAIN_NIX = pkgs.lib.optional (!norust) "${rust}";
 
   shellHook = ''
     ./scripts/nix/git-submodule-init.sh
@@ -68,5 +68,7 @@ mkShell {
 
     rust_version="${rust.version}" rustup_channel="${lib.strings.concatMapStringsSep "-" (x: x) (lib.lists.drop 1 (lib.strings.splitString "-" rust.version))}" \
     dev_rustup="${toString (devrustup)}" devrustup_moth="${devrustup_moth}" . "$CTRL_SRC"/scripts/rust/env-setup.sh
+    unset CC
+    unset AR
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,10 @@ let
   helmShellAttrs = import ./charts/shell.nix { inherit pkgs; };
   stagingShellAttrs = import ./scripts/staging/shell.nix { inherit pkgs; };
   usePreCommit = builtins.getEnv "IN_NIX_SHELL" == "impure" && builtins.getEnv "CI" != "1";
+  pre-commit = pkgs.runCommand "pre-commit" { } ''
+    mkdir -p $out/bin
+    cp ${pkgs.pre-commit}/bin/pre-commit $out/bin/pre-commit
+  '';
 in
 mkShell {
   name = "openebs-shell";


### PR DESCRIPTION
    chore: update chart image metadata
    
---

    chore: use stdenv with no CC,AR in the nix-shell
    
    This reduces the derivation size when not using internal rust and also
    can prevent ring rebuilds due to CC,AR env var mismatch.

---

    chore: add pre-commit trampoline
    
    Allows us to erase the the references which pre-commit now seems
    to leave around and which interfere with nix-shell and venv.
    
---

    feat: add snapshot delete subcommand
    
    Similar to the volume, it first ensures that the volumesnapshotcontent is
    not present! If it is, then it bails out with an error.