### PR TITLE
ci: don't docker login without the secrets

### DIFF
--- a/.github/workflows/chart-images.yml
+++ b/.github/workflows/chart-images.yml
@@ -38,6 +38,9 @@ jobs:
         run: nix-shell ./scripts/helm/shell.nix --run "./scripts/helm/images.sh patch --exit-code"
       - name: Login to DockerHub
         uses: docker/login-action@v3
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         with:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
On PRs from external contrib forks the secrets are not available, so let's just not docker login.
