### PR TITLE
[OEP 4071]: update restore to a new volume from LVM thin snapshot oep

### DIFF
--- a/designs/local-pv/lvm/snapshot-restore.md
+++ b/designs/local-pv/lvm/snapshot-restore.md
@@ -8,7 +8,7 @@ owners:
 editor: TBD
 creation-date: 03/10/2025
 last-updated: 28/10/2025
-status: implementable
+status: implemented
 ---
 
 # Add Snapshot Restore Feature to OpenEBS LVM


### PR DESCRIPTION
This PR update LVM thin snapshot restore design. 

- Update LVM snapshot CRD fields
- Update `lvcreate` command to include `-y` option, `-y` to automatically answer "yes" to all non-signature prompts
- Update LVM volume and snapshot CR.