### PR TITLE
fix(upgrade-job): OpenEBS v3 to v4 upgrade etcd preUpgradeJob toggle

### DIFF
--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -38,8 +38,8 @@ let
         patchShebangs build/mayastor/scripts/utils/log.sh
         patchShebangs build/mayastor/scripts/utils/yaml.sh
 
-        if [ -L build/chart/kubectl-openebs ]; then
-          rm build/chart/kubectl-openebs
+        if [ -L build/charts/kubectl-openebs ]; then
+          rm build/charts/kubectl-openebs
         fi
 
         # if tag is not semver just keep whatever is checked-in

--- a/openebs-upgrade/src/helm/upgrade/config.rs
+++ b/openebs-upgrade/src/helm/upgrade/config.rs
@@ -86,13 +86,13 @@ impl HelmUpgradeConfig {
                     .args_set_file
                     .map(|val| ["--set-file".to_string(), val]),
                 Some(["-f", temp_values_file.path().to_str().unwrap()].map(ToString::to_string)),
-                Some(["--atomic", "--reset-then-reuse-values"].map(ToString::to_string)),
             ]
             .into_iter()
             // Drop the None, unwrap the Some.
             .flatten()
             // Flatten the [String;2] into individual Strings.
             .flatten()
+            .chain(["--reset-then-reuse-values".to_string()])
             .collect(),
             temp_values_file,
             source_version,

--- a/openebs-upgrade/src/helm/upgrade/upgrader.rs
+++ b/openebs-upgrade/src/helm/upgrade/upgrader.rs
@@ -65,7 +65,7 @@ impl HelmUpgrader for UmbrellaUpgrader {
             // Mayastor was disabled by default for OpenEBS v3. If the chart is a v3 one and
             // there are no Etcd Pods, we disable the Etcd preUpgradeJob and perform a helm upgrade.
             // If we don't do this, the Etcd preUpgradeJob gets stuck trying to mount the Etcd
-            // JWT token. After helm helm upgrade, we perform a same version upgrade to the same
+            // JWT token. After helm upgrade, we perform a same version upgrade to the same
             // version (target version) again with the preUpgradeJob enabled, so that future
             // upgrades with helm upgrade --reuse-values and such flags don't keep the Etcd
             // preUpgradeJob disabled. Values for disabling the engines have changed since v3, so
@@ -103,7 +103,7 @@ impl HelmUpgrader for UmbrellaUpgrader {
                                 .into_iter()
                                 .chain(vec_to_strings!(
                                     "--set",
-                                    "mayastor.etcd.preUpgradeJob.enabled=false"
+                                    "mayastor.etcd.preUpgradeJob.enabled=true"
                                 ))
                                 .collect(),
                         ),

--- a/plugin/src/cli_utils/localpv/lvm/volume/mod.rs
+++ b/plugin/src/cli_utils/localpv/lvm/volume/mod.rs
@@ -127,8 +127,8 @@ async fn list_pv(pv_handle: Api<PersistentVolume>) -> Result<Vec<PersistentVolum
             .map_err(|err| Error::Kube { source: err })?;
         vol_list.extend(list.items);
         match list.metadata.continue_ {
-            Some(token) => list_param = list_param.continue_token(&token),
-            None => break,
+            Some(token) if !token.is_empty() => list_param = list_param.continue_token(&token),
+            _ => break,
         }
     }
     Ok(vol_list)

--- a/plugin/src/cli_utils/localpv/zfs/volume/mod.rs
+++ b/plugin/src/cli_utils/localpv/zfs/volume/mod.rs
@@ -124,8 +124,8 @@ async fn list_pv(pv_handle: Api<PersistentVolume>) -> Result<Vec<PersistentVolum
             .map_err(|err| Error::Kube { source: err })?;
         vol_list.extend(list.items);
         match list.metadata.continue_ {
-            Some(token) => list_param = list_param.continue_token(&token),
-            None => break,
+            Some(token) if !token.is_empty() => list_param = list_param.continue_token(&token),
+            _ => break,
         }
     }
     Ok(vol_list)


### PR DESCRIPTION
The strategy we follow when upgrading from OpenEBS v3 to OpenEBS v4 is to disable preUpgradeJob for etcd, then enable it after we've reached target version already.

The enable bit was bugged, fixing that.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
