### PR TITLE
fix: typo in NOTES.txt template

### DIFF
--- a/charts/templates/NOTES.txt
+++ b/charts/templates/NOTES.txt
@@ -4,7 +4,7 @@ Successfully installed OpenEBS.
 Check the status by running: kubectl get pods -n {{ .Release.Namespace }}
 
 The default values will install both Local PV and Replicated PV. However,
-the Replicated PV will require additional configuration to be fuctional.
+the Replicated PV will require additional configuration to be functional.
 The Local PV offers non-replicated local storage using 3 different storage
 backends i.e Hostpath, LVM and ZFS, while the Replicated PV provides one replicated highly-available
 storage backend i.e Mayastor.


### PR DESCRIPTION
This PR fixes a small typo in the NOTES.txt template displayed during every new OpenEBS Helm install.

Closes #4170