### PR TITLE
feat: Add helm global values

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
     repository: "https://openebs.github.io/lvm-localpv"
     condition: engines.local.lvm.enabled
   - name: rawfile-localpv
-    version: 0.12.0
+    version: 0.14.0
     repository: "https://openebs.github.io/rawfile-localpv"
     condition: engines.local.rawfile.enabled
   - name: mayastor
@@ -101,7 +101,7 @@ annotations:
     - name: provisioner-localpv
       image: docker.io/openebs/provisioner-localpv:4.5.0-develop
     - name: rawfile-localpv
-      image: docker.io/openebs/rawfile-localpv:v0.12.0
+      image: docker.io/openebs/rawfile-localpv:v0.14.0
     - name: zfs-driver
       image: docker.io/openebs/zfs-driver:2.10.0-develop
     - name: mc

--- a/charts/README.md
+++ b/charts/README.md
@@ -89,7 +89,7 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | https://openebs.github.io/dynamic-localpv-provisioner | localpv-provisioner | 4.5.0-develop |
 | https://openebs.github.io/lvm-localpv | lvm-localpv | 1.9.0-develop |
 | https://openebs.github.io/mayastor-extensions | mayastor | 0.0.0 |
-| https://openebs.github.io/rawfile-localpv | rawfile-localpv | 0.12.0 |
+| https://openebs.github.io/rawfile-localpv | rawfile-localpv | 0.14.0 |
 | https://openebs.github.io/zfs-localpv | zfs-localpv | 2.10.0-develop |
 
 ## Values
@@ -104,6 +104,9 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | engines.&ZeroWidthSpace;local.&ZeroWidthSpace;rawfile.&ZeroWidthSpace;enabled | Enable/Disable LocalPV Rawfile Storage Engine | `false` |
 | engines.&ZeroWidthSpace;local.&ZeroWidthSpace;zfs.&ZeroWidthSpace;enabled | Enable/Disable LocalPV ZFS Storage Engine | `true` |
 | engines.&ZeroWidthSpace;replicated.&ZeroWidthSpace;mayastor.&ZeroWidthSpace;enabled | Enable/Disable Replicated PV Mayastor Storage Engine | `true` |
+| global.&ZeroWidthSpace;imagePullPolicy | Global override for image pull policy | `""` |
+| global.&ZeroWidthSpace;imagePullSecrets | Global image pull secrets (merged with local imagePullSecrets and not overridden) - secret | `[]` |
+| global.&ZeroWidthSpace;imageRegistry | Global override for container image registry | `""` |
 | loki.&ZeroWidthSpace;enabled | Enable/Disable loki. | `true` |
 | loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;loki.&ZeroWidthSpace;basePath | Host path where local loki data is stored in. | `"/var/local/{{ .Release.Name }}/localpv-hostpath/loki"` |
 | loki.&ZeroWidthSpace;localpvScConfig.&ZeroWidthSpace;loki.&ZeroWidthSpace;reclaimPolicy | ReclaimPolicy of loki's localpv hostpath storage class. | `"Delete"` |

--- a/charts/images.txt
+++ b/charts/images.txt
@@ -24,7 +24,7 @@ docker.io/openebs/mayastor-obs-callhome:develop
 docker.io/openebs/mayastor-operator-diskpool:develop
 docker.io/openebs/provisioner-localpv:4.5.0
 docker.io/openebs/provisioner-localpv:4.5.0-develop
-docker.io/openebs/rawfile-localpv:v0.12.0
+docker.io/openebs/rawfile-localpv:v0.14.0
 docker.io/openebs/zfs-driver:2.10.0-develop
 quay.io/minio/mc:RELEASE.2024-11-21T17-21-54Z
 quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -91,3 +91,50 @@ Usage:
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Concatenates imagepullsecrets and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "openebs.common.pullSecrets" -}}
+{{- $names := list -}}
+{{- range ((.global).imagePullSecrets) -}}
+  {{- if kindIs "map" . }}
+    {{- if and (hasKey . "name") (not (empty .name)) -}}
+      {{ $names = append $names .name }}
+    {{- end -}}
+  {{- else if not (empty .) -}}
+    {{ $names = append $names . -}}
+  {{- end -}}
+{{- end -}}
+{{- range .images -}}
+  {{- range .imagePullSecrets }}
+    {{- if kindIs "map" . -}}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{- $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{- $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $names = uniq $names -}}
+{{- if $names -}}
+  {{- range $names }}
+- name: {{ . }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Creates the image URL ie registry/repository:tag
+*/}}
+{{- define "openebs.common.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) | trimSuffix "/" -}}
+{{- $repositoryName := .imageRoot.repo -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
+{{- else -}}
+    {{- printf "%s:%s"  $repositoryName $termination -}}
+{{- end -}}
+{{- end -}}

--- a/charts/templates/pre-upgrade-hook.yaml
+++ b/charts/templates/pre-upgrade-hook.yaml
@@ -100,15 +100,16 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-upgrade-job
-        image: {{ .Values.preUpgradeHook.image.registry }}/{{ .Values.preUpgradeHook.image.repo }}:{{ .Values.preUpgradeHook.image.tag }}
-        imagePullPolicy: {{ .Values.preUpgradeHook.image.pullPolicy }}
+        image: {{ include "openebs.common.image" (dict "imageRoot" .Values.preUpgradeHook.image "global" .Values.global) }}
+        imagePullPolicy: {{ default .Values.preUpgradeHook.image.pullPolicy .Values.global.imagePullPolicy }}
         command:
         - "/bin/sh"
         - "-c"
         args:
         - "(kubectl annotate --overwrite crd volumesnapshots.snapshot.storage.k8s.io volumesnapshotclasses.snapshot.storage.k8s.io volumesnapshotcontents.snapshot.storage.k8s.io helm.sh/resource-policy=keep || true) && (kubectl -n {{ .Release.Namespace }} delete deploy -l openebs.io/component-name=openebs-localpv-provisioner --ignore-not-found)"
-      {{- if .Values.preUpgradeHook.imagePullSecrets }}
-      imagePullSecrets: {{ toYaml .Values.preUpgradeHook.imagePullSecrets | nindent 8 }}
+      {{- if or .Values.global.imagePullSecrets .Values.preUpgradeHook.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "openebs.common.pullSecrets" (dict "images" (list .Values.preUpgradeHook) "global" .Values.global) | indent 6 }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,3 +1,12 @@
+global:
+  # -- Global override for container image registry
+  imageRegistry: ""
+  # -- Global image pull secrets (merged with local imagePullSecrets and not overridden)
+  # - secret
+  imagePullSecrets: []
+  # -- Global override for image pull policy
+  imagePullPolicy: ""
+
 openebs-crds:
   csi:
     volumeSnapshots:
@@ -9,6 +18,13 @@ openebs-crds:
 localpv-provisioner:
   rbac:
     create: true
+  globalImageRegistryOverride: true
+  helperPod:
+    image:
+      registry: "docker.io"
+  localpv:
+    image:
+      registry: "docker.io"
 
 # Refer to https://github.com/openebs/zfs-localpv/blob/v2.7.1/deploy/helm/charts/values.yaml for complete set of values.
 zfs-localpv:


### PR DESCRIPTION
Fixes https://github.com/openebs/openebs/issues/4171

## Why is this PR required? What issue does it fix?

Currently, the Helm charts do not provide global variables for configuring common parameters such as the image registry, image pull secrets, image pull policy, and analytics settings.

When deploying the OpenEBS Helm charts, users often need to override these values across multiple subcharts and components. This makes it difficult to locate and configure all the required fields consistently. Providing global variables simplifies configuration and improves the user experience.

## What does this PR do?

This PR introduces the following global configuration variables:
```yaml
global:
  # -- Global override for container image registry
  imageRegistry: ""
  # -- Global image pull secrets (merged with local imagePullSecrets and not overridden)
  # - secret
  imagePullSecrets: []
  # -- Global override for image pull policy
  imagePullPolicy: ""
```

These variables allow users to configure common settings in a single place, which will then be applied across the chart components.

## Does this PR require any upgrade changes?

No.
This change is backward compatible and does not require any upgrade steps.

## Verification

The changes were verified using the following scenarios:

Rendered the templates using helm template to confirm correct value substitution.

Deployed the chart on a Kubernetes cluster with 3 worker nodes (kubeadm-based setup).

Verified that the global values are rendered and applied correctly across the components.