### PR TITLE
ci: include openebs-upgrade in rust path filters

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
           filters: |
             rust:
               - 'plugin/**'
+              - 'openebs-upgrade/**'
               - 'nix/**'
               - shell.nix
               - default.nix

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             rust:
               - 'plugin/**'
+              - 'openebs-upgrade/**'
               - 'nix/**'
               - shell.nix
               - default.nix


### PR DESCRIPTION
## Description
Adds `openebs-upgrade/**` to the Rust path filters in PR CI and Rust CI. Tiny CI papercut, but kinda easy to miss.

## Motivation and Context
`openebs-upgrade` is listed as a Rust workspace member, but changes under that dir did not flip the `rust` filter. So a PR touching only `openebs-upgrade/src/...` could skip the Rust jobs, yikes.

No directly related issue/PR found with `openebs-upgrade CI` or `paths-filter rust` searches.

## Testing
Repro before this change:

```bash
file='openebs-upgrade/src/lib.rs'
before=('plugin/**' 'nix/**' 'shell.nix' 'default.nix' 'Cargo.toml' 'Cargo.lock' 'mayastor/**')
```

That file does not match the old filter. After adding `openebs-upgrade/**`, it matches.

Also ran:

```bash
git diff --check -- .github/workflows/rust.yaml .github/workflows/pr.yml
python3 - <<'PY'
import yaml
for path in ['.github/workflows/rust.yaml', '.github/workflows/pr.yml']:
    with open(path, encoding='utf-8') as f:
        yaml.safe_load(f)
print('yaml: ok')
PY
npx --yes @commitlint/cli --config commitlint.config.js --from HEAD~1 --to HEAD
```

## Backward Compatibility
No runtime or chart behavior changes. This only makes existing CI jobs run for one more Rust workspace path.