### PR TITLE
fix: correct error message formatting and values.yaml typo

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -98,7 +98,7 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 |:----|:------------|:--------|
 | alloy.&ZeroWidthSpace;enabled | Enable/Disable Alloy. | `true` |
 | alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;labels | Labels to enable scraping on, at-least one of these labels should be present. | <pre>{<br>"openebs.io/logging":true<br>}</pre> |
-| alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;tenant_id | X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same. | `"openebs"` |
+| alloy.&ZeroWidthSpace;logging_config.&ZeroWidthSpace;tenant_id | X-Scope-OrgID to be populated when pushing logs. Make sure the caller also uses the same. | `"openebs"` |
 | engines.&ZeroWidthSpace;local.&ZeroWidthSpace;hostpath.&ZeroWidthSpace;enabled | Enable/Disable Dynamic LocalPV Provisioner | `true` |
 | engines.&ZeroWidthSpace;local.&ZeroWidthSpace;lvm.&ZeroWidthSpace;enabled | Enable/Disable LocalPV LVM Storage Engine | `true` |
 | engines.&ZeroWidthSpace;local.&ZeroWidthSpace;rawfile.&ZeroWidthSpace;enabled | Enable/Disable LocalPV Rawfile Storage Engine | `false` |

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -259,7 +259,7 @@ alloy:
     # -- Labels to enable scraping on, at-least one of these labels should be present.
     labels:
       openebs.io/logging: true
-    # -- X-Scope-OrgID to pe populated which pushing logs. Make sure the caller also uses the same.
+    # -- X-Scope-OrgID to be populated when pushing logs. Make sure the caller also uses the same.
     tenant_id: openebs
 
   alloy:

--- a/plugin/src/cli_utils/upgrade/mod.rs
+++ b/plugin/src/cli_utils/upgrade/mod.rs
@@ -309,7 +309,7 @@ async fn handle_upgrade_event(
 /// Log to user and error out if any rebuild in progress.
 async fn rebuild_in_progress_validation(client: &ApiClient) -> Result<()> {
     if rebuild_in_progress(client).await? {
-        console_logger::error("Error", "The cluster is rebuilding replica of some volumes. To skip this validation please run after some time or re-run with '--skip-replica-rebuild` flag.");
+        console_logger::error("Error", "The cluster is rebuilding replica of some volumes. To skip this validation please run after some time or re-run with `--skip-replica-rebuild` flag.");
         return Err(anyhow!("Cluster is rebuilding replica of some volumes."));
     }
 
@@ -350,7 +350,7 @@ async fn upgrade_path_validation(allow_unstable: bool, source_version: &Version)
     let destination_version = get_destination_version_tag();
 
     if destination_version.contains("develop") {
-        console_logger::error("Error", "Upgrade failed as destination version is unsupported. Please try with `--skip-upgrade-path-validation-for-unsupported-version.");
+        console_logger::error("Error", "Upgrade failed as destination version is unsupported. Please try with `--skip-upgrade-path-validation-for-unsupported-version`.");
         return Err(anyhow!(
             "The upgrade path is invalid: destination version contains develop"
         ));

--- a/plugin/src/console_logger.rs
+++ b/plugin/src/console_logger.rs
@@ -11,5 +11,5 @@ pub fn info(message: &str, data: Option<&str>) {
 
 /// Print error on console.
 pub fn error(message: &str, data: &str) {
-    eprintln!("{}: {} ", Red.paint(message), Red.paint(data));
+    eprintln!("{}: {}", Red.paint(message), Red.paint(data));
 }


### PR DESCRIPTION
Three small bugs found in the plugin and chart:

**1. Trailing space in all error output** (`plugin/src/console_logger.rs`)

`eprintln!("{}: {} ", ...)` has a trailing space after the second `{}`. Every single error the plugin prints gets a spurious trailing space. Easy to spot if you pipe/redirect output.

**2. Mismatched quotes in two upgrade error messages** (`plugin/src/cli_utils/upgrade/mod.rs`)

- `'--skip-replica-rebuild\`` -- single-quote opens, backtick closes, looks broken to users
- `` `--skip-upgrade-path-validation-for-unsupported-version. `` -- backtick never closed

**3. Typo in `values.yaml` comment** (line 262)

`X-Scope-OrgID to pe populated which pushing logs` => `to be populated when pushing logs`
Visible when running `helm show values openebs/openebs`.

**How to reproduce #1:**
```
kubectl openebs upgrade <args>   # trigger any validation error path
# output ends with trailing space: "Error: <msg> "
```

**How to reproduce #3:**
```
helm show values openebs/openebs | grep -A1 tenant_id
```