### PR TITLE
feat(plugin): add option to input upgrade-job image repo-namespace 

### DIFF
--- a/plugin/src/cli_utils/upgrade/cli.rs
+++ b/plugin/src/cli_utils/upgrade/cli.rs
@@ -5,6 +5,7 @@ use crate::{
         upgrade_preflight_check,
     },
     console_logger,
+    constants::UPGRADE_JOB_IMAGE_REPO,
 };
 use upgrade::common::kube::client::client;
 
@@ -28,6 +29,10 @@ pub struct UpgradeCommonArgs {
     /// Specify the container registry for the upgrade-job image.
     #[arg(long)]
     pub registry: Option<String>,
+
+    /// Specify the container namespace for the upgrade-job image.
+    #[arg(long, default_value = UPGRADE_JOB_IMAGE_REPO)]
+    pub repo_namespace: String,
 
     /// Allow upgrade from stable versions to unstable versions. This is implied when the
     /// '--skip-upgrade-path-validation-for-unsupported-version' option is used.

--- a/plugin/src/cli_utils/upgrade/mod.rs
+++ b/plugin/src/cli_utils/upgrade/mod.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     console_logger,
-    constants::{get_destination_version_tag, upgrade_obj_suffix, UPGRADE_JOB_IMAGE_REPO},
+    constants::{get_destination_version_tag, upgrade_obj_suffix},
     upgrade_labels,
 };
 use upgrade::common::kube::client::{list_pods, paginated_list_metadata};
@@ -137,8 +137,9 @@ async fn upgrade_job(
     let image_properties: ImageProperties =
         ImageProperties::new_from_helm_release(release_name, args).await?;
     let upgrade_image = format!(
-        "{image_registry}/{UPGRADE_JOB_IMAGE_REPO}/openebs-upgrade-job:{image_tag}",
+        "{image_registry}/{namespace}/openebs-upgrade-job:{image_tag}",
         image_registry = image_properties.registry,
+        namespace = args.repo_namespace,
         image_tag = get_destination_version_tag()
     );
 

--- a/plugin/src/constants.rs
+++ b/plugin/src/constants.rs
@@ -16,8 +16,7 @@ pub fn upgrade_obj_suffix() -> String {
 
 /// The default image tag to the upgrade-job image.
 pub const UPGRADE_JOB_IMAGE_TAG: &str = "develop";
-/// The default image registry for container images.
-pub const DEFAULT_IMAGE_REGISTRY: &str = "docker.io";
+
 /// ConfigMap mount path for upgrade.
 pub const UPGRADE_CONFIG_MAP_MOUNT_PATH: &str = "/upgrade-config-map";
 /// Name of the product.


### PR DESCRIPTION
This adds the CLI flag `--repo-namespace` to configure the container image repo namespace for the upgrade-job container image