### PR TITLE
fix(upgrade): detect existing LVM CRDs during v3 to v4 upgrades

### DIFF
--- a/openebs-upgrade/src/helm/values.rs
+++ b/openebs-upgrade/src/helm/values.rs
@@ -35,7 +35,31 @@ pub(crate) async fn generate_values_file<P: AsRef<Path>>(
 async fn safe_crd_install(path: &Path) -> upgrade::common::error::Result<()> {
     let yq = YqV4::new()?;
 
-    let mut crds_to_helm_toggle: HashMap<Vec<&str>, YamlKey> = HashMap::new();
+    let mut crds_to_helm_toggle = crd_names_to_helm_toggles()?;
+
+    let all_crd_names: Vec<String> = KubeClient::list_crds_metadata()
+        .await?
+        .into_iter()
+        // This unwrap should be fine, as it's done on a resource which we get from K8s api-server.
+        .map(|crd| crd.metadata.name.unwrap())
+        .collect();
+    for (crd_set, helm_toggle) in crds_to_helm_toggle.drain() {
+        // Uses an OR logical check to disable set installation, i.e. disable if
+        // at least one exists. Does not make sure if all exist.
+        if all_crd_names
+            .iter()
+            .any(|name| crd_set.contains(&name.as_str()))
+        {
+            yq.set_unquoted_value(helm_toggle, false, path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn crd_names_to_helm_toggles() -> upgrade::common::error::Result<HashMap<Vec<&'static str>, YamlKey>>
+{
+    let mut crds_to_helm_toggle: HashMap<Vec<&'static str>, YamlKey> = HashMap::new();
     crds_to_helm_toggle.insert(
         vec![
             "volumesnapshotclasses.snapshot.storage.k8s.io",
@@ -60,29 +84,28 @@ async fn safe_crd_install(path: &Path) -> upgrade::common::error::Result<()> {
     );
     crds_to_helm_toggle.insert(
         vec![
-            "lvmvolumes.zfs.openebs.io",
-            "lvmnodes.zfs.openebs.io",
-            "lvmsnapshots.zfs.openebs.io",
+            "lvmvolumes.local.openebs.io",
+            "lvmnodes.local.openebs.io",
+            "lvmsnapshots.local.openebs.io",
         ],
         YamlKey::try_from(".lvm-localpv.crds.lvmLocalPv.enabled")?,
     );
 
-    let all_crd_names: Vec<String> = KubeClient::list_crds_metadata()
-        .await?
-        .into_iter()
-        // This unwrap should be fine, as it's done on a resource which we get from K8s api-server.
-        .map(|crd| crd.metadata.name.unwrap())
-        .collect();
-    for (crd_set, helm_toggle) in crds_to_helm_toggle.into_iter() {
-        // Uses an OR logical check to disable set installation, i.e. disable if
-        // at least one exists. Does not make sure if all exist.
-        if all_crd_names
-            .iter()
-            .any(|name| crd_set.contains(&name.as_str()))
-        {
-            yq.set_unquoted_value(helm_toggle, false, path)?;
-        }
-    }
+    Ok(crds_to_helm_toggle)
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::crd_names_to_helm_toggles;
+
+    #[test]
+    fn lvm_crd_detection_uses_local_openebs_group() {
+        let mappings = crd_names_to_helm_toggles().expect("crd toggle mappings should build");
+
+        assert!(mappings
+            .keys()
+            .any(|names| names.contains(&"lvmvolumes.local.openebs.io")
+                && names.contains(&"lvmnodes.local.openebs.io")
+                && names.contains(&"lvmsnapshots.local.openebs.io")));
+    }
 }


### PR DESCRIPTION
## Description
Fix the LVM CRD names used by the v3 to v4 upgrade helper, and add a small test so this typo does not sneak back in.

## Motivation and Context
The helper was checking `lvmvolumes.zfs.openebs.io`, `lvmnodes.zfs.openebs.io` and `lvmsnapshots.zfs.openebs.io`.
Real LVM CRDs use `local.openebs.io`, so existing LVM CRDs were missed and the upgrade could still try to install them again. Thats pretty rough on upgrades.
Related to #3768.

## Testing
`cargo check -p openebs-upgrade`
`cargo test -p openebs-upgrade`

Repro:
1. Start from an OpenEBS v3 install and make sure LVM CRDs already exist, for example `kubectl get crd lvmnodes.local.openebs.io`.
2. Run a v3 to v4 helm upgrade.
3. Before this fix the helper misses those CRDs, leaves `.lvm-localpv.crds.lvmLocalPv.enabled=true`, and helm can hit `lvmnodes.local.openebs.io already exists` ownership errors.
4. After this fix the helper matches the existing `local.openebs.io` CRDs and disables LVM CRD install for that upgrade path.

## Backward Compatibility
No breaking change. This only corrects CRD detection in the v3 to v4 upgrade path.
