### PR TITLE
fix: honor explicit submodule branch selection

### DIFF
--- a/scripts/git/set-submodule-branches.sh
+++ b/scripts/git/set-submodule-branches.sh
@@ -101,7 +101,6 @@ mayastor_branch() {
 }
 
 BRANCH=
-SET_BRANCH=
 CLEAR_BRANCH=
 UPDATE=
 while [ "$#" -gt 0 ]; do
@@ -129,8 +128,8 @@ if [ -n "$UPDATE" ]; then
   submodule_update
 elif [ -n "$CLEAR_BRANCH" ]; then
   submodule_set_branch_all ""
-elif [ -n "$SET_BRANCH" ]; then
-  submodule_set_branch_all "$SET_BRANCH"
+elif [ -n "$BRANCH" ]; then
+  submodule_set_branch_all "$BRANCH"
 else
   # If nothing is specified do it from the charts.
   mayastor_branch


### PR DESCRIPTION
## Description
`--branch` was parsed, but never used. The script always fell back to the chart derived branch, so an explicit branch pick got ignored.

## Motivation and Context
This makes manual submodule branch retargeting actually work. Small fix, but yep it unblocks a real cli path.

## Testing
- `bash -n scripts/git/set-submodule-branches.sh`
- Repro with a stubbed `git` harness:
  - before fix, `bash scripts/git/set-submodule-branches.sh --branch release/9.9` ended up calling `git submodule set-branch --branch develop mayastor`
  - after fix, the same command calls `git submodule set-branch --branch release/9.9 mayastor`
- Default behavior still stays the same:
  - `bash scripts/git/set-submodule-branches.sh` calls `git submodule set-branch --branch develop mayastor`

## Backward Compatibility
No breaking change. Default behavior stays as is, only the ignored cli arg is honored now.
