### PR TITLE
oep(4242): promote ROX-fs OEP to implementable

### DIFF
--- a/designs/replicated-pv/mayastor/rox-filesystem.md
+++ b/designs/replicated-pv/mayastor/rox-filesystem.md
@@ -7,8 +7,8 @@ owners:
   - "@yugchaudhari"
 editor: TBD
 creation-date: 2026-06-09
-last-updated: 2026-06-20
-status: provisional
+last-updated: 2026-06-22
+status: implementable
 see-also:
   - https://github.com/openebs/openebs/issues/4242
   - https://github.com/openebs/mayastor/issues/1993


### PR DESCRIPTION
## Summary

Follow-up to openebs/openebs#4231, which merged as `provisional`. Per @tiagolobocastro's note on openebs/openebs#4242, re-raising to change the status to `implementable` and requesting approval from additional maintainers.

## Changes

- `status: provisional` → `status: implementable`
- `last-updated: 2026-06-20` → `last-updated: 2026-06-22`

Nothing else in the OEP body is changed.

## Tracking

- Tracking issue: openebs/openebs#4242
- Provisional OEP PR: openebs/openebs#4231 (merged)

cc @tiagolobocastro @Abhinandan-Purkait