### PR TITLE
docs: document recursive submodule setup for local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,24 @@ OpenEBS is an `Umbrella Project` whose governance and policies are defined in th
 These policies are applicable to every sub-project, repository and file existing within the [OpenEBS GitHub organization](https://github.com/openebs/).
 
 This project follows the [OpenEBS Contributor Guidelines](https://github.com/openebs/community/blob/HEAD/CONTRIBUTING.md).
+
+## Local Development
+
+The Rust workspace in this repository depends on the `mayastor` submodule and nested submodules under it.
+Before running local `cargo` builds or tests, initialize submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+For a fresh clone, you can fetch everything in one step:
+
+```bash
+git clone --recurse-submodules https://github.com/openebs/openebs.git
+```
+
+There is also a helper script for existing checkouts:
+
+```bash
+./scripts/nix/git-submodule-init.sh
+```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ These features make OpenEBS a robust and flexible solution for managing persiste
 - [Release Process](./RELEASE.md)
 - [Roadmap Tracker](https://github.com/orgs/openebs/projects/78)
 
+### Local Development
+
+The Rust workspace depends on the `mayastor` submodule and its nested submodules. If you want to build or test the workspace locally, clone the repository with submodules:
+
+```bash
+git clone --recurse-submodules https://github.com/openebs/openebs.git
+```
+
+For an existing checkout, initialize them before running `cargo` commands:
+
+```bash
+git submodule update --init --recursive
+```
+
+You can also use the helper script:
+
+```bash
+./scripts/nix/git-submodule-init.sh
+```
+
 ### Community
 
 - Homepage: [openebs.io](https://openebs.io/)


### PR DESCRIPTION
## Description
Document recursive submodule setup for local Rust dev in `README.md` and `CONTRIBUTING.md`.

## Motivation and Context
Fresh clones cant run `cargo test -p openebs-upgrade --lib` out of the box. It fails before compile because `mayastor/constants/Cargo.toml` is missing. Kinda rough for first time contributors.

This points folks to `git clone --recurse-submodules`, `git submodule update --init --recursive`, and the existing helper script.

## Testing
Repro on a fresh clone:
`git clone https://github.com/openebs/openebs.git`
`cd openebs`
`cargo test -p openebs-upgrade --lib`

It fails with:
`failed to read .../mayastor/constants/Cargo.toml`

After the documented fix:
`git submodule update --init --recursive`
`cargo test -p openebs-upgrade --lib`

That one passes and runs the `openebs-upgrade` unit test, yep.

## Backward Compatibility
Docs only. No runtime change.
