### PR TITLE
ci: create dependabot with author&committer as the bot

### DIFF
--- a/.github/workflows/sync-dependabot.yml
+++ b/.github/workflows/sync-dependabot.yml
@@ -91,6 +91,8 @@ jobs:
           branch: sync/dependabot-config/${{ inputs.base_branch }}
           base: ${{ inputs.base_branch }}
           delete-branch: true
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          commiter: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           signoff: true
           commit-message: |
             chore: sync Dependabot configuration


### PR DESCRIPTION
As it stands now, the author is the workflow raise, and the committer is the github bot.
The sign-off is set to the committer (the bot).
When manually rebasing the update PR, the committer becomes the one whom requested the rebase.
This will then lead to DCO failure because the signoff no longer matches either of author/committer.

To fix this we make author the bot, so the signoff will match it!
