### PR TITLE
oep: add CBT to all supported engines

### DIFF
--- a/designs/csi-changed-block-tracking.md
+++ b/designs/csi-changed-block-tracking.md
@@ -1,0 +1,345 @@
+---
+oep-number: OEP TBD
+title: OpenEBS Enhancement Proposal for CSI Changed Block Tracking (CBT)
+authors:
+  - "@tiagolobocastro"
+owners:
+  - "@tiagolobocastro"
+  - TBD
+editor: TBD
+creation-date: 2026-07-04
+last-updated: 2026-07-04
+status: provisional
+see-also:
+  - designs/replicated-pv/mayastor/changed-block-tracking.md
+  - designs/local-pv/zfs/changed-block-tracking.md
+  - designs/local-pv/lvm/changed-block-tracking.md
+  - designs/local-pv/rawfile/changed-block-tracking.md
+---
+
+# OpenEBS Enhancement Proposal for CSI Changed Block Tracking (CBT)
+
+## Table of Contents
+
+- [OpenEBS Enhancement Proposal for CSI Changed Block Tracking (CBT)](#openebs-enhancement-proposal-for-csi-changed-block-tracking-cbt)
+  - [Table of Contents](#table-of-contents)
+  - [Overview: what is CBT and why it is useful](#overview-what-is-cbt-and-why-it-is-useful)
+  - [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Key Concepts](#key-concepts)
+    - [Architecture](#architecture)
+    - [Workflow](#workflow)
+  - [Per-engine Feasibility](#per-engine-feasibility)
+  - [Implementation Details](#implementation-details)
+    - [Common CSI Surface](#common-csi-surface)
+    - [Deployment](#deployment)
+    - [Rollout](#rollout)
+    - [Components to Update](#components-to-update)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Testing](#testing)
+
+---
+
+## Overview: what is CBT and why it is useful
+
+Change Block Tracking (CBT) is a capability that lets a storage backend report,
+for a given volume:
+
+1. Which blocks of a volume snapshot are actually **allocated** (i.e. hold
+   real data), and
+2. Which blocks **changed** between two snapshots of the same volume.
+
+With this information, a backup or disaster-recovery tool can transfer only
+the data that has actually changed since the previous backup instead of
+scanning and copying the whole volume every time.
+
+Concretely, CBT enables:
+
+- **Fast incremental backups**: only changed blocks are read and shipped,
+  turning what would be a full-volume copy into a small delta transfer.
+- **Shorter backup windows**: backups of large volumes fit into normal
+  maintenance windows because the amount of data moved is proportional to
+  the change rate, not to the volume size.
+- **Lower I/O and network load**: production nodes and the backup network
+  are not saturated by repeated full reads of unchanged data.
+- **Smaller backup storage footprint**: incremental backups store only
+  deltas, avoiding repeated full copies of the same underlying data.
+- **Efficient DR and near-CDP workflows**: frequent, cheap incrementals
+  make it practical to keep a remote copy closely up to date.
+
+Typical consumers are Kubernetes-native backup and DR platforms such as
+Velero, Kasten K10, Trilio, and Kanister-style operators. These tools call
+the CSI Snapshot Metadata API, obtain the list of allocated or changed
+block ranges, and stream only those ranges from the volume snapshots.
+
+This OEP proposes adopting CBT across the OpenEBS engines that can
+technically support it and defines the shared design that all engines will
+implement. Per-engine implementation details are captured in separate,
+linked OEPs.
+
+## Motivation
+
+Modern Kubernetes deployments increasingly host stateful workloads with
+large persistent volumes. As those volumes grow, full-volume backups
+become the dominant cost of any data-protection strategy: they consume
+long backup windows, saturate networks, and inflate backup storage. The
+same problem shows up in DR replication, where full re-syncs are
+impractical over the wire.
+
+The Kubernetes CSI ecosystem has standardised a solution: the CSI
+`SNAPSHOT_METADATA_SERVICE` (alpha) exposes allocated-block and
+changed-block metadata for snapshots, and the `external-snapshot-metadata`
+sidecar makes this metadata safely available to backup applications via a
+Kubernetes-native, authenticated API.
+
+OpenEBS provides several storage engines. Some of them already have the
+underlying primitives needed to report allocated and changed blocks
+(Mayastor blobstore, ZFS, LVM thin provisioning, and — conditionally —
+reflink-based raw files). Exposing that information through the standard
+CSI CBT API lets any CSI-aware backup tool light up incremental backup
+support on OpenEBS volumes without engine-specific integrations.
+
+## Goals
+
+- Adopt the CSI `SNAPSHOT_METADATA_SERVICE` API across all OpenEBS engines
+  that can technically support it.
+- Provide a single, consistent user experience for backup tools: the same
+  Kubernetes-visible `SnapshotMetadataService` CR and the same gRPC surface,
+  regardless of the underlying OpenEBS engine.
+- Keep the feature opt-in per engine while upstream CBT is alpha.
+- Define a per-engine feasibility matrix so operators know which engines
+  and volume modes support CBT.
+
+## Non-Goals
+
+- Implement CBT for engines whose storage stack is not block-based
+  under the hood. In particular, the Hostpath LocalPV provisioner is
+  out of scope because it hands out directories on the host filesystem
+  and owns no block device from which to derive block-level metadata.
+- Define or ship a new backup tool. This OEP integrates with existing
+  CSI-aware backup applications; it does not build one.
+- Change the existing snapshot lifecycle for any engine. CBT only reads
+  metadata about snapshots that were created via the existing snapshot APIs.
+- Provide in-flight encryption for the CBT gRPC stream beyond what the
+  `external-snapshot-metadata` sidecar already provides.
+
+## Proposal
+
+### Key Concepts
+
+1. **SnapshotMetadata service**: an optional CSI service, advertised via
+   the `SNAPSHOT_METADATA_SERVICE` plugin capability, that exposes two
+   server-streaming RPCs:
+   - `GetMetadataAllocated(snapshot_id)` — streams the byte ranges that
+     hold data in the given snapshot.
+   - `GetMetadataDelta(base_snapshot_id, target_snapshot_id)` — streams
+     the byte ranges that changed between two snapshots of the same volume.
+2. **BlockMetadata tuples**: each streamed range is a `(byte_offset,
+   size_bytes)` pair. Tuples are strictly ascending, non-overlapping, and
+   the sequence style is one of `FIXED_LENGTH` or `VARIABLE_LENGTH`, kept
+   constant for the whole stream.
+3. **Sidecar + CR**: the `external-snapshot-metadata` sidecar sits in
+   front of the CSI plugin and is exposed to cluster clients via a
+   `SnapshotMetadataService` CR advertising the driver, its endpoint, and
+   its CA bundle.
+4. **Streaming and resumability**: requests carry a `starting_offset` so
+   an interrupted stream can be resumed without restarting from zero.
+
+### Architecture
+
+```
++----------------------+     ServiceAccount token +
+| Backup application   | <----- gRPC (streaming) ------+
++----------+-----------+                               |
+           |                                           |
+           | reads SnapshotMetadataService CR          |
+           v                                           |
++----------------------+                               |
+| Kubernetes API       |                               |
++----------+-----------+                               |
+           ^                                           |
+           |                                           v
++----------+-----------+   Unix socket   +-------------+-----------+
+| SnapshotMetadataSvc  |<----------------|  external-snapshot-     |
+| CR (per driver)      |                 |  metadata sidecar        |
++----------------------+                 +-------------+-----------+
+                                                       |
+                                                       | gRPC over
+                                                       | Unix socket
+                                                       v
+                                         +-------------+-----------+
+                                         |  OpenEBS CSI plugin      |
+                                         |  (per-engine)            |
+                                         +-------------+-----------+
+                                                       |
+                                                       v
+                                         +-------------+-----------+
+                                         |  Engine backend          |
+                                         |  (Mayastor / ZFS / LVM / |
+                                         |   Rawfile)               |
+                                         +--------------------------+
+```
+
+- The CSI plugin implements the `SnapshotMetadata` gRPC service and
+  advertises `SNAPSHOT_METADATA_SERVICE` in `GetPluginCapabilities`.
+- The `external-snapshot-metadata` sidecar terminates the client-facing
+  connection, authenticates the caller via a Kubernetes ServiceAccount
+  token, and proxies to the CSI plugin over the CSI Unix socket.
+- The `SnapshotMetadataService` CR published by the driver tells backup
+  applications where to reach the sidecar and how to trust it (CA bundle).
+
+### Workflow
+
+1. **Install-time**: the OpenEBS Helm chart for a supported engine
+   optionally deploys the `external-snapshot-metadata` sidecar alongside
+   the CSI controller and creates a `SnapshotMetadataService` CR for the
+   driver.
+2. **Snapshot creation**: unchanged from today — the user creates a
+   `VolumeSnapshot` and the engine's existing snapshot logic runs.
+3. **Backup initiation**: the backup application resolves the CSI driver
+   for a `VolumeSnapshot`, looks up the corresponding
+   `SnapshotMetadataService` CR, and opens a streaming gRPC call:
+   - `GetMetadataAllocated` for the first backup of a volume, to learn
+     which byte ranges are worth reading.
+   - `GetMetadataDelta` for subsequent backups, using the previous
+     snapshot as `base_snapshot_id` and the new one as
+     `target_snapshot_id`.
+4. **Data movement**: the backup application reads only the byte ranges
+   returned in the stream, from the snapshot data path already used by
+   the engine.
+5. **Resumption**: if the stream is interrupted, the backup application
+   re-issues the same request with `starting_offset` set to the byte
+   position immediately after the last range it received.
+
+## Per-engine Feasibility
+
+| Engine            | Delta source                                                                             | CBT viable                            |
+|-------------------|------------------------------------------------------------------------------------------|---------------------------------------|
+| Mayastor          | SPDK blobstore cluster allocation and per-snapshot deltas                                | Yes                                   |
+| ZFS-LocalPV       | `zfs diff` / incremental `zfs send -i` / block-birth txg comparison                      | Yes (zvol-backed volumes)             |
+| LVM-LocalPV       | `thin_ls` / `thin_delta` from `thin-provisioning-tools`                                  | Yes (thin-provisioned volumes)        |
+| Rawfile-LocalPV   | `FIEMAP` extent comparison on reflink files (XFS reflink or btrfs); btrfs `send -p` alt. | Yes, conditional (see per-engine OEP) |
+| Hostpath-LocalPV  | N/A                                                                                      | No — driver owns no block device     |
+
+Per-engine implementation details live in the linked OEPs:
+
+- Mayastor: [designs/replicated-pv/mayastor/changed-block-tracking.md](replicated-pv/mayastor/changed-block-tracking.md)
+- ZFS-LocalPV: [designs/local-pv/zfs/changed-block-tracking.md](local-pv/zfs/changed-block-tracking.md)
+- LVM-LocalPV: [designs/local-pv/lvm/changed-block-tracking.md](local-pv/lvm/changed-block-tracking.md)
+- Rawfile-LocalPV: [designs/local-pv/rawfile/changed-block-tracking.md](local-pv/rawfile/changed-block-tracking.md)
+
+## Implementation Details
+
+### Common CSI Surface
+
+Every engine that opts into CBT MUST:
+
+- Advertise `SNAPSHOT_METADATA_SERVICE` in `GetPluginCapabilities`.
+- Implement the two streaming RPCs of the `SnapshotMetadata` service:
+  - `GetMetadataAllocated(GetMetadataAllocatedRequest) → stream GetMetadataAllocatedResponse`
+  - `GetMetadataDelta(GetMetadataDeltaRequest) → stream GetMetadataDeltaResponse`
+- Populate each response with:
+  - `block_metadata_type`: `FIXED_LENGTH` or `VARIABLE_LENGTH`, constant for
+    the whole stream.
+  - `volume_capacity_bytes`: the capacity of the underlying volume.
+  - `block_metadata`: strictly ascending, non-overlapping `(byte_offset,
+    size_bytes)` tuples.
+- Respect `starting_offset` in the request: the first returned tuple MUST
+  overlap or come after `starting_offset` (per CSI spec: the tuple MUST
+  NOT end before `starting_offset`).
+- Return the specified error codes for the well-defined conditions:
+  - `INVALID_ARGUMENT` for missing/invalid arguments.
+  - `NOT_FOUND` for unknown `snapshot_id` / `base_snapshot_id` /
+    `target_snapshot_id`.
+  - `FAILED_PRECONDITION` if the engine cannot serve the request because
+    CBT is not enabled in the backend (relevant for engines where CBT is
+    an opt-in feature of the underlying storage).
+  - `OUT_OF_RANGE` for a `starting_offset` beyond the volume size.
+
+Engines SHOULD prefer `VARIABLE_LENGTH` when the underlying backend
+naturally produces variable-sized extents, and `FIXED_LENGTH` when the
+backend has a natural fixed block/cluster size.
+
+### Deployment
+
+- Each supported OpenEBS engine ships the `external-snapshot-metadata`
+  sidecar in its CSI controller Pod when CBT is enabled.
+- The engine's Helm chart:
+  - Installs the `SnapshotMetadataService` CRD if not already present.
+  - Creates a `SnapshotMetadataService` CR named after the driver, with
+    the driver's Kubernetes Service address and CA bundle.
+  - Provisions RBAC allowing backup applications' ServiceAccounts to
+    obtain audience-scoped tokens for the sidecar's audience.
+- CSI Node Plugins are not affected: CBT is a Controller-side capability.
+
+### Rollout
+
+- CBT is **off by default** on every engine while the upstream CSI CBT
+  API remains alpha.
+- Each engine exposes a Helm values toggle to enable it, e.g.
+  `<engine>.csi.snapshotMetadata.enabled=true`.
+- When disabled, the engine does not advertise
+  `SNAPSHOT_METADATA_SERVICE`, does not deploy the sidecar, and does not
+  create the `SnapshotMetadataService` CR — so backup applications
+  transparently fall back to full backups.
+
+### Components to Update
+
+- **CSI plugins** for Mayastor, ZFS-LocalPV, LVM-LocalPV, and
+  Rawfile-LocalPV: implement the `SnapshotMetadata` service.
+- **Engine backends**: expose the block metadata source (see per-engine
+  OEPs).
+- **Helm charts** for each engine: optional sidecar deployment,
+  `SnapshotMetadataService` CR, and RBAC.
+- **Docs**: user-facing documentation on enabling CBT and integrating
+  with backup tools.
+
+## Risks and Mitigations
+
+- **Upstream API is alpha**: the CSI `SNAPSHOT_METADATA_SERVICE` may
+  evolve before GA. Mitigation: keep CBT off by default, gate it behind a
+  per-engine toggle, and track the upstream spec revisions.
+- **Large streams for very large volumes**: a change-heavy volume can
+  produce large metadata streams. Mitigation: rely on the streaming
+  contract, honour `max_results`, and support `starting_offset`-based
+  resumption.
+- **Consistency between snapshot data path and metadata**: metadata must
+  describe the exact snapshot bytes the backup tool will read.
+  Mitigation: source metadata from the same snapshot objects the engine
+  already exposes for reads; never compute against a live volume.
+- **Backend prerequisites** (e.g. LVM thin pool, ZFS zvol, reflink-capable
+  FS for rawfile): CBT may not be available on all installations of an
+  engine. Mitigation: document prerequisites clearly and return
+  `FAILED_PRECONDITION` when they are not met.
+
+## Graduation Criteria
+
+- Alpha: implemented behind a per-engine toggle on at least one engine
+  (target: Mayastor); Helm chart wiring in place; smoke-tested with a
+  reference backup client.
+- Beta: implemented on all engines listed as viable in this OEP; e2e
+  tested with at least one production backup tool; upstream CSI CBT at
+  beta.
+- GA: on-by-default consideration only when upstream CSI CBT is GA and
+  all supported engines have shipped CBT in at least one release.
+
+## Testing
+
+Common tests, to be specialised per engine:
+
+- `GetMetadataAllocated` on a freshly written volume snapshot returns
+  ranges that cover exactly the written regions, with the declared
+  `block_metadata_type` respected.
+- `GetMetadataDelta` between two snapshots taken around a known write
+  pattern returns exactly the byte ranges of the writes.
+- Streaming resumption: interrupting the stream and re-issuing the
+  request with the correct `starting_offset` yields the remainder without
+  duplicates or gaps.
+- Error semantics: invalid arguments, missing snapshots, and out-of-range
+  offsets return the CSI-specified gRPC codes.
+- CBT disabled: with the per-engine toggle off, the driver does not
+  advertise `SNAPSHOT_METADATA_SERVICE` and the `SnapshotMetadataService`
+  CR is absent.

--- a/designs/local-pv/lvm/changed-block-tracking.md
+++ b/designs/local-pv/lvm/changed-block-tracking.md
@@ -1,0 +1,275 @@
+---
+oep-number: OEP TBD
+title: LVM-LocalPV Changed Block Tracking (CBT)
+authors:
+  - "@tiagolobocastro"
+owners:
+  - TBD
+editor: TBD
+creation-date: 2026-07-04
+last-updated: 2026-07-04
+status: provisional
+see-also:
+  - designs/csi-changed-block-tracking.md
+---
+
+# LVM-LocalPV Changed Block Tracking (CBT)
+
+## Table of Contents
+
+- [LVM-LocalPV Changed Block Tracking (CBT)](#lvm-localpv-changed-block-tracking-cbt)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Metadata Source: thin-provisioning-tools](#metadata-source-thin-provisioning-tools)
+    - [Mapping to CSI SnapshotMetadata](#mapping-to-csi-snapshotmetadata)
+    - [Architecture](#architecture)
+    - [Workflow](#workflow)
+  - [Implementation Details](#implementation-details)
+    - [Node Agent](#node-agent)
+    - [CSI Controller](#csi-controller)
+    - [Helm Chart](#helm-chart)
+    - [Rollout](#rollout)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Testing](#testing)
+
+---
+
+## Summary
+
+Implement the CSI `SNAPSHOT_METADATA_SERVICE` for LVM-LocalPV
+**thin-provisioned** volumes by driving the `thin-provisioning-tools`
+utilities (`thin_ls`, `thin_delta`) on the node that owns the underlying
+thin pool. See the top-level OEP:
+[designs/csi-changed-block-tracking.md](../../csi-changed-block-tracking.md).
+
+## Motivation
+
+LVM thin pools track allocation at the granularity of thin-pool "chunks"
+(typically 64 KiB to several MiB, configured at pool creation). The
+`thin-provisioning-tools` package (already required by LVM thin-pool
+snapshots) provides `thin_ls` to enumerate the mapped chunks of a
+device, and `thin_delta` to compare mappings between two devices in the
+same thin pool. These correspond exactly to the CSI CBT
+`GetMetadataAllocated` and `GetMetadataDelta` semantics.
+
+## Goals
+
+- Expose LVM thin-pool allocated and changed chunk information for
+  **thin-provisioned** LVM-LocalPV volumes via the CSI
+  `SnapshotMetadata` service.
+- Reuse the existing LVM-LocalPV node agent as the executor of the LVM /
+  thin-provisioning-tools commands.
+- Ship the `external-snapshot-metadata` sidecar and CR from the
+  LVM-LocalPV Helm chart, opt-in.
+
+## Non-Goals
+
+- CBT for thick LVs. Thick LVs do not track per-block allocation or
+  deltas; they are excluded.
+- Changing LVM-LocalPV's snapshot lifecycle or storage class semantics.
+- Providing CBT across different thin pools or nodes.
+
+## Proposal
+
+### Metadata Source: thin-provisioning-tools
+
+For a thin pool the kernel exposes a metadata device (or a suitable
+snapshot of it). The user-space `thin-provisioning-tools` operate on that
+metadata device:
+
+- `thin_ls` (or `thin_dump` filtered by device ID) enumerates the mapped
+  virtual chunks of a specific thin device — this is what we need for
+  `GetMetadataAllocated` on a given snapshot's device.
+- `thin_delta --snap1 <id> --snap2 <id>` produces the differences
+  between two thin devices (typically a volume and its snapshot, or two
+  snapshots of the same volume): mapped-only in `snap1`, mapped-only in
+  `snap2`, and different mappings. Their union gives the "changed
+  chunks" we need for `GetMetadataDelta`.
+
+Both tools output XML that is straightforward to stream-parse.
+
+To safely run these tools against a live thin pool, LVM-LocalPV uses the
+standard `lvcreate --type thin --snapshot` (or an equivalent temporary
+snapshot) of the pool metadata to obtain a consistent view.
+
+### Mapping to CSI SnapshotMetadata
+
+- `block_metadata_type`: `FIXED_LENGTH`. Thin-pool chunks are of fixed
+  size for a given pool; each `BlockMetadata` tuple has `size_bytes`
+  equal to a whole number of chunk sizes.
+- `volume_capacity_bytes`: the LV's virtual size.
+- Consecutive mapped/changed chunks are coalesced into a single
+  `BlockMetadata` tuple.
+- `starting_offset` is honoured by skipping tuples that end at or before
+  it.
+
+### Architecture
+
+```
++----------------------+     Kubernetes gRPC
+| Backup application   | <---- (auth: SA token) --------+
++----------+-----------+                                |
+           v                                            v
++----------------------+          +---------------------+--------+
+| SnapshotMetadataSvc  |          | external-snapshot-metadata    |
+| CR (lvm-localpv)     |          | sidecar (CSI controller Pod)  |
++----------------------+          +---------------------+---------+
+                                                        | CSI Unix socket
+                                                        v
+                                        +---------------+---------------+
+                                        | LVM-LocalPV CSI Controller    |
+                                        +---------------+---------------+
+                                                        | node-agent gRPC
+                                                        v
+                                        +---------------+---------------+
+                                        | LVM-LocalPV Node Agent        |
+                                        | (runs lvm2 + thin_ls/         |
+                                        |  thin_delta)                  |
+                                        +---------------+---------------+
+                                                        |
+                                                        v
+                                        +---------------+---------------+
+                                        | LVM thin pool + snapshots     |
+                                        +-------------------------------+
+```
+
+### Workflow
+
+1. Backup application opens a streaming CBT call to the sidecar.
+2. Sidecar authenticates and forwards to the LVM-LocalPV CSI Controller.
+3. Controller resolves the CSI `snapshot_id`(s) to `LVMSnapshot` CR
+   entries; identifies the owning node and thin pool.
+4. Controller invokes the node agent with the LVM thin device IDs of
+   the referenced snapshot(s).
+5. Node agent obtains a consistent view of the thin-pool metadata,
+   runs `thin_ls` or `thin_delta`, streams parsed `BlockRange` results
+   back to the controller, which emits CSI `BlockMetadata` responses.
+
+## Implementation Details
+
+### Node Agent
+
+Add a new node-agent gRPC service:
+
+```proto
+service LvmThinSnapshotMetadata {
+  rpc GetAllocated(GetAllocatedRequest)
+      returns (stream LvmBlockMetadataResponse);
+  rpc GetDelta(GetDeltaRequest)
+      returns (stream LvmBlockMetadataResponse);
+}
+
+message GetAllocatedRequest {
+  string vg               = 1;   // volume group
+  string thin_pool        = 2;   // thin pool LV
+  uint64 thin_device_id   = 3;   // thin device id of the snapshot
+  int64  starting_offset  = 4;
+  int32  max_results      = 5;
+}
+
+message GetDeltaRequest {
+  string vg                   = 1;
+  string thin_pool            = 2;
+  uint64 base_thin_device_id  = 3;
+  uint64 target_thin_device_id= 4;
+  int64  starting_offset      = 5;
+  int32  max_results          = 6;
+}
+
+message LvmBlockMetadataResponse {
+  int64 volume_capacity_bytes = 1;
+  int64 chunk_size_bytes      = 2;   // for FIXED_LENGTH
+  repeated BlockRange ranges  = 3;
+}
+
+message BlockRange {
+  int64 byte_offset = 1;
+  int64 size_bytes  = 2;
+}
+```
+
+Implementation notes:
+
+- Reject non-thin LVs with `FAILED_PRECONDITION`.
+- Take a consistent view of the pool metadata (metadata snapshot) before
+  running `thin_ls` / `thin_delta`, and release it after.
+- Stream-parse the tool's XML output; coalesce contiguous chunks.
+- Enforce strictly ascending, non-overlapping ranges; honour
+  `starting_offset` and `max_results`.
+- Emit `chunk_size_bytes` so the controller can set `FIXED_LENGTH` with
+  the correct alignment.
+
+### CSI Controller
+
+- Advertise `SNAPSHOT_METADATA_SERVICE` when CBT is enabled.
+- Implement CSI `GetMetadataAllocated` / `GetMetadataDelta` by:
+  1. Resolving the CSI `snapshot_id`(s) to `LVMSnapshot` CR entries and
+     underlying thin device IDs.
+  2. Verifying the underlying LV is thin; if not,
+     `FAILED_PRECONDITION`.
+  3. Verifying that base and target belong to the same LV (for delta);
+     otherwise `INVALID_ARGUMENT`.
+  4. Forwarding to the node agent on the owning node.
+  5. Emitting CSI responses with
+     `block_metadata_type = FIXED_LENGTH` and populated
+     `volume_capacity_bytes`.
+- Error mapping: not-found → `NOT_FOUND`; different-volume delta →
+  `INVALID_ARGUMENT`; offset beyond LV virtual size → `OUT_OF_RANGE`.
+
+### Helm Chart
+
+- Add `lvm-localpv.csi.snapshotMetadata.enabled` (default `false`).
+- When enabled:
+  - Deploy `external-snapshot-metadata` sidecar in the CSI controller
+    Pod.
+  - Install the `SnapshotMetadataService` CRD if not already present.
+  - Create the `SnapshotMetadataService` CR for the LVM-LocalPV driver
+    with the sidecar's Service and CA bundle.
+  - Provision RBAC for backup applications' SAs.
+- Ensure the node-agent image includes `thin-provisioning-tools`.
+
+### Rollout
+
+- Off by default while upstream CSI CBT is alpha.
+- Thick-LV volumes are unaffected; CBT requests for their snapshots
+  return `FAILED_PRECONDITION`.
+
+## Risks and Mitigations
+
+- **Metadata locking**: running `thin_ls`/`thin_delta` against a live
+  pool can conflict with pool operations. Mitigation: always operate on
+  a metadata snapshot.
+- **Chunk-size variability across pools**: chunk size is per-pool.
+  Mitigation: read chunk size from the pool and report it explicitly to
+  the controller.
+- **Large streams for many chunks**: mitigated by coalescing contiguous
+  chunks and by `starting_offset`-based resumption.
+- **Tool availability/version drift**: mitigated by pinning the tools
+  version inside the node-agent image and testing against a supported
+  matrix.
+
+## Graduation Criteria
+
+- Alpha: `GetMetadataAllocated` and `GetMetadataDelta` working for a
+  single thin-pool volume, gated by the Helm toggle.
+- Beta: e2e coverage with a backup tool; docs and examples; multiple
+  chunk sizes tested.
+- GA: gated on upstream CSI CBT GA.
+
+## Testing
+
+- Unit tests for the `thin_ls`/`thin_delta` XML stream parser.
+- Integration test: create a thin-provisioned volume, write a known
+  pattern, snapshot, mutate a known set of chunks, snapshot again, and
+  assert `GetMetadataDelta` yields exactly the mutated chunk ranges.
+- `GetMetadataAllocated` returns exactly the written chunk ranges of a
+  fresh snapshot.
+- Negative: thick LVs → `FAILED_PRECONDITION`; delta across different
+  LVs → `INVALID_ARGUMENT`; offset past virtual size → `OUT_OF_RANGE`.
+- Helm test: with the toggle off, no sidecar, no CR, capability not
+  advertised.

--- a/designs/local-pv/rawfile/changed-block-tracking.md
+++ b/designs/local-pv/rawfile/changed-block-tracking.md
@@ -1,0 +1,325 @@
+---
+oep-number: OEP TBD
+title: Rawfile-LocalPV Changed Block Tracking (CBT)
+authors:
+  - "@tiagolobocastro"
+owners:
+  - TBD
+editor: TBD
+creation-date: 2026-07-04
+last-updated: 2026-07-04
+status: provisional
+see-also:
+  - designs/csi-changed-block-tracking.md
+---
+
+# Rawfile-LocalPV Changed Block Tracking (CBT)
+
+## Table of Contents
+
+- [Rawfile-LocalPV Changed Block Tracking (CBT)](#rawfile-localpv-changed-block-tracking-cbt)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Prerequisites](#prerequisites)
+  - [Proposal](#proposal)
+    - [Metadata Source: FIEMAP on Reflink Files](#metadata-source-fiemap-on-reflink-files)
+    - [Alternative: btrfs `send -p`](#alternative-btrfs-send--p)
+    - [Mapping to CSI SnapshotMetadata](#mapping-to-csi-snapshotmetadata)
+    - [Architecture](#architecture)
+    - [Workflow](#workflow)
+  - [Implementation Details](#implementation-details)
+    - [Node Agent](#node-agent)
+    - [CSI Controller](#csi-controller)
+    - [Helm Chart](#helm-chart)
+    - [Rollout](#rollout)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Testing](#testing)
+
+---
+
+## Summary
+
+Implement the CSI `SNAPSHOT_METADATA_SERVICE` for Rawfile-LocalPV
+volumes whose backing files live on a reflink-capable filesystem (XFS
+with reflink, or btrfs), using `FIEMAP` extent maps to compute allocated
+and changed byte ranges. This OEP is **conditional** on Rawfile-LocalPV
+gaining reflink-based snapshots of the backing file. See the top-level
+OEP:
+[designs/csi-changed-block-tracking.md](../../csi-changed-block-tracking.md).
+
+## Motivation
+
+Rawfile-LocalPV backs each volume with a sparse file on a host
+filesystem. On reflink-capable filesystems (XFS with reflink, or btrfs),
+a snapshot of a rawfile volume can be represented as a `cp --reflink=always`
+copy: the snapshot file shares extents with the source until either side
+is written to, at which point only the modified extents diverge.
+
+`FIEMAP` (the Linux `FS_IOC_FIEMAP` ioctl) reports the extent map of a
+file: for each extent it returns `fe_logical`, `fe_physical`,
+`fe_length`, and flags including `FIEMAP_EXTENT_SHARED`. From two such
+extent maps we can compute:
+
+- **Allocated ranges** in a snapshot = extents present in the snapshot
+  file's map (excluding `FIEMAP_EXTENT_UNWRITTEN`).
+- **Changed ranges** between two snapshots of the same volume = logical
+  ranges where the physical extent differs (or one side is a hole).
+
+This gives us native, byte-range-level CBT without any additional
+metadata store.
+
+## Goals
+
+- Expose FIEMAP-derived allocated and changed extents of rawfile
+  snapshots via the CSI `SnapshotMetadata` service, for rawfile volumes
+  whose backing files live on reflink-capable filesystems.
+- Provide `GetMetadataAllocated` for a single snapshot file and
+  `GetMetadataDelta` between two snapshot files of the same volume.
+
+## Non-Goals
+
+- CBT on non-reflink filesystems (e.g. ext4) — FIEMAP alone cannot
+  determine "changed since previous snapshot" without a reflink or
+  send-stream primitive.
+- Introducing a new snapshot format. This OEP assumes Rawfile-LocalPV
+  represents snapshots as reflink copies (or btrfs subvolume snapshots)
+  of the backing file.
+- Support for compressed / encrypted rawfile backends where FIEMAP does
+  not faithfully reflect logical byte ranges.
+
+## Prerequisites
+
+CBT for Rawfile-LocalPV depends on both of the following:
+
+1. **Reflink-capable backing filesystem** for the rawfile store: XFS
+   mounted with reflink enabled, or btrfs. On btrfs, subvolume snapshots
+   are an equivalent and preferred primitive.
+2. **Reflink-based snapshot support** in the Rawfile-LocalPV driver
+   itself, so that a snapshot is represented as a reflink copy (or a
+   btrfs subvolume snapshot) of the backing file. At the time of
+   writing, the upstream Rawfile-LocalPV README still lists such
+   snapshots as a TODO. This OEP is **provisional** and its
+   implementation is gated on that support landing.
+
+When either prerequisite is missing, the driver MUST NOT advertise
+`SNAPSHOT_METADATA_SERVICE`, and CBT requests (if any) MUST return
+`FAILED_PRECONDITION`.
+
+## Proposal
+
+### Metadata Source: FIEMAP on Reflink Files
+
+For a snapshot represented as a reflink copy of a rawfile:
+
+- Call `FS_IOC_FIEMAP` on the snapshot file to enumerate extents.
+- For `GetMetadataAllocated`, emit `(fe_logical, fe_length)` ranges for
+  every extent that is not `FIEMAP_EXTENT_UNWRITTEN`, coalescing
+  contiguous extents.
+- For `GetMetadataDelta`, enumerate extents from both the base and
+  target snapshot files and merge:
+  - Logical ranges present in `target` but not in `base` → changed
+    (allocated in target only).
+  - Logical ranges present in both, with **different physical offsets**
+    → changed (rewritten; reflink was broken).
+  - Logical ranges present in `base` but not in `target` → changed
+    (hole-punched in target).
+  - Logical ranges present in both with the **same physical offset**
+    AND `FIEMAP_EXTENT_SHARED` set on both → unchanged (still shared).
+  Emit the union of changed logical ranges, coalesced.
+
+### Alternative: btrfs `send -p`
+
+On btrfs, the driver MAY implement `GetMetadataDelta` using the
+metadata-only headers of a `btrfs send -p base target` stream, similar
+to the approach used by ZFS. This is optional and left to the
+implementation; the FIEMAP-based path above is the default because it
+works uniformly on XFS reflink and btrfs.
+
+### Mapping to CSI SnapshotMetadata
+
+- `block_metadata_type`: `VARIABLE_LENGTH`. FIEMAP extents are
+  variable-sized.
+- `volume_capacity_bytes`: the logical size of the rawfile volume.
+- Consecutive changed / allocated extents are coalesced.
+- `starting_offset` is honoured by skipping tuples that end at or before
+  it.
+
+### Architecture
+
+```
++----------------------+     Kubernetes gRPC
+| Backup application   | <---- (auth: SA token) --------+
++----------+-----------+                                |
+           v                                            v
++----------------------+          +---------------------+---------+
+| SnapshotMetadataSvc  |          | external-snapshot-metadata     |
+| CR (rawfile-localpv) |          | sidecar (CSI controller Pod)   |
++----------------------+          +---------------------+----------+
+                                                        | CSI Unix socket
+                                                        v
+                                        +---------------+---------------+
+                                        | Rawfile-LocalPV CSI Controller|
+                                        +---------------+---------------+
+                                                        | node-agent gRPC
+                                                        v
+                                        +---------------+---------------+
+                                        | Rawfile-LocalPV Node Agent    |
+                                        | (FS_IOC_FIEMAP,               |
+                                        |  optional btrfs send)         |
+                                        +---------------+---------------+
+                                                        |
+                                                        v
+                                        +---------------+---------------+
+                                        | Reflink filesystem (XFS/btrfs)|
+                                        | rawfile snapshots             |
+                                        +-------------------------------+
+```
+
+### Workflow
+
+1. Backup application opens a streaming CBT call to the sidecar.
+2. Sidecar authenticates and forwards to the Rawfile-LocalPV CSI
+   Controller.
+3. Controller resolves the CSI `snapshot_id`(s) to snapshot file paths
+   on the owning node.
+4. Controller invokes the node agent with those file paths.
+5. Node agent runs `FS_IOC_FIEMAP` on the file(s), merges maps (for
+   delta), streams `BlockRange` tuples back to the controller, which
+   emits CSI `BlockMetadata` responses.
+
+## Implementation Details
+
+### Node Agent
+
+Add a new node-agent gRPC service:
+
+```proto
+service RawfileSnapshotMetadata {
+  rpc GetAllocated(GetAllocatedRequest)
+      returns (stream RawfileBlockMetadataResponse);
+  rpc GetDelta(GetDeltaRequest)
+      returns (stream RawfileBlockMetadataResponse);
+}
+
+message GetAllocatedRequest {
+  string snapshot_file    = 1;
+  int64  starting_offset  = 2;
+  int32  max_results      = 3;
+}
+
+message GetDeltaRequest {
+  string base_snapshot_file   = 1;
+  string target_snapshot_file = 2;
+  int64  starting_offset      = 3;
+  int32  max_results          = 4;
+}
+
+message RawfileBlockMetadataResponse {
+  int64 volume_capacity_bytes = 1;
+  repeated BlockRange ranges  = 2;
+}
+
+message BlockRange {
+  int64 byte_offset = 1;
+  int64 size_bytes  = 2;
+}
+```
+
+Implementation notes:
+
+- Reject requests when the backing filesystem is not reflink-capable
+  with `FAILED_PRECONDITION`. Detect via `statfs` magic and,
+  additionally, `xfs_info` (XFS reflink flag) where applicable.
+- Use `FS_IOC_FIEMAP` in a loop with `FIEMAP_FLAG_SYNC`, paging through
+  extents in ascending `fe_logical` order.
+- For `GetDelta`, run a two-pointer merge over the two ascending extent
+  streams and apply the classification described above.
+- Coalesce contiguous output ranges; enforce strictly ascending,
+  non-overlapping output; honour `starting_offset` and `max_results`.
+
+### CSI Controller
+
+- Advertise `SNAPSHOT_METADATA_SERVICE` when CBT is enabled **and** the
+  driver has reflink-based snapshot support.
+- Implement CSI `GetMetadataAllocated` / `GetMetadataDelta` by:
+  1. Resolving the CSI `snapshot_id`(s) to node + snapshot file path(s).
+  2. Verifying the snapshot files are on a reflink-capable FS; if not,
+     `FAILED_PRECONDITION`.
+  3. Verifying base and target belong to the same volume (for delta);
+     otherwise `INVALID_ARGUMENT`.
+  4. Forwarding to the node agent on the owning node.
+  5. Emitting CSI responses with
+     `block_metadata_type = VARIABLE_LENGTH` and populated
+     `volume_capacity_bytes`.
+- Error mapping: not-found → `NOT_FOUND`; different-volume delta →
+  `INVALID_ARGUMENT`; offset beyond logical size → `OUT_OF_RANGE`.
+
+### Helm Chart
+
+- Add `rawfile-localpv.csi.snapshotMetadata.enabled` (default `false`).
+- When enabled:
+  - Deploy `external-snapshot-metadata` sidecar in the CSI controller
+    Pod.
+  - Install the `SnapshotMetadataService` CRD if not already present.
+  - Create the `SnapshotMetadataService` CR for the Rawfile-LocalPV
+    driver with the sidecar's Service and CA bundle.
+  - Provision RBAC for backup applications' SAs.
+- The chart SHOULD refuse to enable the feature when the driver version
+  in use does not yet support reflink-based snapshots.
+
+### Rollout
+
+- Off by default while upstream CSI CBT is alpha and while the driver's
+  reflink-based snapshot support matures.
+- Volumes on non-reflink filesystems are transparently excluded via
+  `FAILED_PRECONDITION` at request time.
+
+## Risks and Mitigations
+
+- **Non-reflink filesystems**: FIEMAP alone cannot compute "changed
+  since previous snapshot" on ext4 or similar. Mitigation: gate on
+  detected reflink support; return `FAILED_PRECONDITION` otherwise.
+- **Encrypted/compressed extents**: FIEMAP may not reflect logical
+  ranges faithfully. Mitigation: reject with `FAILED_PRECONDITION` when
+  such flags are seen (e.g. `FIEMAP_EXTENT_ENCODED`,
+  `FIEMAP_EXTENT_DATA_ENCRYPTED`).
+- **Driver readiness**: reflink-based snapshots are still a TODO in the
+  upstream driver. Mitigation: this OEP is provisional; implementation
+  is gated on that support landing.
+- **Physical-offset stability**: `FIEMAP_EXTENT_SHARED` combined with
+  identical `fe_physical` is used to detect unchanged extents; on
+  filesystems where the physical layout can shift without a logical
+  write, this could over-report changes. Mitigation: default to
+  reporting such ranges as changed (safe, over-reports rather than
+  under-reports); document the trade-off.
+
+## Graduation Criteria
+
+- Alpha: `GetMetadataAllocated` and `GetMetadataDelta` working for
+  rawfile volumes on XFS reflink or btrfs, gated by the Helm toggle and
+  by driver capability.
+- Beta: e2e coverage with a real backup tool on both XFS reflink and
+  btrfs; documented prerequisites.
+- GA: gated on upstream CSI CBT GA and on Rawfile-LocalPV reflink-based
+  snapshots reaching stable status.
+
+## Testing
+
+- Unit tests for the FIEMAP two-pointer merge classifier (shared,
+  same-physical, different-physical, hole-in-base, hole-in-target).
+- Integration test on XFS with reflink: create a rawfile volume, write a
+  known pattern, snapshot, mutate a known set of byte ranges, snapshot
+  again, and assert `GetMetadataDelta` yields exactly the mutated
+  ranges.
+- Same integration test on btrfs.
+- `GetMetadataAllocated` returns exactly the written ranges of a fresh
+  snapshot.
+- Negative: ext4 backing FS → `FAILED_PRECONDITION`; delta across
+  volumes → `INVALID_ARGUMENT`; offset past logical size →
+  `OUT_OF_RANGE`.
+- Helm test: with the toggle off, no sidecar, no CR, capability not
+  advertised.

--- a/designs/local-pv/zfs/changed-block-tracking.md
+++ b/designs/local-pv/zfs/changed-block-tracking.md
@@ -1,0 +1,273 @@
+---
+oep-number: OEP TBD
+title: ZFS-LocalPV Changed Block Tracking (CBT)
+authors:
+  - "@tiagolobocastro"
+owners:
+  - TBD
+editor: TBD
+creation-date: 2026-07-04
+last-updated: 2026-07-04
+status: provisional
+see-also:
+  - designs/csi-changed-block-tracking.md
+---
+
+# ZFS-LocalPV Changed Block Tracking (CBT)
+
+## Table of Contents
+
+- [ZFS-LocalPV Changed Block Tracking (CBT)](#zfs-localpv-changed-block-tracking-cbt)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Metadata Source: ZFS](#metadata-source-zfs)
+    - [Mapping to CSI SnapshotMetadata](#mapping-to-csi-snapshotmetadata)
+    - [Architecture](#architecture)
+    - [Workflow](#workflow)
+  - [Implementation Details](#implementation-details)
+    - [Node Agent](#node-agent)
+    - [CSI Controller](#csi-controller)
+    - [Helm Chart](#helm-chart)
+    - [Rollout](#rollout)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Testing](#testing)
+
+---
+
+## Summary
+
+Implement the CSI `SNAPSHOT_METADATA_SERVICE` for ZFS-LocalPV
+**zvol-backed** volumes, using ZFS's native ability to describe
+allocated and changed blocks of a snapshot. See the top-level OEP:
+[designs/csi-changed-block-tracking.md](../../csi-changed-block-tracking.md).
+
+## Motivation
+
+ZFS tracks per-block birth transaction group (`txg`) numbers, and can
+enumerate the changes between two snapshots of the same dataset via
+`zfs diff` (records) and incremental `zfs send -i` (data stream).
+Combined, these primitives give us both a per-snapshot allocation view
+and the block-level delta between two snapshots of the same zvol —
+exactly what CSI CBT expects.
+
+## Goals
+
+- Expose ZFS's allocated-block and changed-block information for
+  **zvol-backed** ZFS-LocalPV volumes via the CSI `SnapshotMetadata`
+  service.
+- Reuse the existing ZFS-LocalPV node agent as the executor of the ZFS
+  commands, because zvols are node-local.
+- Ship the `external-snapshot-metadata` sidecar and CR from the
+  ZFS-LocalPV Helm chart, opt-in.
+
+## Non-Goals
+
+- CBT for dataset-backed ZFS-LocalPV volumes. The delta primitives used
+  here (per-block birth `txg`, incremental send WRITE records) are
+  specific to zvols; datasets are out of scope.
+- Changing ZFS-LocalPV's snapshot lifecycle.
+- Cross-pool or cross-node deltas.
+- Shipping ZFS itself or changing kernel modules.
+
+## Proposal
+
+### Metadata Source: ZFS
+
+We consider three complementary ZFS mechanisms:
+
+1. **`zfs diff <snap1> <snap2>`**: describes changed *objects*. For zvols
+   this is a single object, so the record set is coarse; we use it for
+   validation, not as the primary delta source.
+2. **Incremental `zfs send -i <snap1> <snap2> | zstreamdump`**: the
+   incremental send stream contains `WRITE` records identifying the
+   byte ranges that changed on the zvol between the two snapshots.
+   This is the direct source for `GetMetadataDelta`.
+3. **Block-birth `txg` comparison**: for `GetMetadataAllocated`, we walk
+   the snapshot's block pointers (via `zdb`-style introspection or a
+   dedicated helper) and emit ranges for blocks whose birth `txg` is at
+   or before the snapshot's `txg`.
+
+Preferred approach:
+
+- `GetMetadataAllocated` → block-birth traversal (self-contained, no
+  need to reference another snapshot).
+- `GetMetadataDelta` → parse the incremental send stream's write
+  records; do **not** move the data itself, only the range headers.
+
+### Mapping to CSI SnapshotMetadata
+
+- `block_metadata_type`: `VARIABLE_LENGTH`. ZFS records/extents can vary
+  in size depending on `volblocksize`, compression, and write patterns.
+- `volume_capacity_bytes`: the zvol's `volsize`.
+- Consecutive changed records are coalesced into a single
+  `BlockMetadata` tuple where possible.
+- `starting_offset` is honoured by skipping tuples that end at or before
+  it.
+
+### Architecture
+
+```
++----------------------+     Kubernetes gRPC
+| Backup application   | <---- (auth: SA token) --------+
++----------+-----------+                                |
+           v                                            v
++----------------------+          +---------------------+------+
+| SnapshotMetadataSvc  |          | external-snapshot-metadata  |
+| CR (zfs-localpv)     |          | sidecar (CSI controller Pod) |
++----------------------+          +---------------------+-------+
+                                                        | CSI Unix socket
+                                                        v
+                                        +---------------+---------------+
+                                        | ZFS-LocalPV CSI Controller    |
+                                        +---------------+---------------+
+                                                        | node-agent gRPC
+                                                        v
+                                        +---------------+---------------+
+                                        | ZFS-LocalPV Node Agent        |
+                                        | (runs ZFS commands)           |
+                                        +---------------+---------------+
+                                                        | libzfs / CLI
+                                                        v
+                                        +---------------+---------------+
+                                        | ZFS pool (zvols + snapshots)  |
+                                        +-------------------------------+
+```
+
+### Workflow
+
+1. Backup application opens a streaming CBT call to the sidecar.
+2. Sidecar authenticates and forwards to the ZFS-LocalPV CSI controller.
+3. Controller resolves the CSI `snapshot_id`(s) to `ZFSSnapshot`
+   custom-resource entries and identifies the owning node.
+4. Controller invokes a new node-agent RPC on that node with the ZFS
+   snapshot name(s).
+5. Node agent runs the appropriate ZFS operation (block-birth traversal
+   or incremental send parse), streams `BlockRange` tuples back to the
+   controller, which converts them into CSI `BlockMetadata` responses.
+
+## Implementation Details
+
+### Node Agent
+
+Add a new node-agent gRPC service:
+
+```proto
+service ZfsSnapshotMetadata {
+  rpc GetAllocated(GetAllocatedRequest)
+      returns (stream ZfsBlockMetadataResponse);
+  rpc GetDelta(GetDeltaRequest)
+      returns (stream ZfsBlockMetadataResponse);
+}
+
+message GetAllocatedRequest {
+  string zfs_snapshot   = 1;   // pool/dataset@snap
+  int64  starting_offset= 2;
+  int32  max_results    = 3;
+}
+
+message GetDeltaRequest {
+  string base_zfs_snapshot   = 1;
+  string target_zfs_snapshot = 2;
+  int64  starting_offset     = 3;
+  int32  max_results         = 4;
+}
+
+message ZfsBlockMetadataResponse {
+  int64 volume_capacity_bytes = 1;
+  repeated BlockRange ranges  = 2;
+}
+
+message BlockRange {
+  int64 byte_offset = 1;
+  int64 size_bytes  = 2;
+}
+```
+
+Implementation notes:
+
+- Reject datasets that are not zvols with `FAILED_PRECONDITION`.
+- For `GetAllocated`: walk block pointers filtered by
+  `birth_txg <= snapshot_txg`; emit ascending, coalesced ranges.
+- For `GetDelta`:
+  - Verify `base` and `target` belong to the same dataset (and `base` is
+    an ancestor of `target`); reject otherwise with `INVALID_ARGUMENT`.
+  - Run `zfs send -i base target` piped into a parser that consumes only
+    the `WRITE` record headers (offset and length) and discards the
+    payload; emit those as `BlockRange`s.
+- Enforce ascending, non-overlapping output; honour `starting_offset`
+  and `max_results`.
+
+### CSI Controller
+
+- Advertise `SNAPSHOT_METADATA_SERVICE` when CBT is enabled.
+- Implement CSI `GetMetadataAllocated` / `GetMetadataDelta` by:
+  1. Looking up the `ZFSSnapshot` CR(s) for the given CSI snapshot IDs.
+  2. Verifying the underlying dataset is a zvol; if not,
+     `FAILED_PRECONDITION`.
+  3. Forwarding to the node agent on the owning node.
+  4. Emitting CSI responses with
+     `block_metadata_type = VARIABLE_LENGTH` and populated
+     `volume_capacity_bytes`.
+- Error mapping: not-found → `NOT_FOUND`; different-volume delta →
+  `INVALID_ARGUMENT`; offset past `volsize` → `OUT_OF_RANGE`.
+
+### Helm Chart
+
+- Add `zfs-localpv.csi.snapshotMetadata.enabled` (default `false`).
+- When enabled:
+  - Deploy `external-snapshot-metadata` sidecar in the CSI controller
+    Pod.
+  - Install the `SnapshotMetadataService` CRD if not already present.
+  - Create the `SnapshotMetadataService` CR for the ZFS-LocalPV driver
+    with the sidecar's Service and CA bundle.
+  - Provision RBAC for backup applications' SAs.
+
+### Rollout
+
+- Off by default while upstream CSI CBT is alpha.
+- Volumes provisioned as datasets are unaffected — CBT requests for such
+  snapshots return `FAILED_PRECONDITION`.
+
+## Risks and Mitigations
+
+- **`zfs send` overhead**: naively running `zfs send` reads the payload.
+  Mitigation: consume only the send-stream record headers (offset,
+  length) and discard payload bytes, or use a metadata-only introspection
+  path if available.
+- **Long `zfs` command output**: mitigated by streaming line-by-line and
+  by `max_results`/`starting_offset`.
+- **Node-local scope**: the controller must dispatch to the correct
+  node. Mitigation: use the existing node-agent routing already used by
+  the driver.
+- **CLI vs library**: shelling out to `zfs`/`zdb` is easier initially but
+  introduces parsing risk. Mitigation: prefer stable, parseable outputs
+  (send stream); pin `zfs` versions in the Node Agent image where
+  applicable.
+
+## Graduation Criteria
+
+- Alpha: `GetMetadataAllocated` and `GetMetadataDelta` working for
+  single-node zvol volumes, gated by the Helm toggle.
+- Beta: e2e coverage with at least one backup tool; docs and examples;
+  performance validated on large zvols.
+- GA: gated on upstream CSI CBT GA.
+
+## Testing
+
+- Unit tests for the send-stream header parser (correctly extracts
+  offset/length; ignores payload).
+- Integration test: create a zvol-backed volume, write a known pattern,
+  snapshot, mutate a known set of blocks, snapshot again, and assert
+  `GetMetadataDelta` yields exactly the mutated ranges.
+- `GetMetadataAllocated` returns exactly the written ranges of a fresh
+  snapshot.
+- Negative: dataset-backed ZFS volumes → `FAILED_PRECONDITION`;
+  cross-dataset delta → `INVALID_ARGUMENT`; offset past `volsize` →
+  `OUT_OF_RANGE`.
+- Helm test: with the toggle off, no sidecar, no CR, capability not
+  advertised.

--- a/designs/replicated-pv/mayastor/changed-block-tracking.md
+++ b/designs/replicated-pv/mayastor/changed-block-tracking.md
@@ -1,0 +1,285 @@
+---
+oep-number: OEP TBD
+title: Mayastor Changed Block Tracking (CBT)
+authors:
+  - "@tiagolobocastro"
+owners:
+  - "@tiagolobocastro"
+editor: TBD
+creation-date: 2026-07-04
+last-updated: 2026-07-04
+status: provisional
+see-also:
+  - designs/csi-changed-block-tracking.md
+---
+
+# Mayastor Changed Block Tracking (CBT)
+
+## Table of Contents
+
+- [Mayastor Changed Block Tracking (CBT)](#mayastor-changed-block-tracking-cbt)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [Metadata Source: SPDK Blobstore](#metadata-source-spdk-blobstore)
+    - [Mapping to CSI SnapshotMetadata](#mapping-to-csi-snapshotmetadata)
+    - [Architecture](#architecture)
+    - [Workflow](#workflow)
+  - [Implementation Details](#implementation-details)
+    - [io-engine (Data Plane)](#io-engine-data-plane)
+    - [agent-core (Control Plane)](#agent-core-control-plane)
+    - [CSI Controller](#csi-controller)
+    - [Helm Chart](#helm-chart)
+    - [Rollout](#rollout)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Testing](#testing)
+
+---
+
+## Summary
+
+Implement the CSI `SNAPSHOT_METADATA_SERVICE` in the Mayastor CSI
+controller, backed by SPDK blobstore cluster-allocation metadata, so that
+CSI-aware backup tools can perform incremental backups of Mayastor
+volumes. See the top-level OEP:
+[designs/csi-changed-block-tracking.md](../../csi-changed-block-tracking.md).
+
+## Motivation
+
+Mayastor volumes are built on the SPDK blobstore, which already tracks
+per-cluster allocation state and per-snapshot allocation deltas. This is
+exactly the information the CSI CBT API expects to expose. Exposing it
+lets backup tools transfer only the changed clusters between snapshots
+of a Mayastor volume, turning today's full-volume backup workflow into an
+efficient incremental one.
+
+## Goals
+
+- Expose SPDK blobstore allocated and changed cluster information via the
+  CSI `SnapshotMetadata` service in the Mayastor CSI controller.
+- Serve both `GetMetadataAllocated` and `GetMetadataDelta` for existing
+  Mayastor `VolumeSnapshot` objects.
+- Provide the plumbing all the way from the CSI controller down to
+  `io-engine` (the data plane) via `agent-core`.
+- Ship the `external-snapshot-metadata` sidecar and the
+  `SnapshotMetadataService` CR from the Mayastor Helm chart, opt-in.
+
+## Non-Goals
+
+- Changes to Mayastor's snapshot creation, restore, or cloning semantics.
+  This OEP is read-only with respect to existing snapshot state.
+- Cross-pool or cross-node deltas: CBT is defined against two snapshots
+  of the same volume.
+- Any new on-disk format or persistent state beyond what the blobstore
+  already tracks.
+
+## Proposal
+
+### Metadata Source: SPDK Blobstore
+
+The SPDK blobstore allocates data in fixed-size **clusters** (typically
+1 MiB). Each blob (which backs a Mayastor volume or snapshot) tracks:
+
+- The set of clusters it has allocated ("allocated cluster map").
+- For a snapshot chain, which clusters are owned by which snapshot
+  (i.e. which clusters differ from the parent).
+
+From these primitives we can compute:
+
+- **Allocated ranges for a snapshot** — the union of clusters that
+  contain data at that snapshot point, expressed as byte ranges.
+- **Delta ranges between two snapshots of the same volume** — the
+  clusters written between the two snapshot points, expressed as byte
+  ranges.
+
+### Mapping to CSI SnapshotMetadata
+
+- `block_metadata_type`: `FIXED_LENGTH`. Mayastor clusters have a fixed
+  size, so each `BlockMetadata` tuple has `size_bytes` equal to a whole
+  number of cluster sizes.
+- `volume_capacity_bytes`: the capacity of the underlying volume.
+- Tuples are strictly ascending and non-overlapping; consecutive
+  allocated clusters MAY be coalesced into a single tuple to reduce
+  stream length.
+- `starting_offset` is honoured by seeking to the first cluster whose
+  end byte is greater than `starting_offset`.
+
+### Architecture
+
+```
++----------------------+      Kubernetes gRPC
+| Backup application   | <---- (auth: SA token) -----+
++----------+-----------+                             |
+           v                                         v
++----------------------+          +------------------+-----------+
+| SnapshotMetadataSvc  |          | external-snapshot-metadata    |
+| CR (mayastor)        |          | sidecar (in CSI controller)   |
++----------------------+          +---------------+---------------+
+                                                  | CSI Unix socket
+                                                  v
+                                  +---------------+---------------+
+                                  | Mayastor CSI Controller       |
+                                  | (implements SnapshotMetadata) |
+                                  +---------------+---------------+
+                                                  | control-plane gRPC
+                                                  v
+                                  +---------------+---------------+
+                                  | agent-core                    |
+                                  +---------------+---------------+
+                                                  | io-engine gRPC
+                                                  v
+                                  +---------------+---------------+
+                                  | io-engine (SPDK blobstore)    |
+                                  +-------------------------------+
+```
+
+### Workflow
+
+1. Backup application resolves the Mayastor `SnapshotMetadataService` CR
+   and opens a streaming gRPC to the sidecar.
+2. Sidecar authenticates the caller's SA token and forwards the request
+   over the CSI Unix socket to the Mayastor CSI Controller.
+3. CSI Controller translates the CSI request into a control-plane call
+   to `agent-core` referencing the Mayastor snapshot(s) by UUID.
+4. `agent-core` forwards the request to the `io-engine` hosting the
+   snapshot(s) via the existing io-engine gRPC channel.
+5. `io-engine` walks the blobstore allocated-cluster map (for
+   `GetMetadataAllocated`) or the per-snapshot delta (for
+   `GetMetadataDelta`), emits byte-range tuples, and streams them back
+   up the chain to the backup application.
+
+## Implementation Details
+
+### io-engine (Data Plane)
+
+Add a new gRPC service (or extend an existing snapshot service) with two
+server-streaming RPCs:
+
+```proto
+service SnapshotMetadata {
+  rpc GetSnapshotAllocated(GetSnapshotAllocatedRequest)
+      returns (stream SnapshotBlockMetadataResponse);
+  rpc GetSnapshotDelta(GetSnapshotDeltaRequest)
+      returns (stream SnapshotBlockMetadataResponse);
+}
+
+message GetSnapshotAllocatedRequest {
+  string snapshot_uuid    = 1;
+  int64  starting_offset  = 2;
+  int32  max_results      = 3;
+}
+
+message GetSnapshotDeltaRequest {
+  string base_snapshot_uuid   = 1;
+  string target_snapshot_uuid = 2;
+  int64  starting_offset      = 3;
+  int32  max_results          = 4;
+}
+
+message SnapshotBlockMetadataResponse {
+  int64 volume_capacity_bytes = 1;
+  // block_metadata_type is implicit: FIXED_LENGTH cluster-aligned.
+  repeated BlockRange ranges  = 2;
+}
+
+message BlockRange {
+  int64 byte_offset = 1;
+  int64 size_bytes  = 2;
+}
+```
+
+Implementation notes:
+
+- Use SPDK blobstore APIs to enumerate allocated clusters for a snapshot
+  blob and to compute per-snapshot deltas along a snapshot chain.
+- Coalesce contiguous clusters into a single `BlockRange` before
+  emitting.
+- Serve tuples in strictly ascending `byte_offset` order; enforce
+  non-overlap.
+- Skip ranges that end at or before `starting_offset`.
+
+### agent-core (Control Plane)
+
+- Add a thin pass-through service that resolves the snapshot UUID(s) to
+  the owning `io-engine` and forwards the streaming request/response.
+- Reject requests whose snapshots belong to different volumes (for
+  `GetSnapshotDelta`) with `INVALID_ARGUMENT`.
+- Reject requests for unknown snapshot UUIDs with `NOT_FOUND`.
+
+### CSI Controller
+
+- Advertise `SNAPSHOT_METADATA_SERVICE` in `GetPluginCapabilities` when
+  CBT is enabled at deploy time.
+- Implement the CSI `SnapshotMetadata` service (`GetMetadataAllocated`,
+  `GetMetadataDelta`) by:
+  1. Mapping the CSI `snapshot_id` to a Mayastor snapshot UUID (existing
+     mapping).
+  2. Calling the `agent-core` streaming API.
+  3. Emitting CSI `BlockMetadata` tuples with
+     `block_metadata_type = FIXED_LENGTH` and the populated
+     `volume_capacity_bytes`.
+- Translate errors: engine `NotFound` → CSI `NOT_FOUND`,
+  invalid args → `INVALID_ARGUMENT`,
+  offset past volume size → `OUT_OF_RANGE`.
+
+### Helm Chart
+
+- Add `mayastor.csi.snapshotMetadata.enabled` (default `false`).
+- When enabled:
+  - Deploy the `external-snapshot-metadata` sidecar in the CSI
+    controller Pod, wired to the CSI Unix socket.
+  - Install the `SnapshotMetadataService` CRD if not already present.
+  - Create a `SnapshotMetadataService` CR named after the Mayastor CSI
+    driver, referencing the sidecar Service and its CA bundle.
+  - Provision the RBAC required for backup applications' SAs to obtain
+    audience-scoped tokens for the sidecar.
+
+### Rollout
+
+- Off by default while the upstream CSI CBT API is alpha.
+- Enabling and disabling is a Helm-only change; no data migration is
+  required.
+- Cluster-scoped: enabling CBT covers all Mayastor volumes on the
+  deployment.
+
+## Risks and Mitigations
+
+- **Streaming large deltas**: change-heavy volumes can produce large
+  streams. Mitigation: use `max_results`; support `starting_offset`
+  resumption.
+- **Snapshot chain complexity**: deltas across long snapshot chains may
+  require walking multiple parents. Mitigation: constrain
+  `GetSnapshotDelta` to the standard case where `base` is an ancestor of
+  `target`; reject other configurations with `INVALID_ARGUMENT`.
+- **Control-plane fan-out**: the streaming request/response crosses
+  CSI → agent-core → io-engine. Mitigation: keep the intermediate
+  services pure pass-throughs; do not re-buffer entire streams.
+- **Upstream alpha churn**: mitigated by keeping the feature opt-in.
+
+## Graduation Criteria
+
+- Alpha: CBT reachable end-to-end from a reference client against a
+  single-replica volume, off by default, gated by the Helm toggle.
+- Beta: multi-replica volumes covered; e2e tests with a real backup tool;
+  documented backup/restore recipe.
+- GA: only after upstream CSI CBT reaches GA.
+
+## Testing
+
+- Unit tests in `io-engine` for the blobstore-to-`BlockRange`
+  translation, including coalescing, ascending order, and
+  `starting_offset` semantics.
+- Integration test: create a Mayastor volume, write a known pattern,
+  snapshot, mutate a known set of clusters, snapshot again, and assert
+  `GetMetadataDelta` returns exactly the mutated cluster ranges.
+- Integration test: `GetMetadataAllocated` on a snapshot returns
+  precisely the written cluster ranges.
+- Negative tests: unknown snapshot UUIDs → `NOT_FOUND`; snapshots of
+  different volumes → `INVALID_ARGUMENT`; oversized `starting_offset` →
+  `OUT_OF_RANGE`.
+- Helm test: with the toggle off, the sidecar and CR are absent and the
+  driver does not advertise `SNAPSHOT_METADATA_SERVICE`.


### PR DESCRIPTION
Add a top-level Changed Block Tracking design plus four per-engine OEPs describing how each OpenEBS engine will implement the CSI SnapshotMetadata service:

- csi-changed-block-tracking.md: cross-engine overview, sidecar + SnapshotMetadataService CR model, per-engine feasibility matrix.
- replicated-pv/mayastor: SPDK blobstore cluster maps (FIXED_LENGTH).
- local-pv/zfs: block-birth txg + incremental send WRITE records on zvols (VARIABLE_LENGTH).
- local-pv/lvm: thin_ls / thin_delta on a thin-pool metadata snapshot (FIXED_LENGTH).
- local-pv/rawfile: FIEMAP two-pointer merge on reflink files, provisional on driver reflink-snapshot support (VARIABLE_LENGTH).

All OEPs are provisional and gated behind a per-engine Helm toggle, off by default while upstream CSI CBT is alpha.

<!-- For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- For pull requesting new features, improvements and changes use https://github.com/openebs/openebs/compare/?template=features.md -->
