### PR TITLE
feat(helm): install snapshot-controller outside each engine

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -131,4 +131,13 @@ helm delete `<RELEASE NAME>` -n `<RELEASE NAMESPACE>`
 | preUpgradeHook.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the hook job | `"1.25.15"` |
 | preUpgradeHook.&ZeroWidthSpace;imagePullSecrets | Optional array of imagePullSecrets containing private registry credentials # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ | `[]` |
 | preUpgradeHook.&ZeroWidthSpace;tolerations | Node tolerations for server scheduling to nodes with taints # Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ # | `[]` |
+| snapshotController.&ZeroWidthSpace;enabled | Enable/Disable the snapshot-controller. Disable if the cluster already runs one. | `true` |
+| snapshotController.&ZeroWidthSpace;extraArgs | Additional arguments for the snapshot-controller | `[]` |
+| snapshotController.&ZeroWidthSpace;image.&ZeroWidthSpace;pullPolicy | The imagePullPolicy for the container | `"IfNotPresent"` |
+| snapshotController.&ZeroWidthSpace;image.&ZeroWidthSpace;registry | The container image registry URL for the snapshot-controller | `"registry.k8s.io"` |
+| snapshotController.&ZeroWidthSpace;image.&ZeroWidthSpace;repo | The container repository for the snapshot-controller | `"sig-storage/snapshot-controller"` |
+| snapshotController.&ZeroWidthSpace;image.&ZeroWidthSpace;tag | The container image tag for the snapshot-controller | `"v8.2.1"` |
+| snapshotController.&ZeroWidthSpace;imagePullSecrets | Optional registry credentials | `[]` |
+| snapshotController.&ZeroWidthSpace;replicas | Number of snapshot-controller replicas | `1` |
+| snapshotController.&ZeroWidthSpace;resources | Resource requests and limits for the snapshot-controller | <pre>{<br><br>}</pre> |
 

--- a/charts/templates/snapshot-controller.yaml
+++ b/charts/templates/snapshot-controller.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.snapshotController.enabled }}
+{{- $distributed := and .Values.engines.local.rawfile.enabled (dig "capabilities" "snapshots" "enabled" false ((index .Values "rawfile-localpv") | default dict)) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-snapshot-controller
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["list", "watch", "create", "update", "patch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents/status"]
+  verbs: ["patch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots/status"]
+  verbs: ["update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- if $distributed }}
+# Required by --enable-distributed-snapshotting.
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+{{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-snapshot-controller
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+subjects:
+- kind: ServiceAccount
+  name: openebs-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: openebs-snapshot-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-snapshot-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  replicas: {{ .Values.snapshotController.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openebs-snapshot-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openebs-snapshot-controller
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      serviceAccountName: openebs-snapshot-controller
+      containers:
+      - name: snapshot-controller
+        image: {{ include "openebs.common.image" (dict "imageRoot" .Values.snapshotController.image "global" .Values.global) }}
+        imagePullPolicy: {{ default .Values.snapshotController.image.pullPolicy .Values.global.imagePullPolicy }}
+        args:
+        - "--v=2"
+        - "--leader-election=true"
+        {{- if $distributed }}
+        # LocalPV Rawfile needs this
+        - "--enable-distributed-snapshotting=true"
+        {{- end }}
+        {{- range .Values.snapshotController.extraArgs }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
+        resources:
+        {{- toYaml .Values.snapshotController.resources | nindent 10 }}
+      {{- if or .Values.global.imagePullSecrets .Values.snapshotController.imagePullSecrets }}
+      imagePullSecrets:
+      {{- include "openebs.common.pullSecrets" (dict "images" (list .Values.snapshotController) "global" .Values.global) | indent 6 }}
+      {{- end }}
+{{- end }}

--- a/charts/templates/snapshot-controller.yaml
+++ b/charts/templates/snapshot-controller.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-snapshot-controller
+  name: {{ .Release.Name }}-openebs-snapshot-controller
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -14,6 +14,29 @@ openebs-crds:
       enabled: true
       keep: true
 
+# A cluster only needs one snapshot-controller, so it is installed here instead of by each engine.
+snapshotController:
+  # -- Enable/Disable the snapshot-controller. Disable if the cluster already runs one.
+  enabled: true
+  # -- Number of snapshot-controller replicas
+  replicas: 1
+  # -- Additional arguments for the snapshot-controller
+  extraArgs: []
+  # -- Resource requests and limits for the snapshot-controller
+  resources: {}
+  # -- Optional registry credentials
+  imagePullSecrets: []
+  # - name: secretName
+  image:
+    # -- The container image registry URL for the snapshot-controller
+    registry: registry.k8s.io
+    # -- The container repository for the snapshot-controller
+    repo: sig-storage/snapshot-controller
+    # -- The container image tag for the snapshot-controller
+    tag: "v8.2.1"
+    # -- The imagePullPolicy for the container
+    pullPolicy: IfNotPresent
+
 # Refer to https://github.com/openebs/dynamic-localpv-provisioner/blob/v4.2.0/deploy/helm/charts/values.yaml for complete set of values.
 localpv-provisioner:
   rbac:
@@ -28,6 +51,9 @@ localpv-provisioner:
 
 # Refer to https://github.com/openebs/zfs-localpv/blob/v2.7.1/deploy/helm/charts/values.yaml for complete set of values.
 zfs-localpv:
+  zfsController:
+    snapshotController:
+      enabled: false
   crds:
     zfsLocalPv:
       enabled: true
@@ -37,6 +63,9 @@ zfs-localpv:
 
 # Refer to https://github.com/openebs/lvm-localpv/blob/lvm-localpv-1.6.2/deploy/helm/charts/values.yaml for complete set of values.
 lvm-localpv:
+  lvmController:
+    snapshotController:
+      enabled: false
   crds:
     lvmLocalPv:
       enabled: true
@@ -46,6 +75,9 @@ lvm-localpv:
 
 # Refer to https://github.com/openebs/rawfile-localpv/blob/v0.11.0/deploy/helm/rawfile-localpv/values.yaml for complete set of values.
 rawfile-localpv:
+  node:
+    snapshotController:
+      enabled: false
   crds:
     csi:
       volumeSnapshots:
@@ -54,6 +86,9 @@ rawfile-localpv:
 # Refer to https://github.com/openebs/mayastor-extensions/blob/v2.8.0/chart/values.yaml for complete set of values.
 mayastor:
   csi:
+    controller:
+      snapshotController:
+        enabled: false
     node:
       initContainers:
         enabled: true


### PR DESCRIPTION
<!-- This is for pull requesting new features, improvements and changes! For fixing bugs use https://github.com/openebs/openebs/compare/?template=bugs.md -->
<!-- Don't forget to follow code style, and update documentation and tests if needed -->
<!-- If you can't answer some sections, please delete them -->

## Description
<!-- Describe your changes in detail -->
Follow-up from https://github.com/openebs/zfs-localpv/pull/742.
 Moves the snapshot-controller into a standalone, singleton deployment that is created by default. The engine-specific snapshot-controllers are disabled by default with this change.

Depends on
https://github.com/openebs/rawfile-localpv/pull/393
https://github.com/openebs/zfs-localpv/pull/742
https://github.com/openebs/lvm-localpv/pull/495
https://github.com/openebs/mayastor-extensions/pull/971

## Motivation and Context
<!-- Why is this change required? How can it benefit other users? -->
 As mentioned in my other PRs across the different engines, the snapshot-controller should only be run once in a cluster. The new deployment added here follows the deployment recommended upstream https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller.

<!-- If it is from an open issue, please link to the issue here -->
Originally raised in https://github.com/openebs/zfs-localpv/issues/736

## Testing
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc -->
```
helm template openebs charts -s templates/snapshot-controller.yaml --set snapshotController.enabled=false
Error: could not find template templates/snapshot-controller.yaml in chart
anthony@mac-mini ~/openebs-umbrella (feat/single-snapshot-controller) [1]> helm template openebs charts -s templates/snapshot-controller.yaml --set snapshotController.enabled=true
---
# Source: openebs/templates/snapshot-controller.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: openebs-snapshot-controller
  namespace: default
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "openebs"
    app.kubernetes.io/version: 4.6.0-develop
    helm.sh/chart: "openebs-4.6.0-develop"
---
# Source: openebs/templates/snapshot-controller.yaml
kind: ClusterRole
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: openebs-snapshot-controller
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "openebs"
    app.kubernetes.io/version: 4.6.0-develop
    helm.sh/chart: "openebs-4.6.0-develop"
rules:
- apiGroups: [""]
  resources: ["persistentvolumes"]
  verbs: ["get", "list", "watch"]
- apiGroups: [""]
  resources: ["persistentvolumeclaims"]
  verbs: ["get", "list", "watch", "update"]
- apiGroups: [""]
  resources: ["events"]
  verbs: ["list", "watch", "create", "update", "patch"]
- apiGroups: ["snapshot.storage.k8s.io"]
  resources: ["volumesnapshotclasses"]
  verbs: ["get", "list", "watch"]
- apiGroups: ["snapshot.storage.k8s.io"]
  resources: ["volumesnapshotcontents"]
  verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
- apiGroups: ["snapshot.storage.k8s.io"]
  resources: ["volumesnapshotcontents/status"]
  verbs: ["patch"]
- apiGroups: ["snapshot.storage.k8s.io"]
  resources: ["volumesnapshots"]
  verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
- apiGroups: ["snapshot.storage.k8s.io"]
  resources: ["volumesnapshots/status"]
  verbs: ["update", "patch"]
- apiGroups: ["coordination.k8s.io"]
  resources: ["leases"]
  verbs: ["get", "watch", "list", "delete", "update", "create"]
---
# Source: openebs/templates/snapshot-controller.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: openebs-snapshot-controller
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "openebs"
    app.kubernetes.io/version: 4.6.0-develop
    helm.sh/chart: "openebs-4.6.0-develop"
subjects:
- kind: ServiceAccount
  name: openebs-snapshot-controller
  namespace: default
roleRef:
  kind: ClusterRole
  name: openebs-snapshot-controller
  apiGroup: rbac.authorization.k8s.io
---
# Source: openebs/templates/snapshot-controller.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: openebs-snapshot-controller
  namespace: default
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "openebs"
    app.kubernetes.io/version: 4.6.0-develop
    helm.sh/chart: "openebs-4.6.0-develop"
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: openebs-snapshot-controller
  template:
    metadata:
      labels:
        app.kubernetes.io/name: openebs-snapshot-controller
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "openebs"
        helm.sh/chart: "openebs-4.6.0-develop"
    spec:
      serviceAccountName: openebs-snapshot-controller
      containers:
      - name: snapshot-controller
        image: registry.k8s.io/sig-storage/snapshot-controller:v8.2.1
        imagePullPolicy: IfNotPresent
        args:
        - "--v=2"
        - "--leader-election=true"
        resources:
          {}
```