### PR TITLE
docs: fix star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These features make OpenEBS a robust and flexible solution for managing persiste
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openebs/openebs&type=Date)](https://star-history.com/#openebs/openebs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=openebs/openebs&type=Date)](https://star-history.dera.page/#openebs/openebs&Date)
 
 ## Activity dashboard
 


### PR DESCRIPTION
The Star History chart in the README stopped rendering because the previous provider is affected by the GitHub stargazer API restrictions. This change moves the chart to a working endpoint using the same domain for the API and frontend, so the chart loads correctly again without requiring an API token.