### PR TITLE
docs: fix star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These features make OpenEBS a robust and flexible solution for managing persiste
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openebs/openebs&type=Date)](https://star-history.com/#openebs/openebs&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=openebs/openebs&type=Date)](https://star-history.dera.page/#openebs/openebs&Date)
 
 ## Activity dashboard
 


### PR DESCRIPTION
The Star History chart in the README is currently broken because the previous provider relies on the GitHub stargazer API. Point the badge and its wrapping link at the new, working endpoint so the chart renders again.

Supersedes #4290