### PR TITLE
ci: retry publish helm chart on failure

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -34,7 +34,29 @@ jobs:
           nix-shell --pure --run "./scripts/staging/validate.sh \
             --trigger ${TRIGGER_TYPE}" ./scripts/staging/shell.nix
 
-      - name: Publish openebs develop or prerelease umbrella helm chart
+      - name: Publish openebs umbrella helm chart
+        uses: stefanprodan/helm-gh-pages@v1.7.0
+        continue-on-error: true
+        id: publish
+        env:
+          TMPDIR: /tmp
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: .
+
+      - name: Retry Publish openebs umbrella helm chart
+        uses: stefanprodan/helm-gh-pages@v1.7.0
+        continue-on-error: true
+        id: publish2
+        if: steps.publish.outcome == 'failure'
+        env:
+          TMPDIR: /tmp
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: .
+
+      - name: Retry Again Publish openebs umbrella helm chart
+        if: steps.publish2.outcome == 'failure'
         uses: stefanprodan/helm-gh-pages@v1.7.0
         env:
           TMPDIR: /tmp


### PR DESCRIPTION
There seems to be no clean way of retrying an action.
There's an action which does this retry by itself but it's not maintained, so we better stay away since the nodejs update may render it unusable.
The other option would be to fork the stefanprodan/helm-gh-pages, but for now let's try this small hack.
