### PR TITLE
build: stop re-enabling kube default features in openebs-upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
  "subtle",

--- a/openebs-upgrade/Cargo.toml
+++ b/openebs-upgrade/Cargo.toml
@@ -20,7 +20,7 @@ color-eyre = { workspace = true }
 constants = { path = "../mayastor/constants" }
 futures = { workspace = true }
 k8s-openapi = { workspace = true }
-kube = { workspace = true, default-features = true, features = ["derive", "runtime"] }
+kube = { workspace = true, features = ["derive", "runtime"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }


### PR DESCRIPTION
The workspace opts out of kube's defaults to get aws-lc-rs:

```toml
kube = { version = "0.99.0", default-features = false, features = [..., "aws-lc-rs"] }
```

kube's defaults are `["client", "rustls-tls", "ring"]`, so `default-features = true` in `openebs-upgrade` puts `ring` straight back. Cargo features are additive and unified graph-wide, so that one override re-activates the whole chain and cannot be switched off downstream:

```
kube/ring -> kube-client/ring -> hyper-rustls/ring -> rustls/ring -> rustls-webpki/ring -> ring
```

Net effect: `ring` is built alongside aws-lc-rs, so both backends ship and the workspace's choice is defeated. `plugin/` has no such override; blame points at e8250439, which preserved each crate's features when moving to shared deps rather than picking a backend.

Safe to drop — the crate only uses `kube::api::{Api, ListParams}`, already covered by the workspace entry. `cargo check -p openebs-upgrade --all-targets` is clean and `cargo tree -i ring --workspace` then finds nothing.