### PR TITLE
docs(oep): update SMART health OEP from GetPoolHealth to ListPoolHealth

### DIFF
--- a/designs/replicated-pv/mayastor/smart-health.md
+++ b/designs/replicated-pv/mayastor/smart-health.md
@@ -3,11 +3,12 @@ oep-number: OEP 5198
 title: Disk Health (SMART) Support in io-engine
 authors:
   - "@susobhandey"
+  - "@rohan2794"
 owners:
   - "@susobhandey"
 editor: TBD
 creation-date: 2026-07-02
-last-updated: 2026-08-17
+last-updated: 2026-09-10
 status: implementable
 ---
 
@@ -25,6 +26,7 @@ status: implementable
     - [Data Model](#data-model)
     - [Device Information](#device-information)
     - [SMART Attributes and Thresholds](#smart-attributes-and-thresholds)
+    - [NVMe Error Log Entries](#nvme-error-log-entries)
     - [The Common Method](#the-common-method)
     - [Branch Selection](#branch-selection)
     - [Common Start and End](#common-start-and-end)
@@ -56,7 +58,7 @@ This enhancement adds SMART (Self-Monitoring, Analysis and Reporting Technology)
 
 Alongside the wear and error counters, each disk also reports the static identity of the device — model, serial number, firmware revision, capacity, and, where the transport exposes it, link speed — and, for ATA devices, the full SMART attribute table including each attribute's `value`, `worst` and `threshold`. The identity fields let an operator correlate a warning with a physical part number without a second tool, and the threshold columns are what make an attribute value interpretable: `value = 100` means nothing until you know the vendor's failure threshold for that attribute.
 
-The results are exposed through a new `GetPoolHealth` RPC on the existing pool gRPC service, which returns one entry per backing disk. Devices that genuinely cannot report health — a virtual cloud disk with no SMART support, for example — are returned with `supported = false` rather than failing the call, so a mixed pool always produces a usable answer. No changes to SPDK source are required; the only change outside io-engine is un-commenting an opcode constant that already exists in the `spdk-rs` bindings.
+The results are exposed through a new `ListPoolHealth` RPC on the existing pool gRPC service, which accepts optional filters (pool name, uuid, pool type) and returns per-pool results each containing one entry per backing disk. Devices that genuinely cannot report health — a virtual cloud disk with no SMART support, for example — are returned with `supported = false` rather than failing the call, so a mixed pool always produces a usable answer. No changes to SPDK source are required; the only change outside io-engine is un-commenting an opcode constant that already exists in the `spdk-rs` bindings.
 
 ## Motivation
 
@@ -80,28 +82,29 @@ No single mechanism reaches both classes of device. A design that only shipped o
 - Expose the health of a pool's backing disks over the pool gRPC API.
 - Require no changes to SPDK source.
 - Degrade gracefully: a device that cannot report health returns `supported = false` instead of failing the request.
+- **Control-plane** Surface health through the control plane, `kubectl mayastor` plugin.
+- **Metrics** Expose disk pool smart health metrics.
 
 ### Non-Goals
 
 - **Health polling, history, or trend storage.** This proposal is strictly on-demand read. Periodic collection is deliberately deferred to follow-on work, for the reason given under [Alternatives](#alternatives): a cached or sampled value is misleading precisely when it matters.
-- **Control-plane and CSI integration.** Surfacing health through the control plane, `kubectl mayastor`, or CSI lives in other repositories and is out of scope here.
-- **Metrics, alerting, or automatic remediation.** No Prometheus exporter, no threshold-based pool eviction, no automatic replica migration on a failure prediction.
 - **Changes to SPDK source.** Only an already-present opcode constant in the `spdk-rs` bindings is enabled.
 - **Interpreting vendor-specific SMART attributes.** The normalised fields cover only the standard, cross-vendor values. The ATA attribute table is passed through as `smartctl` reports it — id, name, `value`, `worst`, `threshold` and raw value — but io-engine does not attempt to decode vendor-specific raw encodings or to assign meaning to non-standard attribute ids. Interpretation of those is left to the caller.
+- **Automatic remediation.** No automatic replica migration on a failure prediction.
 - **Health for devices other than pool-backing disks** (for example NVMe-oF targets consumed as nexus children).
 
 ## Proposal
 
 A new `device_health()` method is added to the `BlockDevice` trait in io-engine. The default implementation returns "not supported", so every existing device type compiles unchanged and simply reports no health until it implements the method. The concrete implementation in `bdev/device.rs` inspects the device's driver and name and dispatches to one of two readers, both of which return the same `DeviceHealth` struct.
 
-A new `GetPoolHealth` RPC on `PoolRpc` resolves a pool by name, enumerates its backing disks, calls `device_health()` on each, and returns a list of per-disk results.
+A new `ListPoolHealth` RPC on `PoolRpc` accepts optional filters — pool name, uuid, and pool type — iterates over all matching pools, enumerates each pool's backing disks, calls `device_health()` on each, and returns per-pool results each containing a list of per-disk health entries.
 
 ```
-              user asks:  GetPoolHealth(pool)
+              user asks:  ListPoolHealth(filters)
                           |
-                 io-engine finds the pool
+                 io-engine finds matching pools
                           |
-                 get the pool's disk(s)
+                 for each pool -> get disk(s)
                           |
              for each disk -> device_health()
                           |
@@ -132,12 +135,13 @@ The key design decisions and their rationale:
 | 6 | Per-disk `supported` flag rather than a failed call | Mixed pools and SMART-less cloud disks still return useful data |
 | 7 | Report device identity alongside the counters | A wear warning is only actionable if the operator can tell which physical disk to pull; the identity is free at the point the health data is read |
 | 8 | Report SMART attributes with their `value`, `worst` and `threshold` | A normalised attribute value is uninterpretable without the vendor threshold it is measured against |
+| 9 | List/filter multiple pools in one call rather than requiring one call per pool | A single RPC covers fleet-wide health queries and single-pool lookups alike; the optional filters keep the simple case simple |
 
 ### User Stories
 
 #### Story 1
 
-As a platform SRE running Mayastor on bare metal, I want to query the health of a pool's backing disk so that I can replace a drive that is nearing end of life *before* it fails and forces a replica rebuild. I call `GetPoolHealth` on the pool and see `percentage_used`, `available_spare_percent`, and `media_errors` for the disk, and act when wear crosses my own threshold. The same response gives me the model and serial number, so I can raise the replacement or RMA against the right part without logging on to the node to run `smartctl` myself.
+As a platform SRE running Mayastor on bare metal, I want to query the health of a pool's backing disk so that I can replace a drive that is nearing end of life *before* it fails and forces a replica rebuild. I call `ListPoolHealth` with the pool name and see `percentage_used`, `available_spare_percent`, and `media_errors` for the disk, and act when wear crosses my own threshold. The same response gives me the model and serial number, so I can raise the replacement or RMA against the right part without logging on to the node to run `smartctl` myself.
 
 #### Story 2
 
@@ -156,11 +160,14 @@ A new struct, `DeviceHealth`, is added in `io-engine/src/core/device_health.rs`.
 | Field | Meaning |
 | ----- | ------- |
 | `critical_warning` | Vendor warning flags; `0` means good |
+| `healthy` | Top-level boolean summarising the device's health — folds `critical_warning`, the SMART overall-health verdict, and any attribute whose `value` has fallen to or below its `threshold` |
 | `temperature_celsius` | Composite temperature in Celsius |
 | `available_spare_percent` | Remaining spare capacity |
 | `available_spare_threshold_percent` | Spare capacity warning level |
 | `percentage_used` | Estimated life consumed |
 | `data_units_read` / `data_units_written` | Volume read / written |
+| `host_read_commands` / `host_write_commands` | Number of host read / write commands |
+| `controller_busy_time_minutes` | Minutes the controller has been busy servicing I/O |
 | `power_cycles` | Number of power cycles |
 | `power_on_hours` | Hours powered on |
 | `unsafe_shutdowns` | Number of unsafe shutdowns |
@@ -168,21 +175,22 @@ A new struct, `DeviceHealth`, is added in `io-engine/src/core/device_health.rs`.
 | `num_error_log_entries` | Number of error log entries |
 | `warning_temperature_threshold_celsius` | Temperature at which the device reports a warning |
 | `critical_temperature_threshold_celsius` | Temperature at which the device considers itself critical |
-| `info` | Static device identity — see [Device Information](#device-information) |
+| `identity` | Static device identity — see [Device Information](#device-information) |
 | `smart_attributes` | The SMART attribute table with thresholds — see [SMART Attributes and Thresholds](#smart-attributes-and-thresholds) |
+| `error_log_entries` | NVMe Error Information Log entries — see [NVMe Error Log Entries](#nvme-error-log-entries) |
 
-Small helpers are provided alongside it, for example `is_healthy()`, which folds `critical_warning`, the SMART overall-health verdict, and any attribute whose `value` has fallen to or below its `threshold` into a single boolean.
+The `healthy` field on both the Rust struct and the protobuf message folds `critical_warning`, the SMART overall-health verdict, and any attribute whose `value` has fallen to or below its `threshold` into a single boolean, so callers can check a device's overall status without inspecting individual counters.
 
 #### Device Information
 
-The counters above tell an operator that *a* disk is wearing out; they do not say *which* disk to pull from the shelf. A nested `DeviceInfo` struct therefore carries the static identity of the device, read from the same source as the health data in the same call, so no second tool and no second round trip is needed.
+The counters above tell an operator that *a* disk is wearing out; they do not say *which* disk to pull from the shelf. A nested `DeviceIdentity` struct therefore carries the static identity of the device, read from the same source as the health data in the same call, so no second tool and no second round trip is needed.
 
 | Field | Meaning |
 | ----- | ------- |
 | `model_number` | Device model, for example `CT250MX500SSD1` |
 | `model_family` | Vendor family from the `smartctl` drive database, where recognised |
 | `serial_number` | Device serial number |
-| `firmware_version` | Firmware revision |
+| `firmware_revision` | Firmware revision |
 | `wwn` | World-wide name / unique device identifier |
 | `capacity_bytes` | User-addressable capacity |
 | `logical_block_size` / `physical_block_size` | Sector sizes, for example 512 logical / 4096 physical |
@@ -195,7 +203,7 @@ The counters above tell an operator that *a* disk is wearing out; they do not sa
 Coverage differs by path, and absent fields stay absent rather than being defaulted:
 
 - **Path A (`smartctl`)** populates every field above; this is exactly the content of the `=== START OF INFORMATION SECTION ===` block, taken from the JSON equivalents rather than the human-readable text.
-- **Path B (VFIO NVMe)** populates `model_number`, `serial_number`, `firmware_version`, `wwn` and `capacity_bytes` from the Identify Controller data structure that io-engine already reads for `identify`, and reports `transport` as `NVMe (PCIe)` with `rotation_rate_rpm = 0`. `model_family` and `form_factor` have no NVMe equivalent. `link_speed` is a property of the PCIe link rather than of the controller, so it is not available from Identify and is left absent for now; surfacing it would mean reading PCI config space, which is deliberately out of scope for this proposal.
+- **Path B (VFIO NVMe)** populates `model_number`, `serial_number`, `firmware_revision`, `wwn` and `capacity_bytes` from the Identify Controller data structure that io-engine already reads for `identify`, and reports `transport` as `NVMe (PCIe)` with `rotation_rate_rpm = 0`. `model_family` and `form_factor` have no NVMe equivalent. `link_speed` is a property of the PCIe link rather than of the controller, so it is not available from Identify and is left absent for now; surfacing it would mean reading PCI config space, which is deliberately out of scope for this proposal.
 
 `smart_enabled` is meaningful only for ATA devices, which can have SMART switched off. NVMe has no such toggle — the SMART log page is mandatory — so both flags are reported as true on Path B.
 
@@ -211,9 +219,6 @@ A bare attribute value is not actionable. `Reallocated_Sector_Ct` at `value = 10
 | `worst` | Worst normalised value recorded over the device's lifetime |
 | `threshold` | Vendor failure threshold for this attribute |
 | `raw_value` | Raw value as an integer |
-| `raw_string` | Raw value as rendered by `smartctl`, retained because some vendors pack several counters into one raw field |
-| `failing_now` | `value` is at or below `threshold` today |
-| `failed_before` | The attribute has failed at some point in the past |
 
 Availability again follows the device class, and the field is an empty list rather than an error when a class has no such table:
 
@@ -222,6 +227,21 @@ Availability again follows the device class, and the field is an empty list rath
 - **NVMe devices** likewise have no attribute table; the SMART log page is a fixed structure whose fields are already normalised into `DeviceHealth` directly. NVMe's equivalents of a threshold are reported as first-class fields instead: `available_spare_threshold_percent` from the log page, and `warning_temperature_threshold_celsius` / `critical_temperature_threshold_celsius` from Identify Controller (`WCTEMP` and `CCTEMP`, converted from Kelvin).
 
 This keeps one shape across all device classes: a caller can always read the normalised counters, and can additionally walk `smart_attributes` when the device is one that provides them.
+
+#### NVMe Error Log Entries
+
+NVMe devices maintain an Error Information Log (log page `0x01`) that records recent command failures. The implementation reads this log alongside the SMART log page for VFIO-attached NVMe (Path B) and from the `smartctl` JSON for kernel-attached NVMe (Path A), and returns it as a list of `NvmeErrorLogEntry`:
+
+| Field | Meaning |
+| ----- | ------- |
+| `error_count` | Error count assigned by the controller |
+| `submission_queue_id` | Submission queue that issued the failed command |
+| `command_id` | Command identifier of the failed command |
+| `status_field` | Status field from the completion queue entry |
+| `lba` | Logical block address involved, if applicable |
+| `namespace_id` | Namespace the command targeted |
+
+The list is empty for device classes that do not maintain an NVMe error log (ATA, SAS).
 
 #### The Common Method
 
@@ -239,9 +259,9 @@ Note that a `/dev/disk/by-path/...` name also starts with `/dev/` and therefore 
 
 #### Common Start and End
 
-**Start (both paths).** The client calls `GetPoolHealth` with a pool name. The handler in `grpc/v1/pool.rs` resolves the pool via `finder()`, obtains the backing disk list via `pool.disks()`, looks up the `BlockDevice` for each disk, and calls `device_health()` on it.
+**Start (both paths).** The client calls `ListPoolHealth` with optional filters (pool name, uuid, pool type). The handler in `grpc/v1/pool.rs` iterates over all matching pools, obtains the backing disk list for each via `pool.disks()`, looks up the `BlockDevice` for each disk, and calls `device_health()` on it.
 
-**End (both paths).** Each call yields either a `DeviceHealth` or an error. The handler builds a `DiskHealth { disk_uri, supported, health }` — `supported = true` with the health payload on success, `supported = false` on failure or when the device reports no SMART capability. All entries are collected into a `GetPoolHealthResponse`.
+**End (both paths).** Each call yields either a `DeviceHealth` or an error. The handler builds a `DiskHealth { disk_uri, supported, health, error }` — `supported = true` with the health payload on success, `supported = false` with an `error` string describing the failure reason when the device reports no SMART capability or the read fails. Per-pool results are wrapped in a `PoolHealth { name, uuid, disks }`, and all pool entries are collected into a `ListPoolHealthResponse`.
 
 #### Path A — smartctl (kernel-attached disks)
 
@@ -249,14 +269,14 @@ Applies to SATA, SAS, and NVMe not bound to VFIO. Code lives in `bdev/device.rs`
 
 ```
 User (grpcurl / client)
-   |   GetPoolHealth("pool-node-0")
+   |   ListPoolHealth(filters)
    v
-gRPC server: PoolRpc.GetPoolHealth            [grpc/v1/pool.rs]
+gRPC server: PoolRpc.ListPoolHealth           [grpc/v1/pool.rs]
    |
    v
-find the pool          finder()
+find matching pools    (filter by name / uuid / pooltype)
    |
-   v
+   v  for each pool:
 get disk list          pool.disks()   ->  "aio:///dev/sdb"
    |
    v
@@ -273,40 +293,44 @@ run:  smartctl --json --all /dev/sdb
    |
    v
 read the JSON  ->  fill DeviceHealth
-   |               (+ DeviceInfo, + SmartAttribute list)
+   |               (+ DeviceIdentity, + SmartAttribute list)
    |
    v
-back to handler  ->  DiskHealth { uri, supported, health }
+back to handler  ->  DiskHealth { uri, supported, health, error }
    |
    v
-GetPoolHealthResponse  ->  send to user
+PoolHealth { name, uuid, disks }
+   |
+   v
+ListPoolHealthResponse  ->  send to user
 ```
 
 The JSON produced by `smartctl --json --all` is mapped as follows:
 
 | JSON field | `DeviceHealth` field |
 | ---------- | -------------------- |
-| `smart_status.passed = false` | set the critical warning flag |
+| `smart_status.passed = false` | set the critical warning flag; `healthy` = false |
 | `temperature.current` | temperature |
 | `power_on_time.hours` | power on hours |
 | `power_cycle_count` | power cycles |
-| `nvme_smart_health_information_log` | all NVMe fields (kernel NVMe) |
+| `nvme_smart_health_information_log` | all NVMe fields (kernel NVMe), including `host_read_commands`, `host_write_commands`, `controller_busy_time` |
 | ATA attribute id 194 | temperature |
 | ATA attribute id 5 | media errors |
 | ATA attribute id 9 | power on hours |
 | ATA attribute id 12 | power cycles |
 | ATA attribute id 198 | error log entries |
 | `scsi_grown_defect_list` | media errors (SAS) |
-| `ata_smart_attributes.table[]` | `smart_attributes` — `id`, `name`, `value`, `worst`, `thresh`, `raw.value`, `raw.string`, and `when_failed` (`"now"` → `failing_now`, `"past"` → `failed_before`) |
+| `ata_smart_attributes.table[]` | `smart_attributes` — `id`, `name`, `value`, `worst`, `thresh`, `raw.value` |
+| `nvme_smart_health_information_log.error_information_log_entries` | `error_log_entries` (NVMe error log via `smartctl`) |
 
-The information-section fields map into `DeviceInfo` as follows. These are read from the JSON keys rather than by scraping the human-readable `=== START OF INFORMATION SECTION ===` block:
+The information-section fields map into `DeviceIdentity` as follows. These are read from the JSON keys rather than by scraping the human-readable `=== START OF INFORMATION SECTION ===` block:
 
-| JSON field | `DeviceInfo` field |
+| JSON field | `DeviceIdentity` field |
 | ---------- | ------------------ |
 | `model_name` | model number |
 | `model_family` | model family |
 | `serial_number` | serial number |
-| `firmware_version` | firmware version |
+| `firmware_version` | firmware revision |
 | `wwn.{naa,oui,id}` | wwn (formatted) |
 | `user_capacity.bytes` | capacity bytes |
 | `logical_block_size` / `physical_block_size` | sector sizes |
@@ -324,14 +348,14 @@ Applies to NVMe attached over `pcie://`. There is no `/dev` name, so the SMART /
 
 ```
 User (grpcurl / client)
-   |   GetPoolHealth("pool-node-0")
+   |   ListPoolHealth(filters)
    v
-gRPC server: PoolRpc.GetPoolHealth            [grpc/v1/pool.rs]
+gRPC server: PoolRpc.ListPoolHealth           [grpc/v1/pool.rs]
    |
    v
-find the pool          finder()
+find matching pools    (filter by name / uuid / pooltype)
    |
-   v
+   v  for each pool:
 get disk list          pool.disks()   ->  "pcie://...."
    |
    v
@@ -366,29 +390,34 @@ DeviceHealth::from_nvme_smart(page)  ->  fill DeviceHealth
    v
 nvme_identify_ctrlr()             (already implemented)
    |   4096 byte Identify Controller data
-   |   MN / SN / FR / TNVMCAP  ->  DeviceInfo
+   |   MN / SN / FR / TNVMCAP  ->  DeviceIdentity
    |   WCTEMP / CCTEMP        ->  temperature thresholds
    v
-back to handler  ->  DiskHealth { uri, supported, health }
+back to handler  ->  DiskHealth { uri, supported, health, error }
    |
    v
-GetPoolHealthResponse  ->  send to user
+PoolHealth { name, uuid, disks }
+   |
+   v
+ListPoolHealthResponse  ->  send to user
 ```
 
 **Log page parsing.** The SMART log page is a fixed 512-byte structure with each value at a defined offset (byte 0 is the critical warning bitmap, bytes 1–2 the composite temperature, byte 4 the available spare threshold, byte 5 the percentage used, and so on). Each field is read from its fixed offset into `DeviceHealth`. Buffers shorter than 512 bytes are rejected rather than parsed partially.
 
-**Device identity.** The SMART log page carries counters only — it contains no model or serial number. The identity fields are therefore taken from the Identify Controller data structure via the existing `nvme_identify_ctrlr()`: model number (`MN`), serial number (`SN`), firmware revision (`FR`) and total capacity (`TNVMCAP`), all at fixed offsets in the 4096-byte response. The same structure supplies the warning and critical composite temperature thresholds (`WCTEMP`, `CCTEMP`), which are stored in Kelvin and converted to Celsius. This is a second admin command on the same read-only handle; both are issued before the handle is dropped. If the Identify call fails, the health counters are still returned and only `info` is left absent — identity is useful context, not a precondition for reporting wear.
+**Device identity.** The SMART log page carries counters only — it contains no model or serial number. The identity fields are therefore taken from the Identify Controller data structure via the existing `nvme_identify_ctrlr()`: model number (`MN`), serial number (`SN`), firmware revision (`FR`) and total capacity (`TNVMCAP`), all at fixed offsets in the 4096-byte response. The same structure supplies the warning and critical composite temperature thresholds (`WCTEMP`, `CCTEMP`), which are stored in Kelvin and converted to Celsius. This is a second admin command on the same read-only handle; both are issued before the handle is dropped. If the Identify call fails, the health counters are still returned and only `identity` is left absent — identity is useful context, not a precondition for reporting wear.
 
 The handle is opened **read-only** (`open_with_bdev(bdev, false)`) so that reading health cannot interfere with the pool that is already using the device, and both admin commands use the read-only passthru variant.
 
 #### Combined Flow
 
 ```
-                 GetPoolHealth (gRPC)
+                 ListPoolHealth (gRPC)
                         |
-                 find pool + disks
+                 find matching pools (filter)
                         |
-                 device_health()
+                 for each pool -> get disks
+                        |
+                 for each disk -> device_health()
                         |
          +--------------+---------------+
          |                              |
@@ -403,15 +432,17 @@ The handle is opened **read-only** (`open_with_bdev(bdev, false)`) so that readi
          |                              |
          |                        read 512 byte page
          |                              |
-   info + attributes            nvme_identify_ctrlr()
-   from same JSON               -> info + temp thresholds
+   identity + attributes        nvme_identify_ctrlr()
+   from same JSON               -> identity + temp thresholds
          +--------------+---------------+
                         |
-              DeviceHealth (+ info, + attributes)
+              DeviceHealth (+ identity, + attributes)
                         |
                     DiskHealth
                         |
-              GetPoolHealthResponse -> user
+                    PoolHealth
+                        |
+              ListPoolHealthResponse -> user
 ```
 
 #### gRPC / Protobuf Interface
@@ -419,17 +450,19 @@ The handle is opened **read-only** (`open_with_bdev(bdev, false)`) so that readi
 One RPC is added to the existing `PoolRpc` service in `protobuf/v1/pool.proto`:
 
 ```protobuf
-rpc GetPoolHealth (GetPoolHealthRequest) returns (GetPoolHealthResponse) {}
+rpc ListPoolHealth (ListPoolHealthOptions) returns (ListPoolHealthResponse) {}
 ```
 
 New messages:
 
-- `GetPoolHealthRequest { name, uuid }` — pool name, with optional uuid for disambiguation.
-- `DeviceInfo { ... }` — the static identity fields listed in [Device Information](#device-information).
-- `SmartAttribute { id, name, value, worst, threshold, raw_value, raw_string, failing_now, failed_before }` — one per attribute, as listed in [SMART Attributes and Thresholds](#smart-attributes-and-thresholds).
-- `DeviceHealth { ... }` — the fields listed in [Data Model](#data-model), including `DeviceInfo info` and `repeated SmartAttribute smart_attributes`.
-- `DiskHealth { disk_uri, supported, health }` — one per backing disk.
-- `GetPoolHealthResponse { repeated DiskHealth disks }`.
+- `ListPoolHealthOptions { name, pooltype, uuid }` — all optional filters; when no filter is set, health is returned for every pool on the node.
+- `DeviceIdentity { ... }` — the static identity fields listed in [Device Information](#device-information).
+- `SmartAttribute { id, name, value, worst, threshold, raw_value }` — one per attribute, as listed in [SMART Attributes and Thresholds](#smart-attributes-and-thresholds).
+- `NvmeErrorLogEntry { error_count, submission_queue_id, command_id, status_field, lba, namespace_id }` — one per NVMe error log entry, as listed in [NVMe Error Log Entries](#nvme-error-log-entries).
+- `DeviceHealth { ... }` — the fields listed in [Data Model](#data-model), including `DeviceIdentity identity`, `repeated SmartAttribute smart_attributes`, and `repeated NvmeErrorLogEntry error_log_entries`.
+- `DiskHealth { disk_uri, supported, health, error }` — one per backing disk; `error` is an optional string carrying the failure reason when `supported` is false.
+- `PoolHealth { name, uuid, repeated DiskHealth disks }` — one per matching pool.
+- `ListPoolHealthResponse { repeated PoolHealth pools }`.
 
 Fields that a device class does not report use `optional` scalars so that "absent" is distinguishable from zero on the wire — the distinction matters for exactly the values an operator acts on, since a `media_errors` of `0` and an unknown `media_errors` are very different answers. `smart_attributes` is a repeated field and is simply empty for device classes that have no attribute table.
 
@@ -437,7 +470,7 @@ The addition is backwards compatible: no existing message or RPC is modified, so
 
 #### Error Handling
 
-If a disk cannot produce health data for any reason — `smartctl` missing from the image, the device does not implement SMART, the handle open fails, the admin command is rejected, or the output cannot be parsed — that disk's entry is returned with `supported = false` and no health payload. The overall RPC still succeeds. This is deliberate: a pool striped across a SMART-capable disk and a SMART-less cloud volume should still tell the operator what it knows about the first one.
+If a disk cannot produce health data for any reason — `smartctl` missing from the image, the device does not implement SMART, the handle open fails, the admin command is rejected, or the output cannot be parsed — that disk's entry is returned with `supported = false`, no health payload, and an `error` string describing the failure reason. The overall RPC still succeeds. This is deliberate: a pool striped across a SMART-capable disk and a SMART-less cloud volume should still tell the operator what it knows about the first one, and the `error` field gives visibility into why a particular disk could not report.
 
 The implementation never synthesises or defaults a health value. An absent field is absent, not zero.
 
@@ -451,12 +484,16 @@ Both paths are invoked from the gRPC handler, not from the I/O hot path. Path A 
 
 | File | Change |
 | ---- | ------ |
-| `core/device_health.rs` (new) | `DeviceHealth`, `DeviceInfo`, `SmartAttribute`, the `smartctl` reader, the JSON parser, the 512-byte log-page parser, the Identify Controller field extraction, unit tests |
+| `core/device_health.rs` (new) | `DeviceHealth`, `DeviceIdentity`, `SmartAttribute`, `NvmeErrorLogEntry`, the `smartctl` reader, the JSON parser, the 512-byte log-page parser, the Identify Controller field extraction, unit tests |
 | `core/block_device.rs` | Add `device_health()` to the `BlockDevice` trait with a default implementation |
-| `core/handle.rs` | Add `nvme_get_smart()` (modelled on `nvme_identify_ctrlr`, reusing the existing `nvme_admin`) |
+| `core/handle.rs` | Add `nvme_get_smart()` and `nvme_identify_ctrlr()` (reusing the existing `nvme_admin`) |
 | `core/mod.rs` | Declare the module and re-export `DeviceHealth` |
 | `bdev/device.rs` | Implement `device_health()` — `smartctl` path and VFIO log-page path |
-| `grpc/v1/pool.rs` | `GetPoolHealth` handler, type conversions, `disks()` accessor |
+| `pool_backend.rs` | Add `PoolOps::read_device_health()` trait method with default `smartctl` implementation |
+| `lvs/mod.rs` | LVS override for resolving bdev URIs to device names |
+| `grpc/v1/pool.rs` | `list_pool_health` handler, type conversions, `From` impls for proto messages |
+| `bin/io-engine-client/v1/pool_cli.rs` | `pool get-health` CLI subcommand |
+| `tests/pool_health.rs` (new) | Integration tests (loop device + scsi_debug) |
 
 **spdk-rs**
 
@@ -468,8 +505,14 @@ Both paths are invoked from the gRPC handler, not from the I/O hot path. Path A 
 
 | File | Change |
 | ---- | ------ |
-| `protobuf/v1/pool.proto` | New RPC and messages |
+| `protobuf/v1/pool.proto` | New RPC and messages (`ListPoolHealthOptions`, `ListPoolHealthResponse`, `PoolHealth`, `DeviceHealth`, `DeviceIdentity`, `SmartAttribute`, `NvmeErrorLogEntry`, `DiskHealth`) |
 | `src/v1.rs` | Re-export the new message names in the pool module |
+
+**nix**
+
+| File | Change |
+| ---- | ------ |
+| `nix/pkgs/images/default.nix` | Add `smartmontools` to the io-engine container image |
 
 #### Runtime Requirements
 
@@ -495,23 +538,23 @@ Both paths are invoked from the gRPC handler, not from the I/O hot path. Path A 
 | Admin passthru could in principle carry a harmful opcode | Device damage or data loss if misused | Only `GET LOG PAGE` is enabled, only log ID `0x02` is requested, and only the read-only passthru variant is used; the opcode is not exposed through any user-supplied parameter |
 | Shelling out to an external binary | Process-spawn failures, parsing drift across `smartctl` versions | Parse the stable JSON output rather than human-readable text; treat parse failure as unsupported; pin the `smartmontools` version in the image |
 | Health data exposed over gRPC | Serial numbers, firmware revisions and wear data become visible to any gRPC client — hardware inventory detail that was previously not obtainable through this API | The pool service is already an internal, node-local API with the same trust boundary; no new authentication surface is introduced. The identity fields are exactly what an operator needs to locate a failing disk, so the exposure is intentional rather than incidental |
-| Vendor-specific attribute raw values are easy to misread | An operator or a downstream tool draws the wrong conclusion from a raw value whose encoding is vendor-defined | Report `value`, `worst` and `threshold` alongside every raw value so the normalised scale is always available; retain `raw_string` as rendered by `smartctl` rather than only the integer; do not interpret vendor encodings in io-engine |
-| Attribute table enlarges the response | A pool with many disks returns a noticeably larger payload than the counters alone would | The table is a few dozen small entries per ATA disk and the RPC is on-demand rather than polled; if this becomes a problem, a request flag to omit attributes can be added compatibly |
+| Vendor-specific attribute raw values are easy to misread | An operator or a downstream tool draws the wrong conclusion from a raw value whose encoding is vendor-defined | Report `value`, `worst` and `threshold` alongside every raw value so the normalised scale is always available; do not interpret vendor encodings in io-engine |
+| Attribute table and multi-pool response enlarge the payload | A node-wide query with many pools and disks returns a noticeably larger payload than the counters alone would | The table is a few dozen small entries per ATA disk and the RPC is on-demand rather than polled; if this becomes a problem, the optional filters narrow the scope, and a request flag to omit attributes can be added compatibly |
 
 ## Graduation Criteria
 
 **Provisional → Implementable**
 
-- Design questions in this OEP resolved with maintainer review, in particular the reported field set: whether the `DeviceInfo` identity fields and the ATA attribute table cover what operators need, and whether anything listed should be dropped.
+- Design questions in this OEP resolved with maintainer review, in particular the reported field set: whether the `DeviceIdentity` identity fields and the ATA attribute table cover what operators need, and whether anything listed should be dropped.
 - Agreement that the `supported = false` degradation model is preferable to failing the RPC.
 - POC demonstrating both paths on real hardware — one kernel-attached disk and one VFIO-attached NVMe device.
 
 **Implementable → Implemented**
 
 - `device_health()` implemented for both paths, with unit tests passing on captured fixtures for NVMe JSON, SATA attribute tables, SAS payloads, and the raw 512-byte log page.
-- `GetPoolHealth` available and callable via `grpcurl`, returning counters, identity and attribute table.
+- `ListPoolHealth` available and callable via `grpcurl`, returning per-pool results with counters, identity and attribute table.
 - Verified on real VFIO-attached NVMe hardware, including a read-only health read while the pool is `Online` and serving I/O, with no measurable impact on pool I/O.
-- BDD test for `GetPoolHealth` running in CI, including a pool mixing a SMART-capable and a SMART-less device.
+- BDD test for `ListPoolHealth` running in CI, including a pool mixing a SMART-capable and a SMART-less device.
 - `smartmontools` present in the released image, and the `SYS_RAWIO` capability requirement documented in the user-facing docs.
 - Field feedback gathered from operators on whether the normalised field set is sufficient, and the control-plane / CSI consumer work scoped even though it is delivered separately.
 
@@ -520,7 +563,8 @@ Both paths are invoked from the gRPC handler, not from the I/O hot path. Path A 
 - 2026-07-02: High-Level and Low-Level Design Documents drafted (v1.0)
 - 2026-07-22: Reformatted as an OEP for community review
 - 2026-07-28: Provisional OEP submitted as [openebs/openebs#4274](https://github.com/openebs/openebs/pull/4274); review by @tiagolobocastro raised device information and SMART attribute thresholds
-- 2026-07-29: Device identity (`DeviceInfo`) and the SMART attribute table with thresholds added to the proposal in response to review
+- 2026-07-29: Device identity (`DeviceIdentity`) and the SMART attribute table with thresholds added to the proposal in response to review
+- 2026-09-10: Updated from `GetPoolHealth` (single-pool) to `ListPoolHealth` (multi-pool with optional filters) to match implementation PRs [mayastor#2070](https://github.com/openebs/mayastor/pull/2070) and [mayastor-dependencies#186](https://github.com/openebs/mayastor-dependencies/pull/186); added `PoolHealth` wrapper, `NvmeErrorLogEntry`, `healthy` field, host I/O counters, `error` on `DiskHealth`; renamed `DeviceInfo` to `DeviceIdentity`; removed `raw_string`, `failing_now`, `failed_before` from `SmartAttribute`
 
 ## Drawbacks
 
@@ -565,14 +609,16 @@ No hardware required; these run on standard CI runners against captured fixtures
 - A failed SMART overall-health status maps to "not healthy".
 - Malformed or empty `smartctl` output yields "not supported", not a panic.
 - A non-zero `smartctl` exit code with valid JSON is still parsed successfully.
-- Parse the information section of a captured SATA payload and assert every `DeviceInfo` field, including `rotation_rate = 0` mapping to solid state and `interface_speed.current.string` mapping to link speed.
-- Assert `DeviceInfo` fields absent from a payload — `model_family` for an unrecognised drive, `form_factor` for NVMe — are reported absent rather than as empty strings.
-- Parse a captured `ata_smart_attributes.table` and assert `id`, `name`, `value`, `worst`, `threshold` and both raw representations for every entry.
-- `when_failed = "now"` sets `failing_now`, `"past"` sets `failed_before`, and `""` sets neither.
-- An attribute whose `value` is at or below its `threshold` makes `is_healthy()` false even when `critical_warning` is `0` and the overall-health verdict passed.
+- Parse the information section of a captured SATA payload and assert every `DeviceIdentity` field, including `rotation_rate = 0` mapping to solid state and `interface_speed.current.string` mapping to link speed.
+- Assert `DeviceIdentity` fields absent from a payload — `model_family` for an unrecognised drive, `form_factor` for NVMe — are reported absent rather than as empty strings.
+- Parse a captured `ata_smart_attributes.table` and assert `id`, `name`, `value`, `worst`, `threshold` and `raw_value` for every entry.
+- An attribute whose `value` is at or below its `threshold` makes `healthy` false even when `critical_warning` is `0` and the overall-health verdict passed.
 - A SAS payload and an NVMe payload both yield an empty `smart_attributes` list rather than an error.
-- Extract `DeviceInfo` and the temperature thresholds from a synthetic 4096-byte Identify Controller buffer, asserting `MN`/`SN`/`FR` are trimmed of padding and `WCTEMP`/`CCTEMP` are converted from Kelvin.
-- A failed Identify call still yields the health counters, with `info` absent.
+- Parse NVMe error log entries from a captured payload and assert `error_count`, `submission_queue_id`, `command_id`, `status_field`, `lba`, `namespace_id`.
+- ATA and SAS payloads yield an empty `error_log_entries` list.
+- Assert `host_read_commands`, `host_write_commands` and `controller_busy_time_minutes` are parsed from an NVMe payload.
+- Extract `DeviceIdentity` and the temperature thresholds from a synthetic 4096-byte Identify Controller buffer, asserting `MN`/`SN`/`FR` are trimmed of padding and `WCTEMP`/`CCTEMP` are converted from Kelvin.
+- A failed Identify call still yields the health counters, with `identity` absent.
 
 ### Hardware and integration tests
 
@@ -582,8 +628,8 @@ No hardware required; these run on standard CI runners against captured fixtures
 - VFIO-attached NVMe via `pcie://`, including a read-only health read while the pool is `Online` and serving I/O, verifying no disruption to in-flight I/O.
 - A device with no SMART support (for example a cloud virtual disk), confirming `supported = false`.
 - io-engine running without `smartctl` in the image, confirming graceful degradation rather than a failed RPC.
-- On a real SATA disk, cross-check the reported `DeviceInfo` and attribute table against `smartctl -a` run directly on the host, confirming the JSON mapping matches the human-readable output an operator would compare against.
-- On real VFIO NVMe, cross-check `model_number`, `serial_number` and `firmware_version` against the values reported before the device was bound to VFIO.
+- On a real SATA disk, cross-check the reported `DeviceIdentity` and attribute table against `smartctl -a` run directly on the host, confirming the JSON mapping matches the human-readable output an operator would compare against.
+- On real VFIO NVMe, cross-check `model_number`, `serial_number` and `firmware_revision` against the values reported before the device was bound to VFIO.
 
 ### BDD tests
 
@@ -594,27 +640,33 @@ Feature: DiskPool health reporting
 
   Scenario: Health is reported for a SMART-capable disk
     Given a DiskPool backed by a SMART-capable disk
-    When the pool health is requested
-    Then the disk should be reported as supported
-    And the response should include the device model, serial number and firmware version
+    When ListPoolHealth is called with the pool name
+    Then the pool's disk should be reported as supported
+    And the response should include the device model, serial number and firmware revision
     And the wear and error counters should be populated
+
+  Scenario: Listing health with no filter returns all pools
+    Given two DiskPools on the node
+    When ListPoolHealth is called with no filters
+    Then the response should contain one PoolHealth entry per pool
 
   Scenario: A pool mixing SMART-capable and SMART-less disks still answers
     Given a DiskPool backed by one SMART-capable disk and one disk without SMART support
-    When the pool health is requested
+    When ListPoolHealth is called with the pool name
     Then the call should succeed
-    And there should be one entry per backing disk
+    And there should be one DiskHealth entry per backing disk
     And only the SMART-capable disk should be reported as supported
+    And the unsupported disk should carry an error string
 
   Scenario: SMART attributes carry their thresholds
     Given a DiskPool backed by a SATA disk
-    When the pool health is requested
+    When ListPoolHealth is called with the pool name
     Then each reported SMART attribute should carry a value, worst and threshold
 
-  Scenario: Health of an unknown pool is an error
+  Scenario: Health of an unknown pool returns an empty list
     Given a node with no pool named "missing"
-    When the pool health is requested for "missing"
-    Then the call should fail with a not-found status
+    When ListPoolHealth is called with name "missing"
+    Then the response should contain zero PoolHealth entries
 ```
 
 Backwards compatibility is asserted separately: an older client using the pool service is unaffected by the new RPC.


### PR DESCRIPTION
Align the design document with the implementation in mayastor#2070 and mayastor-dependencies#186. The RPC changed from a single-pool lookup (GetPoolHealth) to a multi-pool list/filter (ListPoolHealth).

Key changes:
- GetPoolHealth → ListPoolHealth with optional name/uuid/pooltype filters
- GetPoolHealthRequest → ListPoolHealthOptions, response wrapped in PoolHealth per pool
- DeviceInfo → DeviceIdentity, firmware_version → firmware_revision
- Added: healthy bool, host_read/write_commands, controller_busy_time_minutes
- Added: NvmeErrorLogEntry message and error_log_entries on DeviceHealth
- Added: error string on DiskHealth for failure reasons
- Removed: raw_string, failing_now, failed_before from SmartAttribute
- Updated diagrams, file-level changes, unit tests, and BDD scenarios

