### PR TITLE
ci: arm build for kubectl-plugin and sboms

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -4,6 +4,24 @@ on:
     branches:
       - develop
       - 'release/**'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build, example: v4.2.0'
+        required: false
+        type: string
+      registry:
+        description: 'Registry host (no slash), example: ghcr.io'
+        required: false
+        type: string
+      owner:
+        description: 'Repository owner (defaults to github.repository_owner if empty)'
+        required: false
+        type: string
+      namespace:
+        description: 'Namespace, example: dev'
+        required: false
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -11,11 +29,15 @@ on:
         required: true
         type: string
       registry:
-        description: 'Registry, example: ghcr.io'
+        description: 'Registry host (no slash), example: ghcr.io'
         required: true
         type: string
+      owner:
+        description: 'Repository owner (defaults to github.repository_owner if empty)'
+        required: false
+        type: string
       namespace:
-        description: 'Namespace, example: openebs/dev'
+        description: 'Namespace, example: dev'
         required: true
         type: string
 
@@ -23,13 +45,51 @@ env:
   CI: 1
 
 jobs:
-  image-build-push:
-    runs-on: oracle-vm-8cpu-32gb-x86-64
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
+  vars:
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.registry.outputs.registry }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
 
+      - name: Compose the registry
+        id: registry
+        uses: ./mayastor/dependencies/control-plane/utils/dependencies/.github/actions/registry-compose
+        with:
+          registry: ${{ inputs.registry }}
+          owner: ${{ inputs.owner || github.repository_owner }}
+          namespace: ${{ inputs.namespace }}
+
+      # A push build is given no tag, and the release script would then fall
+      # back to tagging the images with the commit hash, aliased to the branch.
+      # The chart's appVersion is used instead, as the single-job build did:
+      # that tag is also baked into the plugin binary, which is where it looks
+      # for the upgrade job image. Here rather than in each job below only to
+      # keep the one reading of the chart in one place.
+      - name: Resolve the image tag
+        id: tag
+        env:
+          TAG_IN: ${{ inputs.tag }}
+        run: |
+          tag="$TAG_IN"
+          if [ -z "$tag" ]; then
+            tag="v$(awk -F': ' '/^appVersion:/ {print $2}' charts/Chart.yaml)"
+          fi
+          echo "Tag: $tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  image-build:
+    needs: vars
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -38,37 +98,42 @@ jobs:
 
       - uses: cachix/install-nix-action@v31.11.1
 
-      - name: Pre-populate nix-shell
+      # The upgrade job image carries the chart, so the chart versions must be
+      # settled before it is built. Only for a release: a push build ships
+      # whatever the branch says.
+      - name: Update the chart versions
+        if: inputs.tag != ''
         run: |
           export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
-          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
-          nix-shell --run "echo" ./scripts/staging/shell.nix
+          nix-shell --pure --run "./scripts/helm/update-version-upon-release.sh" ./scripts/staging/shell.nix
 
-      - name: Login to Docker Hub
-        if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v4
+      - name: Build the release images
+        uses: ./mayastor/dependencies/control-plane/utils/dependencies/.github/actions/image-build
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          tag: ${{ needs.vars.outputs.tag }}
+          registry: ${{ needs.vars.outputs.registry }}
+          sbom: 'true'
 
-      - name: Login to GHCR
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: docker/login-action@v4
+  manifest-push:
+    needs: [vars, image-build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # Required for cosign to get an OIDC token for keyless signing.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          submodules: 'recursive'
+          fetch-depth: 0
 
-      - name: Build and push the release images
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            nix-shell --pure --run "./scripts/helm/update-version-upon-release.sh" ./scripts/staging/shell.nix
-            nix-shell --run "./scripts/release.sh --tag ${{ inputs.tag }} --registry ${{ inputs.registry }}/${{ inputs.namespace }}" ./scripts/staging/shell.nix
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            nix-shell --run './scripts/release.sh --tag v$(yq '.appVersion' charts/Chart.yaml)' ./scripts/staging/shell.nix
-          fi
-      # debugging
-      # - name: Setup tmate session
-      #   if: ${{ failure() }}
-      #   timeout-minutes: 120
-      #   uses: mxschmitt/action-tmate@v3
+      - name: Assemble and push the multi-arch images
+        uses: ./mayastor/dependencies/control-plane/utils/dependencies/.github/actions/image-manifest-push
+        with:
+          tag: ${{ needs.vars.outputs.tag }}
+          registry: ${{ needs.vars.outputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}
+          attest: 'true'

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -18,16 +18,18 @@ jobs:
       id-token: write
       contents: read
       packages: write
+      # Required to record the build provenance of the archives.
+      attestations: write
 
     strategy:
       fail-fast: false
       matrix:
         include:
           # NOTE: Update the .krew.yaml file (if required) when making changes here.
-          - os: oracle-vm-8cpu-32gb-x86-64
+          - os: cncf-ubuntu-8-32-x86
             target: linux-musl
             arch: x86_64
-          - os: oracle-vm-8cpu-32gb-x86-64
+          - os: cncf-ubuntu-8-32-arm
             target: linux-musl
             arch: aarch64
           - os: macos-14
@@ -37,7 +39,7 @@ jobs:
             target: apple-darwin
             arch: x86_64
             platform: x86_64-darwin
-          - os: oracle-vm-8cpu-32gb-x86-64
+          - os: cncf-ubuntu-8-32-x86
             target: windows-gnu
             arch: x86_64
             suffix: .exe
@@ -66,9 +68,28 @@ jobs:
         run: |
           tar -czvf kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.tar.gz LICENSE -C result/bin kubectl-openebs${{ matrix.suffix }}
 
+      - name: Generate the SBOM
+        run: |
+          ./mayastor/scripts/github/kubectl-plugin-sbom.sh \
+            --binary result/bin/kubectl-openebs${{ matrix.suffix }} \
+            --output kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.cdx.json
+
+      # Binds the archive to the workflow, repository and commit which built it,
+      # keylessly, and is verified with "gh attestation verify".
+      # Only when called with a tag, ie for a staging release: a push build is
+      # never published, so there is nothing for its provenance to say.
+      - name: Attest the build provenance
+        if: inputs.tag != ''
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.tar.gz
+
+      # The SBOM travels with the archive: staging bundles whatever is here into
+      # the OCI artifact, which the release then mirrors into the release assets.
       - uses: actions/upload-artifact@v7
         with:
           name: kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}
-          path: kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.tar.gz
+          path: |
+            kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.tar.gz
+            kubectl-openebs-${{ matrix.arch }}-${{ matrix.target }}.cdx.json
           if-no-files-found: error
-

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -32,10 +32,10 @@ jobs:
           - os: cncf-ubuntu-8-32-arm
             target: linux-musl
             arch: aarch64
-          - os: macos-14
+          - os: macos-15
             target: apple-darwin
             arch: aarch64
-          - os: macos-14
+          - os: macos-15-intel
             target: apple-darwin
             arch: x86_64
             platform: x86_64-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,3 +184,106 @@ jobs:
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'false'
+
+  chart-sboms:
+    runs-on: ubuntu-latest
+    needs: [release-helm-chart, release-kubectl-binaries]
+    permissions:
+      # To upload the bundle to the release, and to attest it.
+      contents: write
+      id-token: write
+      attestations: write
+      packages: read
+
+    env:
+      TAG: ${{ github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v31.11.1
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --pure --run "echo" ./scripts/staging/shell.nix
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Most of the chart comes from Docker Hub; logging in keeps the anonymous
+      # pull limit out of the picture, which otherwise starts failing to resolve
+      # images partway through and reports them as unresolved.
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Chart Version
+        run: echo "CHART_VERSION=${TAG#v}" >> $GITHUB_ENV
+
+      # Against the released chart, so the inventory matches what was published
+      # rather than what staging happened to hold. The kubectl bundle is only
+      # ever pushed to the staging namespace, so that is where it is read from.
+      #
+      # --verify requires that every attestation found, whoever published it,
+      # verifies against an openebs workflow identity. An artefact with no
+      # attestation is reported rather than fatal, since most of the umbrella's
+      # images are still in that state. The default shell has no pipefail, and
+      # without it the status below would be tee's, never the script's.
+      - name: Collect the SBOMs of everything the chart deploys
+        id: sboms
+        env:
+          PLUGIN: openebs
+        run: |
+          set -o pipefail
+          {
+            echo '### Chart SBOM coverage'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          rc=0
+          ./mayastor/scripts/github/chart-sboms.sh \
+            --chart oci://ghcr.io/${{ github.repository_owner }}/charts/openebs \
+            --version "${CHART_VERSION}" \
+            --registry ghcr.io \
+            --namespace ${{ github.repository_owner }}/dev/plugin \
+            --tag "${TAG}" \
+            --verify | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      # Without the marker the script leaves for itself to recognise its output.
+      - name: Bundle the SBOMs
+        run: tar -czf "sboms-${TAG}.tar.gz" --exclude=.chart-sboms -C sboms .
+
+      # Provenance of the bundle itself, the same way the kubectl archives are
+      # attested in release-binaries.yml. This says the collection came from this
+      # workflow. The documents inside are the bare SBOMs, unwrapped from their
+      # attestations: what vouches for each is the cosign attestation left on the
+      # artefact in the registry, and the summary.json alongside says which were
+      # verified against it and which were not.
+      - name: Attest the SBOM bundle
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: sboms-${{ github.ref_name }}.tar.gz
+
+      - name: Upload the SBOM bundle to the release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${TAG}" --clobber "sboms-${TAG}.tar.gz"
+
+      - name: Fail if an attestation did not verify
+        if: steps.sboms.outputs.rc != '0'
+        run: |
+          echo "The SBOM collection is attached to the release, but verification"
+          echo "failed - see the coverage table in the job summary."
+          exit 1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -158,3 +158,78 @@ jobs:
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.GITHUB_TOKEN }}
           update_dependencies: 'true'
+
+  chart-sboms:
+    runs-on: ubuntu-latest
+    needs: [release-staging-chart]
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: cachix/install-nix-action@v31.11.1
+      - name: Pre-populate nix-shell
+        run: |
+          export NIX_PATH=nixpkgs=$(jq '.nixpkgs.url' nix/sources.json -r)
+          echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
+          nix-shell --pure --run "echo" ./scripts/staging/shell.nix
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Most of the chart comes from Docker Hub; logging in keeps the anonymous
+      # pull limit out of the picture, which otherwise starts failing to resolve
+      # images partway through and reports them as unresolved.
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Chart Version
+        run: echo "CHART_VERSION=${TAG#v}" >> $GITHUB_ENV
+
+      # --verify requires that every attestation found - on the chart's images,
+      # ours or third-party, and on the kubectl bundle - verifies against an
+      # openebs workflow identity; one signed by anybody else fails the run. An
+      # image with no SBOM yet, or an unsigned one, is reported rather than
+      # fatal - most of the umbrella's images are still in that state, so gating
+      # on it would be red every time. The default shell has no pipefail, and
+      # without it the status below would be tee's, never the script's.
+      - name: Collect the SBOMs of everything the chart deploys
+        env:
+          PLUGIN: openebs
+        run: |
+          set -o pipefail
+          {
+            echo '### Chart SBOM coverage'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          rc=0
+          ./mayastor/scripts/github/chart-sboms.sh \
+            --chart oci://ghcr.io/${{ github.repository_owner }}/dev/helm/openebs \
+            --version "${CHART_VERSION}" \
+            --registry ghcr.io \
+            --namespace ${{ github.repository_owner }}/dev/plugin \
+            --tag "${TAG}" \
+            --verify | tee -a "$GITHUB_STEP_SUMMARY" || rc=$?
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
+
+      - name: Upload the SBOMs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: sboms-${{ inputs.tag }}
+          path: sboms
+          if-no-files-found: error

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,7 +46,7 @@ jobs:
     with:
       tag: ${{ inputs.tag }}
       registry: ghcr.io
-      namespace: ${{ github.repository_owner }}/dev
+      namespace: dev
     secrets: inherit
 
   build-binaries:
@@ -77,6 +77,15 @@ jobs:
           echo "NIX_PATH=$NIX_PATH" >> $GITHUB_ENV
           nix-shell --pure --run "echo" ./scripts/staging/shell.nix
 
+      # oras logs itself in below; this is what leaves the credentials where
+      # cosign can find them when it signs what oras pushed.
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Download kubectl artifacts
         uses: actions/download-artifact@v8
         with:
@@ -91,6 +100,15 @@ jobs:
             --namespace ${{ github.repository_owner }}/dev/plugin \
             --username ${{ github.actor }} \
             --password ${{ secrets.GITHUB_TOKEN }}" ./scripts/staging/shell.nix
+
+      - name: Sign the kubectl bundle and attest its SBOMs
+        env:
+          PLUGIN: openebs
+        run: |
+          ./mayastor/scripts/github/attest-kubectl-oci.sh \
+            --tag ${TAG} \
+            --namespace ${{ github.repository_owner }}/dev/plugin \
+            --sbom-dir artifacts
 
   release-staging-chart:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ plugin/target/
 # artifacts
 /artifacts/
 /sbom/
+/sboms/
 *.cdx.json
 # never commit a signing key
 cosign.key

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ plugin/target/
 
 # artifacts
 /artifacts/
+/sbom/
+*.cdx.json
+# never commit a signing key
+cosign.key
+cosign.pub

--- a/scripts/staging/mirror-images.sh
+++ b/scripts/staging/mirror-images.sh
@@ -57,5 +57,13 @@ for IMAGE in "${IMAGES[@]}"; do
   DEST="${TARGET}/${IMAGE}:${TAG}"
   crane copy --platform all "${SRC}" "${DEST}"
 
+  # The signature and the SBOM attestations are attached as OCI 1.1 referrers of
+  # the manifest list and of each per-arch manifest within it. Referrers aren't
+  # reachable from the manifest, so crane leaves them behind; oras walks the
+  # referrer graph. The image blobs are already at the target by now, so this
+  # only moves what's missing.
+  echo "Mirroring the referrers of ${IMAGE}:${TAG}..."
+  oras cp --recursive "${SRC}" "${DEST}"
+
   echo "✓ Successfully mirrored ${IMAGE}:${TAG}"
 done

--- a/scripts/staging/shell.nix
+++ b/scripts/staging/shell.nix
@@ -9,6 +9,8 @@ pkgs.mkShellNoCC {
     crane
     yq-go
     jq
+    # Used to verify the signature and SBOM attestation of the mirrored images.
+    cosign
   ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure" && pkgs.system != "aarch64-darwin") [
     docker
     git

--- a/scripts/staging/validate.sh
+++ b/scripts/staging/validate.sh
@@ -60,8 +60,8 @@ echo "Validating tag: $TAG"
 
 case "$TRIGGER" in
     release|staging)
-        [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]] \
-            || log_fatal "❌ Tag must be in format vX.Y.Z or vX.Y.Z-rc.N"
+        [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]] \
+            || log_fatal "❌ Tag must be in format vX.Y.Z or vX.Y.Z-<suffix>"
         ;;
     develop)
         [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-develop$ ]] \


### PR DESCRIPTION
    ci(sbom): collect and verify the SBOMs of a chart release
    
    The umbrella chart deploys images from four openebs repositories and a dozen
    third parties, and nothing said what any of them are made of, nor whether the
    SBOM a registry hands back is one we would trust.
    
    Both release paths now walk the chart's helm.sh/images annotation and the
    kubectl plugin bundle published alongside it, and collect an SBOM for every one
    of them, using chart-sboms.sh from the mayastor submodule. It reads a cosign
    attestation where there is one, falls back to the older .att tag layout and to
    buildx attestation manifests, and scans the image with syft where there is
    none, so the inventory has no holes. CycloneDX and SPDX are both read.
    
    Output is kind first then platform, with a summary per platform and one per
    kind above them:
    
      sboms/containers/summary.json
      sboms/containers/linux-amd64/summary.json
      sboms/containers/linux-amd64/sboms/openebs-upgrade-job.cdx.json
      sboms/plugins/summary.json
      sboms/plugins/darwin-arm64/summary.json
      sboms/plugins/darwin-arm64/sboms/kubectl-openebs.cdx.json
    
    --verify requires that every attestation found, whoever published it, verifies
    against an openebs workflow identity. An artefact with none is reported rather
    than failed: most of what this chart deploys is still unattested, and a gate
    that is red from its first run gets ignored.
    
    staging.yml runs it against the staging chart, writes the table to the job
    summary and uploads the collection. release.yml runs it against the released
    chart, so the inventory matches what was published rather than what staging
    happened to hold, attaches it to the GitHub release, attests the bundle with
    attest-build-provenance as the plugin archives already are, and enforces the
    gate after the upload so that a release still carries its inventory when
    verification fails.
    
    The kubectl bundle is only ever pushed to the staging namespace, so that is
    where both read it from.
    
---

    ci(image): build multi-arch images and attest the SBOMs
    
    The container images were built on a single x86 runner and published as
    single-arch, and neither they nor the kubectl plugin carried any inventory of
    what is in them.
    
    The image push workflow is now split into two phases, delegating to the
    composite actions from the dependencies submodule:
    
    - image-build: matrix over the x86 and arm runners, building the images
      natively per arch, scanning each with syft and uploading the archives and
      SBOMs as short-lived workflow artifacts (no registry access).
    
    - manifest-push: downloads the per-arch archives and assembles/pushes the
      multi-arch manifest lists, with the member images uploaded untagged
      (addressed only by digest), then signs the list and each architecture's
      manifest within it, and attaches each architecture's SBOM to its own
      manifest. A single SBOM describes only the architecture it was scanned on,
      so attesting the list with one of them would claim contents that were never
      scanned.
    
    The plain image tags only appear once both arch builds have succeeded; a
    failed run leaves the previous manifests untouched.
    
    The registry is now composed by the registry-compose action, so staging passes
    the namespace on its own rather than pre-joined to the owner. A push build is
    still tagged with the chart's appVersion, which the release script would
    otherwise replace with the commit hash aliased to the branch; that tag is also
    baked into the plugin binary, which is where it looks for the upgrade job
    image.
    
    The kubectl plugin is covered too:
    
    - each release-binaries job scans the binary it built, natively, and fails if
      the scan finds no crate rather than shipping an SBOM whose only claim is
      that the file exists. What makes scanning the binary work is cargo-auditable,
      which the submodule's naersk builder asks for on release builds.
    
    - the archive gets a build provenance attestation, binding it to the workflow,
      repository and commit which built it.
    
    - staging signs the pushed OCI bundle and attaches each architecture's SBOM to
      it as an attestation. Signing is keyless, hence the "id-token: write"
      permission on that job.
    
    Nothing is added to the images or the bundle themselves: the signatures and
    SBOMs are attached in the registry as OCI 1.1 referrers of the manifest they
    describe, addressed by digest rather than by tag, so verifying a floating tag
    such as :develop always returns the SBOM of whatever that tag points at now.
    The SBOMs also travel with the archives into the bundle, so they are mirrored
    into the release assets, for consumers who would rather download a file than
    pull an attestation out of a registry.
    
    The linux release binaries move from the oracle VMs to the cncf runners, which
    is what makes the native aarch64 build possible.
    
    Verify a published image with:
    
      ISS=https://token.actions.githubusercontent.com
      ID='^https://github\.com/openebs/openebs/\.github/workflows/images\.yml@'
    
      cosign verify --experimental-oci11 \
        --certificate-oidc-issuer $ISS --certificate-identity-regexp "$ID" $REF
    
    The identity flags are the point of a keyless signature: without them the
    check only proves that somebody signed it, which is no check at all.
    
    A published archive is verified against GitHub's attestation store instead:
    
      gh attestation verify --repo openebs/openebs \
        kubectl-openebs-x86_64-linux-musl.tar.gz
